### PR TITLE
Fix typo: Rename IsConsideredSameOriginForUIR → IsConsideredSameOrigi…

### DIFF
--- a/docshell/base/nsDocShell.cpp
+++ b/docshell/base/nsDocShell.cpp
@@ -10157,7 +10157,7 @@ nsIPrincipal* nsDocShell::GetInheritedPrincipal(
       aRv = nsContentUtils::GetSecurityManager()->GetChannelResultPrincipal(
           channel, getter_AddRefs(resultPrincipal));
       NS_ENSURE_SUCCESS(aRv, false);
-      if (nsContentSecurityUtils::IsConsideredSameOriginForUIR(
+      if (nsContentSecurityUtils::IsConsideredSameOriginForURI(
               aLoadState->TriggeringPrincipal(), resultPrincipal)) {
         aLoadInfo->SetUpgradeInsecureRequests(true);
       }

--- a/dom/security/nsContentSecurityUtils.cpp
+++ b/dom/security/nsContentSecurityUtils.cpp
@@ -57,7 +57,7 @@ extern Atomic<bool, mozilla::Relaxed> sJSHacksPresent;
 extern Atomic<bool, mozilla::Relaxed> sCSSHacksChecked;
 extern Atomic<bool, mozilla::Relaxed> sCSSHacksPresent;
 
-// Helper function for IsConsideredSameOriginForUIR which makes
+// Helper function for IsConsideredSameOriginForURI which makes
 // Principals of scheme 'http' return Principals of scheme 'https'.
 static already_AddRefed<nsIPrincipal> MakeHTTPPrincipalHTTPS(
     nsIPrincipal* aPrincipal) {
@@ -87,7 +87,7 @@ static already_AddRefed<nsIPrincipal> MakeHTTPPrincipalHTTPS(
 }
 
 /* static */
-bool nsContentSecurityUtils::IsConsideredSameOriginForUIR(
+bool nsContentSecurityUtils::IsConsideredSameOriginForURI(
     nsIPrincipal* aTriggeringPrincipal, nsIPrincipal* aResultPrincipal) {
   MOZ_ASSERT(aTriggeringPrincipal);
   MOZ_ASSERT(aResultPrincipal);

--- a/dom/security/nsContentSecurityUtils.h
+++ b/dom/security/nsContentSecurityUtils.h
@@ -33,7 +33,7 @@ class nsContentSecurityUtils {
   // page triggers and http page to load, even though that http page would be
   // upgraded to https later. Hence we have to use that custom function instead
   // of simply calling aTriggeringPrincipal->Equals(aResultPrincipal).
-  static bool IsConsideredSameOriginForUIR(nsIPrincipal* aTriggeringPrincipal,
+  static bool IsConsideredSameOriginForURI(nsIPrincipal* aTriggeringPrincipal,
                                            nsIPrincipal* aResultPrincipal);
 
   static bool IsEvalAllowed(JSContext* cx, bool aIsSystemPrincipal,

--- a/netwerk/protocol/http/HttpBaseChannel.cpp
+++ b/netwerk/protocol/http/HttpBaseChannel.cpp
@@ -4474,7 +4474,7 @@ already_AddRefed<nsILoadInfo> HttpBaseChannel::CloneLoadInfoForRedirect(
             BasePrincipal::CreateContentPrincipal(
                 aNewURI, newLoadInfo->GetOriginAttributes());
         bool isConsideredSameOriginforUIR =
-            nsContentSecurityUtils::IsConsideredSameOriginForUIR(
+            nsContentSecurityUtils::IsConsideredSameOriginForURI(
                 newLoadInfo->TriggeringPrincipal(), resultPrincipal);
         static_cast<mozilla::net::LoadInfo*>(newLoadInfo.get())
             ->SetUpgradeInsecureRequests(isConsideredSameOriginforUIR);


### PR DESCRIPTION
### Summary

This patch fixes a typo in the function name `IsConsideredSameOriginForUIR`, correcting it to `IsConsideredSameOriginForURI`.

### Steps taken

To locate and update all references, I used:

```
grep -rnw ./ -e "IsConsideredSameOriginForUIR"
->
 ./docshell/base/nsDocShell.cpp:10160:      if (nsContentSecurityUtils::IsConsideredSameOriginForUIR(
./netwerk/protocol/http/HttpBaseChannel.cpp:4477:            nsContentSecurityUtils::IsConsideredSameOriginForUIR(
./dom/security/nsContentSecurityUtils.h:36:  static bool IsConsideredSameOriginForUIR(nsIPrincipal* aTriggeringPrincipal,
./dom/security/nsContentSecurityUtils.cpp:60:// Helper function for IsConsideredSameOriginForUIR which makes //in comment
```
**Fix the typo in located files**
```
grep -rnw ./ -e "IsConsideredSameOriginForUIR"  #No Results
```

```
grep -rnw ./ -e "IsConsideredSameOriginForURI" #Updated usages
-> 
./docshell/base/nsDocShell.cpp:10160:      if (nsContentSecurityUtils::IsConsideredSameOriginForURI(
./netwerk/protocol/http/HttpBaseChannel.cpp:4477:            nsContentSecurityUtils::IsConsideredSameOriginForURI(
./dom/security/nsContentSecurityUtils.h:36:  static bool IsConsideredSameOriginForURI(nsIPrincipal* aTriggeringPrincipal,
./dom/security/nsContentSecurityUtils.cpp:60:// Helper function for IsConsideredSameOriginForURI which makes
./dom/security/nsContentSecurityUtils.cpp:90:bool nsContentSecurityUtils::IsConsideredSameOriginForURI(
```