### PR TITLE
Bug 2000658 - Strip "rcm" parameter on LinkedIn with "Copy Clean Link"

### DIFF
--- a/toolkit/components/antitracking/StripOnShareLists/LGPL/StripOnShareLGPL.json
+++ b/toolkit/components/antitracking/StripOnShareLists/LGPL/StripOnShareLGPL.json
@@ -563,8 +563,8 @@
     "topLevelSites": ["github.com"]
   },
   "linkedin": {
-    "queryParams": ["refId", "trk", "trackingId"],
-    "topLevelSites": ["ca.linkedin.com", "ro.linkedin.com"]
+    "queryParams": ["refId", "trk", "trackingId", "rcm"],
+    "topLevelSites": ["www.linkedin.com", "ca.linkedin.com", "ro.linkedin.com"]
   },
   "newyorker": {
     "queryParams": ["esrc", "bxid", "cndid", "source", "mbid"],


### PR DESCRIPTION
## Summary

Adds support for stripping the "rcm" query parameter from LinkedIn URLs when using the "Copy Clean Link" feature. Also adds www.linkedin.com to the LinkedIn domain list to ensure coverage of the main domain.

## Details

The "rcm" parameter is used by LinkedIn for tracking purposes. When users share LinkedIn links using Firefox's "Copy Clean Link" feature, this parameter should be removed along with existing tracking parameters (refId, trk, trackingId).

Example: 
Before: https://www.linkedin.com/posts/...?rcm=ACoAAAGC-2EBzjgg24fnlF68iUBquJrddBNg9iE&utm_source=share
After: https://www.linkedin.com/posts/...

## Testing

- ✅ Validation tests pass (no JSON schema errors, no duplicates)
- ✅ Context menu tests pass (29 subtests)
- ✅ Strip-on-share feature tests pass (44 checks)

## Fixes

Bug 2000658