### PR TITLE
Composable settings exploration

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ lifecycle = "2.10.0"
 localbroadcastmanager = "1.0.0"
 media = "1.7.1"
 navigation = "2.9.5"
+navigation3 = "1.0.0"
 paging = "3.3.6"
 palette = "1.0.0"
 preferences = "1.2.1"
@@ -159,6 +160,8 @@ androidx-navigation-compose = { group = "androidx.navigation", name = "navigatio
 androidx-navigation-fragment = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigation" }
 androidx-navigation-safeargs = { group = "androidx.navigation", name = "navigation-safe-args-gradle-plugin", version.ref = "navigation" }
 androidx-navigation-ui = { group = "androidx.navigation", name = "navigation-ui", version.ref = "navigation" }
+androidx-navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "navigation3" }
+androidx-navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "navigation3" }
 androidx-paging = { group = "androidx.paging", name = "paging-runtime", version.ref = "paging" }
 androidx-palette = { group = "androidx.palette", name = "palette-ktx", version.ref = "palette" }
 androidx-preferences = { group = "androidx.preference", name = "preference", version.ref = "preferences" }

--- a/mobile/android/fenix/app/build.gradle
+++ b/mobile/android/fenix/app/build.gradle
@@ -679,6 +679,8 @@ dependencies {
     implementation libs.androidx.navigation.compose
     implementation libs.androidx.navigation.fragment
     implementation libs.androidx.navigation.ui
+    implementation libs.androidx.navigation3.runtime
+    implementation libs.androidx.navigation3.ui
     implementation libs.androidx.paging
     implementation libs.androidx.preferences
     implementation libs.androidx.profileinstaller

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMiddleware.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMiddleware.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.os.Build
 import androidx.annotation.VisibleForTesting
 import androidx.navigation.NavController
+import androidx.navigation.fragment.findNavController
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -127,6 +128,7 @@ import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.navigateSafe
 import org.mozilla.fenix.nimbus.FxNimbus
 import org.mozilla.fenix.settings.ShortcutType
+import org.mozilla.fenix.settings.logins.fragment.SavedLoginsAuthFragmentDirections
 import org.mozilla.fenix.settings.quicksettings.protections.cookiebanners.getCookieBannerUIMode
 import org.mozilla.fenix.tabstray.Page
 import org.mozilla.fenix.tabstray.ext.isActiveDownload
@@ -276,11 +278,8 @@ class BrowserToolbarMiddleware(
             }
 
             is MenuClicked -> {
-                navController.nav(
-                    R.id.browserFragment,
-                    BrowserFragmentDirections.actionGlobalMenuDialogFragment(
-                        accesspoint = MenuAccessPoint.Browser,
-                    ),
+                navController.navigate(
+                    BrowserFragmentDirections.actionBrowserFragmentToComposableSettingsFragment(),
                 )
 
                 next(action)

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/ComposeSettingsFragment.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/ComposeSettingsFragment.kt
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import org.mozilla.fenix.settings.navigation.SettingsHost
+import org.mozilla.fenix.theme.FirefoxTheme
+
+/**
+ * New Compose-based Settings fragment following MVI architecture.
+ *
+ * This is a modernized version of [SettingsFragment] that uses:
+ * - Jetpack Compose for UI
+ * - MVI (Model-View-Intent) architecture with mozilla-components Store
+ * - SettingsRepository for data management
+ * - Middleware for side effects
+ */
+class ComposeSettingsFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                FirefoxTheme {
+                    SettingsHost()
+                }
+            }
+        }
+    }
+}

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/data/SettingsRepository.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/data/SettingsRepository.kt
@@ -1,0 +1,382 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.data
+
+import android.content.Context
+import androidx.annotation.StringRes
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.engine.Engine
+import org.mozilla.fenix.R
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.nimbus.FxNimbus
+import org.mozilla.fenix.settings.store.SettingsItem
+import org.mozilla.fenix.settings.ui.TextValue
+import org.mozilla.fenix.utils.Settings
+
+/**
+ * Repository for building and managing settings data.
+ * This class is responsible for creating the settings structure that should be displayed in the UI.
+ */
+class SettingsRepository(
+    private val context: Context,
+    private val settings: Settings,
+    private val browserStore: BrowserStore,
+) {
+    // Get all settings items
+    val all
+        get() = main/* + search + customize + advanced + etc. */
+
+    /**
+     * Current configuration of the settings items shown on the main settings screen.
+     */
+    val main
+        get() = buildSettings {
+            category(R.string.preferences_category_general) {
+                simple(R.string.preferences_search)
+                simple(
+                    titleRes = R.string.preferences_home_2,
+                    summaryRes = getHomepageSummaryRes(),
+                    keywords = listOf("test"),
+                )
+                simple(
+                    titleRes = R.string.preferences_tabs,
+                    summaryRes = getTabTimeoutSummaryRes(),
+                )
+                simple(R.string.preferences_customize)
+                simple(R.string.preferences_passwords_logins_and_passwords_2)
+                simple(
+                    titleRes = if (settings.addressFeature) {
+                        R.string.preferences_autofill
+                    } else {
+                        R.string.preferences_credit_cards_2
+                    },
+                )
+                simple(R.string.preferences_accessibility)
+
+                simple(R.string.preferences_language)
+                simple(
+                    titleRes = R.string.preferences_translations,
+                    isVisible = FxNimbus.features.translations.value().globalSettingsEnabled &&
+                            browserStore.state.translationEngine.isEngineSupported == true,
+                )
+            }
+
+            category(titleRes = R.string.preferences_category_privacy_security) {
+                simple(R.string.preferences_private_browsing_options)
+                simple(
+                    titleRes = R.string.preferences_https_only_title,
+                    summaryRes = getHttpsOnlySummaryRes(),
+                )
+                toggle(
+                    titleRes = R.string.preferences_cookie_banner_reduction_private_mode,
+                    backingPreference = R.string.pref_key_cookie_banner_private_mode,
+                    isChecked = settings.shouldUseCookieBannerPrivateMode,
+                    isVisible = settings.shouldShowCookieBannerUI,
+                    keywords = listOf("test"),
+                )
+                simple(
+                    titleRes = R.string.preference_enhanced_tracking_protection,
+                    summaryRes = getTrackingProtectionSummaryRes(),
+                )
+                simple(
+                    titleRes = R.string.preference_doh_title,
+                    summaryRes = getDohSummaryRes(),
+                    isVisible = settings.showDohEntryPoint,
+                )
+                simple(R.string.preferences_site_settings)
+                simple(R.string.preferences_delete_browsing_data)
+                simple(
+                    titleRes = R.string.preferences_delete_browsing_data_on_quit,
+                    summaryRes = if (settings.shouldDeleteBrowsingDataOnQuit) {
+                        R.string.delete_browsing_data_quit_on
+                    } else {
+                        R.string.delete_browsing_data_quit_off
+                    },
+                )
+                simple(R.string.preferences_notifications)
+                simple(R.string.preferences_data_collection)
+            }
+
+            category(titleRes = R.string.preferences_category_advanced) {
+                simple(R.string.preferences_extensions)
+                simple(
+                    titleRes = R.string.preferences_install_local_extension,
+                    isVisible = settings.showSecretDebugMenuThisSession,
+                )
+                if (settings.overrideAmoCollection.isNotEmpty()) {
+                    simple(
+                        titleRes = R.string.preferences_customize_extension_collection,
+                        summaryFormatArgs = listOf(settings.overrideAmoCollection),
+                        isVisible = settings.amoCollectionOverrideConfigured() || settings.showSecretDebugMenuThisSession,
+                    )
+                } else {
+                    simple(
+                        titleRes = R.string.preferences_customize_extension_collection,
+                        isVisible = settings.amoCollectionOverrideConfigured() || settings.showSecretDebugMenuThisSession,
+                    )
+                }
+                simple(
+                    titleRes = R.string.preferences_link_sharing,
+                    isVisible = FxNimbus.features.sentFromFirefox.value().enabled,
+                )
+                simple(
+                    titleRes = R.string.preferences_open_links_in_apps,
+                    summaryRes = getOpenLinksInAppsSummaryRes(),
+                )
+                simple(R.string.preferences_downloads)
+                toggle(
+                    titleRes = R.string.preferences_remote_debugging,
+                    backingPreference = R.string.pref_key_remote_debugging,
+                    isChecked = settings.isRemoteDebuggingEnabled,
+                )
+                toggle(
+                    titleRes = R.string.preferences_enable_gecko_logs,
+                    backingPreference = R.string.pref_key_enable_gecko_logs,
+                    isChecked = settings.enableGeckoLogs,
+                    isVisible = settings.showSecretDebugMenuThisSession,
+                )
+            }
+
+            category(titleRes = R.string.preferences_category_about) {
+                simple(R.string.preferences_rate)
+                simple(
+                    titleRes = R.string.preferences_about,
+                    titleFormatArgs = listOf(R.string.app_name),
+                )
+            }
+
+            simple(
+                titleRes = R.string.preferences_debug_settings,
+                isVisible = settings.showSecretDebugMenuThisSession,
+            )
+            simple(
+                titleRes = R.string.preferences_debug_info,
+                isVisible = settings.showSecretDebugMenuThisSession,
+            )
+            simple(
+                titleRes = R.string.preferences_nimbus_experiments,
+                isVisible = settings.showSecretDebugMenuThisSession,
+            )
+            simple(
+                titleRes = R.string.preferences_sync_debug,
+                isVisible = settings.showSecretDebugMenuThisSession,
+            )
+        }
+
+    @StringRes
+    private fun getHomepageSummaryRes(): Int? = when {
+        settings.alwaysOpenTheHomepageWhenOpeningTheApp -> R.string.opening_screen_homepage_summary
+        settings.openHomepageAfterFourHoursOfInactivity -> R.string.opening_screen_after_four_hours_of_inactivity_summary
+        settings.alwaysOpenTheLastTabWhenOpeningTheApp -> R.string.opening_screen_last_tab_summary
+        else -> null
+    }
+
+    @StringRes
+    private fun getTabTimeoutSummaryRes(): Int? = when {
+        settings.closeTabsAfterOneDay -> R.string.close_tabs_after_one_day_summary
+        settings.closeTabsAfterOneWeek -> R.string.close_tabs_after_one_week_summary
+        settings.closeTabsAfterOneMonth -> R.string.close_tabs_after_one_month_summary
+        settings.manuallyCloseTabs -> R.string.close_tabs_manually_summary
+        else -> null
+    }
+
+    @StringRes
+    private fun getTrackingProtectionSummaryRes(): Int = when {
+        !settings.shouldUseTrackingProtection -> R.string.tracking_protection_off
+        settings.useStandardTrackingProtection -> R.string.tracking_protection_standard
+        settings.useStrictTrackingProtection -> R.string.tracking_protection_strict
+        settings.useCustomTrackingProtection -> R.string.tracking_protection_custom
+        else -> R.string.tracking_protection_standard
+    }
+
+    @StringRes
+    private fun getDohSummaryRes(): Int = when (settings.getDohSettingsMode()) {
+        Engine.DohSettingsMode.DEFAULT -> R.string.preference_doh_default_protection
+        Engine.DohSettingsMode.OFF -> R.string.preference_doh_off
+        Engine.DohSettingsMode.INCREASED -> R.string.preference_doh_increased_protection
+        Engine.DohSettingsMode.MAX -> R.string.preference_doh_max_protection
+    }
+
+    @StringRes
+    private fun getHttpsOnlySummaryRes(): Int? = when {
+        !settings.shouldUseHttpsOnly -> R.string.preferences_https_only_off
+        settings.shouldUseHttpsOnlyInAllTabs -> R.string.preferences_https_only_on_all
+        settings.shouldUseHttpsOnlyInPrivateTabsOnly -> R.string.preferences_https_only_on_private
+        else -> null
+    }
+
+    @StringRes
+    private fun getOpenLinksInAppsSummaryRes(): Int = when (settings.openLinksInExternalApp) {
+        context.getString(R.string.pref_key_open_links_in_apps_always) -> {
+            if (settings.lastKnownMode == BrowsingMode.Normal) {
+                R.string.preferences_open_links_in_apps_always
+            } else {
+                R.string.preferences_open_links_in_apps_ask
+            }
+        }
+        context.getString(R.string.pref_key_open_links_in_apps_ask) -> {
+            R.string.preferences_open_links_in_apps_ask
+        }
+        else -> R.string.preferences_open_links_in_apps_never
+    }
+
+    /**
+     * DSL builder for creating a new settings structure for a settings screen.
+     */
+    private fun buildSettings(
+        block: SettingsBuilder.() -> Unit,
+    ) = SettingsBuilder()
+        .apply(block)
+        .build()
+}
+
+/**
+ * DSL marker to prevent inadvertent nesting of settings scopes.
+ */
+@DslMarker
+annotation class SettingsDslMarker
+
+/**
+ * Base scope for building settings.
+ */
+@SettingsDslMarker
+abstract class SettingsScope {
+    protected val _items = mutableListOf<SettingsItem>()
+    val items: List<SettingsItem>
+        get() = _items
+
+    /**
+     * Creates a simple preference with a string resource title.
+     *
+     * @param titleRes String resource ID for the title.
+     * @param summaryFormatArgs Format arguments for the title. Can be other @StringRes or plain values.
+     * @param summaryRes Optional string resource ID for the summary.
+     * @param summaryFormatArgs Format arguments for the summary. Can be other @StringRes or plain values.
+     * @param icon Optional icon resource ID.
+     * @param isVisible Whether this item should be visible.
+     * @param isEnabled Whether this item should be enabled.
+     * @param id Optional navigation destination ID. Defaults to [titleRes].
+     * @param keywords Optional keywords for this item used in the search functionality.
+     */
+    fun simple(
+        @StringRes titleRes: Int,
+        titleFormatArgs: List<Any> = emptyList(),
+        @StringRes summaryRes: Int? = null,
+        summaryFormatArgs: List<Any> = emptyList(),
+        icon: Int? = null,
+        isVisible: Boolean = true,
+        isEnabled: Boolean = true,
+        id: Int = titleRes,
+        keywords: List<String> = emptyList(),
+    ) {
+        if (isVisible) {
+            _items.add(
+                SettingsItem.SimplePreference(
+                    title = TextValue(titleRes, titleFormatArgs),
+                    summary = summaryRes?.let { TextValue(it, summaryFormatArgs) },
+                    icon = icon,
+                    isVisible = true,
+                    isEnabled = isEnabled,
+                    id = id,
+                    keywords = keywords,
+                ),
+            )
+        }
+    }
+
+    /**
+     * Creates a toggle preference with a string resource title.
+     *
+     * @param titleRes String resource ID for the title.
+     * @param summaryFormatArgs Format arguments for the title. Can be other @StringRes or plain values.
+     * @param summaryRes Optional string resource ID for the summary.
+     * @param summaryFormatArgs Format arguments for the summary. Can be other @StringRes or plain values.
+     * @param icon Optional icon resource ID.
+     * @param backingPreference String resource ID of the preference key backing this toggle.
+     * @param isChecked Whether the toggle is currently checked.
+     * @param isVisible Whether this item should be visible.
+     * @param isEnabled Whether this item should be enabled.
+     * @param id Optional navigation destination ID. Defaults to [titleRes].
+     * @param keywords Optional keywords for this item used in the search functionality.
+     */
+    fun toggle(
+        @StringRes titleRes: Int,
+        titleFormatArgs: List<Any> = emptyList(),
+        @StringRes summaryRes: Int? = null,
+        summaryFormatArgs: List<Any> = emptyList(),
+        icon: Int? = null,
+        @StringRes backingPreference: Int,
+        isChecked: Boolean,
+        isVisible: Boolean = true,
+        isEnabled: Boolean = true,
+        id: Int = titleRes,
+        keywords: List<String> = emptyList(),
+    ) {
+        if (isVisible) {
+            _items.add(
+                SettingsItem.TogglePreference(
+                    title = TextValue(titleRes, titleFormatArgs),
+                    summary = summaryRes?.let { TextValue(it, summaryFormatArgs) },
+                    icon = icon,
+                    isVisible = true,
+                    isEnabled = isEnabled,
+                    isChecked = isChecked,
+                    preferenceKey = backingPreference,
+                    id = id,
+                    keywords = keywords,
+                ),
+            )
+        }
+    }
+
+    internal fun build(): List<SettingsItem> = items.toList()
+}
+
+/**
+ * Category scope that groups related settings.
+ */
+@SettingsDslMarker
+class CategoryScope : SettingsScope()
+
+/**
+ * Top-level settings builder scope.
+ */
+@SettingsDslMarker
+class SettingsBuilder : SettingsScope() {
+    /**
+     * Adds a category to the settings.
+     *
+     * @param titleRes String resource ID for the category title.
+     * @param summaryFormatArgs Format arguments for the title. Can be other @StringRes or plain values.
+     * @param summaryRes Optional string resource ID for the summary.
+     * @param summaryFormatArgs Format arguments for the summary. Can be other @StringRes or plain values.
+     * @param icon Optional icon resource ID.
+     * @param isVisible Whether this category should be visible.
+     * @param isEnabled Whether this category should be enabled.
+     * @param content Factory of other [SettingsItem] that should be shown in this settings category.
+     */
+    fun category(
+        @StringRes titleRes: Int,
+        titleFormatArgs: List<Any> = emptyList(),
+        @StringRes summaryRes: Int? = null,
+        summaryFormatArgs: List<Any> = emptyList(),
+        icon: Int? = null,
+        isVisible: Boolean = true,
+        isEnabled: Boolean = true,
+        content: CategoryScope.() -> Unit = {},
+    ) {
+        val categoryScope = CategoryScope().apply(content)
+        _items.add(
+            SettingsItem.Category(
+                title = TextValue(titleRes, titleFormatArgs),
+                summary = summaryRes?.let { TextValue(it, summaryFormatArgs) },
+                icon = icon,
+                isVisible = isVisible,
+                isEnabled = isEnabled,
+                items = categoryScope.items,
+            ),
+        )
+    }
+}

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/middleware/SettingsMiddleware.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/middleware/SettingsMiddleware.kt
@@ -1,0 +1,289 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.middleware
+
+import android.content.Context
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import mozilla.components.lib.state.Middleware
+import mozilla.components.lib.state.MiddlewareContext
+import mozilla.telemetry.glean.private.NoExtras
+import org.mozilla.fenix.GleanMetrics.Addons
+import org.mozilla.fenix.GleanMetrics.CookieBanners
+import org.mozilla.fenix.GleanMetrics.Translations
+import org.mozilla.fenix.R
+import org.mozilla.fenix.components.Components
+import org.mozilla.fenix.settings.data.SettingsRepository
+import org.mozilla.fenix.settings.navigation.SettingsDestination
+import org.mozilla.fenix.settings.navigation.SettingsNavController
+import org.mozilla.fenix.settings.store.SettingsAction
+import org.mozilla.fenix.settings.store.SettingsAction.DestinationChanged
+import org.mozilla.fenix.settings.store.SettingsAction.ItemClicked
+import org.mozilla.fenix.settings.store.SettingsAction.ItemToggled
+import org.mozilla.fenix.settings.store.SettingsAction.SearchEnded
+import org.mozilla.fenix.settings.store.SettingsAction.SearchQueryUpdated
+import org.mozilla.fenix.settings.store.SettingsAction.SearchResultsUpdated
+import org.mozilla.fenix.settings.store.SettingsAction.SearchStarted
+import org.mozilla.fenix.settings.store.SettingsAction.SearchableItemsUpdated
+import org.mozilla.fenix.settings.store.SettingsAction.SettingsAreLoading
+import org.mozilla.fenix.settings.store.SettingsAction.SettingsLoaded
+import org.mozilla.fenix.settings.store.SettingsAction.SettingsUpdateFeedbackAvailable
+import org.mozilla.fenix.settings.store.SettingsItem
+import org.mozilla.fenix.settings.store.SettingsState
+import org.mozilla.fenix.utils.Settings
+import org.mozilla.fenix.GleanMetrics.Settings as SettingsMetrics
+
+/**
+ * Middleware for handling SettingsStore side effects.
+ *
+ * @param uiContext [Context] used for various system interactions.
+ * @param components Application components.
+ * @param settings Application settings.
+ * @param repository Repository for building settings data.
+ * @param navController Navigation controller for navigating between settings screens.
+ * @param scope Coroutine scope for launching async operations.
+ */
+class SettingsMiddleware(
+    private val uiContext: Context,
+    private val components: Components,
+    private val settings: Settings,
+    private val repository: SettingsRepository,
+    private val navController: SettingsNavController,
+    private val scope: CoroutineScope,
+) : Middleware<SettingsState, SettingsAction> {
+
+    override fun invoke(
+        context: MiddlewareContext<SettingsState, SettingsAction>,
+        next: (SettingsAction) -> Unit,
+        action: SettingsAction,
+    ) {
+        next(action)
+
+        when (action) {
+            is DestinationChanged -> {
+                context.dispatch(SettingsAreLoading)
+
+                loadSettings(context, action.destination)
+            }
+
+            is ItemClicked -> {
+                handleItemClick(context, action.item)
+            }
+
+            is ItemToggled -> {
+                handleTogglePreference(context, action.preferenceKey, action.newValue)
+            }
+
+            is SearchStarted -> {
+                // The below dispatches should not be needed here
+                // but they don't work nicely in SearchEnded at the moment
+                context.dispatch(SearchQueryUpdated(""))
+                context.dispatch(SearchResultsUpdated(emptyList()))
+                context.dispatch(SearchableItemsUpdated(emptyList()))
+
+                resetSearchResults(context)
+            }
+
+            is SearchEnded -> {
+                context.dispatch(SearchQueryUpdated(""))
+                context.dispatch(SearchResultsUpdated(emptyList()))
+                context.dispatch(SearchableItemsUpdated(emptyList()))
+            }
+
+            is SearchQueryUpdated -> {
+                handleSearching(context, action.query)
+            }
+
+            else -> {}
+        }
+    }
+
+    private fun handleItemClick(
+        context: MiddlewareContext<SettingsState, SettingsAction>,
+        item: SettingsItem,
+    ) {
+        when (item) {
+            is SettingsItem.SimplePreference -> {
+                handleSimplePreferenceClick(context, item)
+            }
+
+            is SettingsItem.TogglePreference -> {
+                // Clicking a toggle preference means actually toggling it <=> not handled here.
+            }
+
+            is SettingsItem.Category -> {
+                // Categories are not clickable
+                // Probably need a separate interface for just clickable items
+            }
+        }
+    }
+
+    private fun handleSimplePreferenceClick(
+        context: MiddlewareContext<SettingsState, SettingsAction>,
+        item: SettingsItem.SimplePreference,
+    ) {
+        // Record telemetry
+        when (item.title.resId) {
+            R.string.preferences_passwords_logins_and_passwords_2 -> SettingsMetrics.passwords.record()
+            R.string.preferences_autofill,
+            R.string.preferences_credit_cards_2,
+                -> SettingsMetrics.autofill.record()
+
+            R.string.preferences_extensions -> Addons.openAddonsInSettings.record(NoExtras())
+            R.string.preference_enhanced_tracking_protection -> org.mozilla.fenix.GleanMetrics.TrackingProtection.etpSettings.record(
+                NoExtras(),
+            )
+
+            R.string.preferences_translations -> Translations.action.record(
+                Translations.ActionExtra("global_settings_from_preferences"),
+            )
+        }
+
+        // Handle navigating to outside the settings screens.
+        // We'd need new dependencies for delegating this to.
+        when (item.id) {
+            R.string.preferences_notifications -> {
+                // Navigate to the notification settings for this app in system settings
+            }
+
+            R.string.preferences_rate -> {
+                // Start the rating UX
+            }
+
+            R.string.preferences_install_local_extension -> {
+                // Handled by AddonFilePicker in fragment or here?
+            }
+
+            R.string.preferences_customize_extension_collection -> {
+                // Handled by dialog in fragment or here?
+            }
+
+            else -> {
+                destinationMap.value[item.id]?.let {
+                    navController.navigateTo(it)
+                }
+            }
+        }
+    }
+
+    private fun handleTogglePreference(
+        context: MiddlewareContext<SettingsState, SettingsAction>,
+        preferenceKey: Int,
+        newValue: Boolean,
+    ) {
+        when (preferenceKey) {
+            R.string.pref_key_cookie_banner_private_mode -> {
+                settings.shouldUseCookieBannerPrivateMode = newValue
+                val metricTag = if (newValue) "reject_all" else "disabled"
+                CookieBanners.settingChangedPmb.record(
+                    CookieBanners.SettingChangedPmbExtra(
+                        metricTag,
+                    ),
+                )
+
+                val mode = settings.getCookieBannerHandlingPrivateMode()
+                components.core.engine.settings.cookieBannerHandlingModePrivateBrowsing = mode
+                components.useCases.sessionUseCases.reload()
+            }
+
+            R.string.pref_key_remote_debugging -> {
+                settings.preferences.edit().putBoolean(uiContext.getString(preferenceKey), newValue).apply()
+                components.core.engine.settings.remoteDebuggingEnabled = newValue
+            }
+
+            R.string.pref_key_enable_gecko_logs -> {
+                settings.enableGeckoLogs = newValue
+                context.dispatch(SettingsUpdateFeedbackAvailable(uiContext.getString(R.string.quit_application)))
+            }
+
+            else -> {
+                settings.preferences.edit().putBoolean(uiContext.getString(preferenceKey), newValue).apply()
+            }
+        }
+
+        // Reload settings to reflect changes.
+        if (navController.currentDestination == SettingsDestination.SearchResults) {
+            resetSearchResults(context)
+        } else {
+            loadSettings(context)
+        }
+    }
+
+    private fun handleSearching(
+        context: MiddlewareContext<SettingsState, SettingsAction>,
+        query: String,
+    ) {
+        if (query.isBlank()) {
+            return context.dispatch(SearchResultsUpdated(emptyList()))
+        }
+
+        val allItems = context.state.allSearchableItems
+        val query = query.lowercase()
+        val filteredItems = allItems.filter { item ->
+            // Getting a string is cheap but we should not do this for every query change and every title/summary
+            // We should store the allSearchableItems with the strings values already resolved.
+            item.title.resolve(uiContext).lowercase().contains(query) ||
+                    item.summary?.resolve(uiContext)?.lowercase()?.contains(query) == true ||
+                    (item as? SettingsItem.SimplePreference)?.keywords?.contains(query) == true ||
+                    (item as? SettingsItem.TogglePreference)?.keywords?.contains(query) == true
+        }
+
+        context.dispatch(SearchResultsUpdated(filteredItems))
+    }
+
+    private fun loadSettings(
+        context: MiddlewareContext<SettingsState, SettingsAction>,
+        destination: SettingsDestination = navController.currentDestination,
+    ) = scope.launch {
+        if (destination == SettingsDestination.Root) {
+            context.dispatch(SettingsLoaded(repository.main))
+        }
+    }
+
+    private fun resetSearchResults(
+        context: MiddlewareContext<SettingsState, SettingsAction>,
+    ) = scope.launch {
+        val allItems = mutableListOf<SettingsItem>()
+        repository.all.forEach {
+            when (it) {
+                is SettingsItem.Category -> allItems.addAll(it.items)
+                else -> allItems.add(it)
+            }
+        }
+        context.dispatch(SearchableItemsUpdated(allItems))
+
+        if (context.state.searchQuery.isNotBlank()) {
+            handleSearching(context, context.state.searchQuery)
+        }
+    }
+
+    private val destinationMap = lazy {
+        mapOf(
+            R.string.preferences_search to SettingsDestination.SearchEngine,
+            R.string.preferences_tabs to SettingsDestination.Tabs,
+            R.string.preferences_home_2 to SettingsDestination.Home,
+            R.string.preferences_customize to SettingsDestination.Customize,
+            R.string.preferences_passwords_logins_and_passwords_2 to SettingsDestination.Passwords,
+            R.string.preferences_autofill to SettingsDestination.Autofill,
+            R.string.preferences_credit_cards_2 to SettingsDestination.Autofill,
+            R.string.preferences_accessibility to SettingsDestination.Accessibility,
+            R.string.preferences_language to SettingsDestination.Language,
+            R.string.preferences_translations to SettingsDestination.Translations,
+            R.string.preferences_private_browsing_options to SettingsDestination.PrivateBrowsing,
+            R.string.preferences_https_only_title to SettingsDestination.HttpsOnly,
+            R.string.preference_enhanced_tracking_protection to SettingsDestination.TrackingProtection,
+            R.string.preference_doh_title to SettingsDestination.DnsOverHttps,
+            R.string.preferences_site_settings to SettingsDestination.SitePermissions,
+            R.string.preferences_delete_browsing_data to SettingsDestination.DeleteBrowsingData,
+            R.string.preferences_delete_browsing_data_on_quit to SettingsDestination.DeleteBrowsingDataOnQuit,
+            R.string.preferences_data_collection to SettingsDestination.DataChoices,
+            R.string.preferences_extensions to SettingsDestination.Addons,
+            R.string.preferences_link_sharing to SettingsDestination.LinkSharing,
+            R.string.preferences_open_links_in_apps to SettingsDestination.OpenLinksInApps,
+            R.string.preferences_downloads to SettingsDestination.Downloads,
+            R.string.preferences_about to SettingsDestination.About,
+        )
+    }
+}

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/navigation/SettingsHost.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/navigation/SettingsHost.kt
@@ -1,0 +1,261 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.navigation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import mozilla.components.compose.base.textfield.TextField
+import mozilla.components.lib.state.ext.observeAsComposableState
+import mozilla.components.lib.state.helpers.StoreProvider.Companion.composableStore
+import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.settings.data.SettingsRepository
+import org.mozilla.fenix.settings.middleware.SettingsMiddleware
+import org.mozilla.fenix.settings.store.SettingsAction
+import org.mozilla.fenix.settings.store.SettingsAction.SearchStarted
+import org.mozilla.fenix.settings.store.SettingsState
+import org.mozilla.fenix.settings.store.SettingsStore
+import org.mozilla.fenix.settings.ui.SearchSettingsScreen
+import org.mozilla.fenix.settings.ui.SettingsScreen
+import org.mozilla.fenix.theme.FirefoxTheme
+import mozilla.components.ui.icons.R as iconsR
+
+/**
+ * Host of all settings screens.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsHost() {
+    val context = LocalContext.current
+    val settingsRepository = remember {
+        SettingsRepository(
+            context = context,
+            settings = context.components.settings,
+            browserStore = context.components.core.store,
+        )
+    }
+    val navController = rememberSettingsNavigationState()
+    val lifecycleScope = rememberCoroutineScope()
+    val settingsStore by composableStore(SettingsState()) {
+            SettingsStore(
+                initialState = it,
+                middlewares = listOf(
+                    SettingsMiddleware(
+                        uiContext = context,
+                        components = context.components,
+                        settings = context.components.settings,
+                        repository = settingsRepository,
+                        navController = navController,
+                        scope = lifecycleScope,
+                    ),
+                ),
+            )
+        }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            if (navController.currentDestination == SettingsDestination.SearchResults) {
+                SearchSettingsInput(settingsStore, navController)
+            } else {
+                SettingsDisplayTopBar(settingsStore, navController)
+            }
+        },
+    ) { innerPadding ->
+        SettingsNavHost(
+            navigationState = navController,
+            modifier = Modifier
+                .padding(top = innerPadding.calculateTopPadding())
+                .fillMaxSize(),
+        ) { destination ->
+            when (destination) {
+                is SettingsDestination.Root -> {
+                    SettingsScreen(destination, settingsStore)
+                }
+
+                is SettingsDestination.SearchResults -> {
+                    SearchSettingsScreen(settingsStore)
+                }
+
+                else -> PlaceholderScreen("Placeholder for ${context.getString(destination.title)} settings")
+            }
+        }
+    }
+}
+
+/**
+ * Simple placeholder screen for demonstration purposes.
+ */
+@Composable
+private fun PlaceholderScreen(title: String) {
+    FirefoxTheme {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineMedium,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SettingsDisplayTopBar(
+    settingsStore: SettingsStore,
+    navController: SettingsNavController,
+) {
+    TopAppBar(
+        title = {
+            Text(
+                style = FirefoxTheme.typography.headline5,
+                text = stringResource(navController.currentDestination.title),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
+        navigationIcon = {
+            IconButton(onClick = { navController.navigateBack() }) {
+                Icon(
+                    painter = painterResource(iconsR.drawable.mozac_ic_back_24),
+                    contentDescription = "Go back",
+                )
+            }
+        },
+        actions = {
+            IconButton(onClick = {
+                navController.navigateTo(SettingsDestination.SearchResults)
+                settingsStore.dispatch(SearchStarted)
+            }) {
+                Icon(
+                    painter = painterResource(iconsR.drawable.mozac_ic_search_24),
+                    contentDescription = "Search settings",
+                )
+            }
+        },
+        windowInsets = WindowInsets(
+            top = 0.dp,
+            bottom = 0.dp,
+        ),
+    )
+}
+
+/**
+ * Composable for the settings search bar.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SearchSettingsInput(
+    settingsStore: SettingsStore,
+    navController: SettingsNavController,
+) {
+    val state by settingsStore.observeAsComposableState { it }
+    val focusRequester = remember { FocusRequester() }
+
+    TopAppBar(
+        modifier = Modifier
+            .wrapContentHeight(),
+        title = {
+            TextField(
+                value = state.searchQuery,
+                onValueChange = { value ->
+                    settingsStore.dispatch(SettingsAction.SearchQueryUpdated(value))
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester),
+                placeholder = stringResource(R.string.settings_search_title),
+                singleLine = true,
+                errorText = stringResource(R.string.settings_search_error_message),
+                colors = TextFieldDefaults.colors(
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    errorIndicatorColor = Color.Transparent,
+                ),
+                trailingIcon = {
+                    if (state.searchQuery.isNotBlank()) {
+                        ClearTextButton(
+                            onClick = {
+                                settingsStore.dispatch(SettingsAction.SearchQueryUpdated(""))
+                            },
+                        )
+                    }
+                },
+            )
+        },
+        navigationIcon = {
+            mozilla.components.compose.base.button.IconButton(
+                onClick = { navController.navigateBack() },
+                contentDescription =
+                    stringResource(
+                        R.string.content_description_settings_search_navigate_back,
+                    ),
+            ) {
+                Icon(
+                    painter = painterResource(
+                        iconsR.drawable.mozac_ic_back_24,
+                    ),
+                    contentDescription = null,
+                    tint = FirefoxTheme.colors.textPrimary,
+                )
+            }
+        },
+        windowInsets = WindowInsets(
+            top = 0.dp,
+            bottom = 0.dp,
+        ),
+    )
+
+    SideEffect {
+        focusRequester.requestFocus()
+    }
+}
+
+@Composable
+private fun ClearTextButton(
+    onClick: () -> Unit,
+) {
+    mozilla.components.compose.base.button.IconButton(
+        onClick = onClick,
+        contentDescription = stringResource(
+            R.string.content_description_settings_search_clear_search,
+        ),
+    ) {
+        Icon(
+            painter = painterResource(iconsR.drawable.mozac_ic_cross_circle_fill_24),
+            contentDescription = null,
+            tint = FirefoxTheme.colors.textPrimary,
+        )
+    }
+}

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/navigation/SettingsNavigation.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/navigation/SettingsNavigation.kt
@@ -1,0 +1,226 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.navigation
+
+import android.os.Parcelable
+import androidx.annotation.StringRes
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.ui.NavDisplay
+import kotlinx.parcelize.Parcelize
+import org.mozilla.fenix.R
+import org.mozilla.fenix.settings.navigation.SettingsDestination.About
+import org.mozilla.fenix.settings.navigation.SettingsDestination.Accessibility
+import org.mozilla.fenix.settings.navigation.SettingsDestination.Addons
+import org.mozilla.fenix.settings.navigation.SettingsDestination.Autofill
+import org.mozilla.fenix.settings.navigation.SettingsDestination.Customize
+import org.mozilla.fenix.settings.navigation.SettingsDestination.DataChoices
+import org.mozilla.fenix.settings.navigation.SettingsDestination.DeleteBrowsingData
+import org.mozilla.fenix.settings.navigation.SettingsDestination.DeleteBrowsingDataOnQuit
+import org.mozilla.fenix.settings.navigation.SettingsDestination.DnsOverHttps
+import org.mozilla.fenix.settings.navigation.SettingsDestination.Downloads
+import org.mozilla.fenix.settings.navigation.SettingsDestination.Home
+import org.mozilla.fenix.settings.navigation.SettingsDestination.HttpsOnly
+import org.mozilla.fenix.settings.navigation.SettingsDestination.Language
+import org.mozilla.fenix.settings.navigation.SettingsDestination.LinkSharing
+import org.mozilla.fenix.settings.navigation.SettingsDestination.NimbusExperiments
+import org.mozilla.fenix.settings.navigation.SettingsDestination.OpenLinksInApps
+import org.mozilla.fenix.settings.navigation.SettingsDestination.Passwords
+import org.mozilla.fenix.settings.navigation.SettingsDestination.PrivateBrowsing
+import org.mozilla.fenix.settings.navigation.SettingsDestination.Root
+import org.mozilla.fenix.settings.navigation.SettingsDestination.SearchEngine
+import org.mozilla.fenix.settings.navigation.SettingsDestination.SearchResults
+import org.mozilla.fenix.settings.navigation.SettingsDestination.SecretDebugInfo
+import org.mozilla.fenix.settings.navigation.SettingsDestination.SecretSettings
+import org.mozilla.fenix.settings.navigation.SettingsDestination.SitePermissions
+import org.mozilla.fenix.settings.navigation.SettingsDestination.SyncDebug
+import org.mozilla.fenix.settings.navigation.SettingsDestination.Tabs
+import org.mozilla.fenix.settings.navigation.SettingsDestination.TrackingProtection
+import org.mozilla.fenix.settings.navigation.SettingsDestination.Translations
+
+/**
+ * All possible destinations in the Settings navigation graph.
+ * Each destination implements [NavKey] for type-safe navigation with Navigation 3.
+ */
+@Parcelize
+sealed class SettingsDestination(@param:StringRes open val title: Int) : NavKey, Parcelable {
+    data object SearchResults : SettingsDestination(R.string.settings)
+
+    data object Root : SettingsDestination(R.string.settings)
+    data object SearchEngine : SettingsDestination(R.string.preferences_search)
+    data object Tabs : SettingsDestination(R.string.preferences_tabs)
+    data object Home : SettingsDestination(R.string.preferences_home_2)
+    data object Customize : SettingsDestination(R.string.preferences_customize)
+    data object Passwords : SettingsDestination(R.string.preferences_passwords_logins_and_passwords_2)
+    data object Autofill : SettingsDestination(R.string.preferences_autofill)
+    data object Accessibility : SettingsDestination(R.string.preferences_accessibility)
+    data object Language : SettingsDestination(R.string.preferences_language)
+    data object Translations : SettingsDestination(R.string.preferences_translations)
+    data object PrivateBrowsing : SettingsDestination(R.string.preferences_private_browsing_options)
+    data object HttpsOnly : SettingsDestination(R.string.preferences_https_only_title)
+    data object TrackingProtection : SettingsDestination(R.string.preference_enhanced_tracking_protection)
+    data object DnsOverHttps : SettingsDestination(R.string.preference_doh_title)
+    data object SitePermissions : SettingsDestination(R.string.preferences_site_settings)
+    data object DeleteBrowsingData : SettingsDestination(R.string.preferences_delete_browsing_data)
+    data object DeleteBrowsingDataOnQuit : SettingsDestination(R.string.preferences_delete_browsing_data_on_quit)
+    data object DataChoices : SettingsDestination(R.string.preferences_data_collection)
+    data object Addons : SettingsDestination(R.string.preferences_extensions)
+    data object LinkSharing : SettingsDestination(R.string.preferences_link_sharing)
+    data object OpenLinksInApps : SettingsDestination(R.string.preferences_open_links_in_apps)
+    data object Downloads : SettingsDestination(R.string.preferences_downloads)
+    data object About : SettingsDestination(R.string.preferences_about)
+    data object SecretSettings : SettingsDestination(R.string.preferences_debug_settings)
+    data object SecretDebugInfo : SettingsDestination(R.string.preferences_debug_info)
+    data object NimbusExperiments : SettingsDestination(R.string.preferences_nimbus_experiments)
+    data object SyncDebug : SettingsDestination(R.string.preferences_sync_debug)
+}
+
+/**
+ * Central back stack management for the settings screens.
+ * This makes it easy to work with the Navigation 3 framework.
+ *
+ * @property backStack The navigation back stack as a mutable state list.
+ */
+class SettingsNavController(
+    val backStack: SnapshotStateList<SettingsDestination> = mutableStateListOf(Root),
+) {
+    /**
+     * Navigate to a destination by adding it to the back stack.
+     *
+     * @param destination The destination to navigate to.
+     */
+    fun navigateTo(destination: SettingsDestination) {
+        backStack.add(destination)
+    }
+
+    /**
+     * Navigate back by removing the last destination from the back stack.
+     *
+     * @return true if navigation was successful, false if already at root.
+     */
+    fun navigateBack(): Boolean {
+        return if (backStack.size > 1) {
+            backStack.removeAt(backStack.lastIndex)
+            true
+        } else {
+            false
+        }
+    }
+
+    /**
+     * Pop back stack up to and including a specific destination.
+     *
+     * @param destination The destination to pop up to.
+     * @param inclusive Whether to also remove the specified destination.
+     */
+    fun popUpTo(destination: SettingsDestination, inclusive: Boolean = false) {
+        val index = backStack.indexOfLast { it == destination }
+        if (index >= 0) {
+            val removeFrom = if (inclusive) index else index + 1
+            while (backStack.size > removeFrom) {
+                backStack.removeAt(backStack.lastIndex)
+            }
+        }
+    }
+
+    /**
+     * Clear the back stack and navigate to a new root destination.
+     *
+     * @param destination The new root destination.
+     */
+    fun navigateToRoot(destination: SettingsDestination = Root) {
+        backStack.clear()
+        backStack.add(destination)
+    }
+
+    /**
+     * Check if the current destination is the root.
+     */
+    val isAtRoot: Boolean
+        get() = backStack.size == 1
+
+    /**
+     * Get the current destination.
+     */
+    val currentDestination: SettingsDestination
+        get() = backStack.last()
+}
+
+/**
+ * Remember the settings navigation state.
+ *
+ * @param startDestination The initial destination for the navigation graph.
+ * @return A remembered [SettingsNavController] instance.
+ */
+@Composable
+fun rememberSettingsNavigationState(
+    startDestination: SettingsDestination = Root,
+): SettingsNavController {
+    return remember {
+        SettingsNavController(mutableStateListOf(startDestination))
+    }
+}
+
+/**
+ * Settings Navigation Host using Navigation 3.
+ *
+ * @param navigationState The navigation state holder.
+ * @param modifier Modifier for the NavDisplay.
+ * @param onExternalNavigation Callback for navigating outside the settings graph (e.g., to other fragments).
+ * @param content Provides the screen content for each destination.
+ */
+@Composable
+fun SettingsNavHost(
+    navigationState: SettingsNavController,
+    modifier: Modifier = Modifier,
+    onExternalNavigation: ((Int) -> Unit)? = null,
+    content: @Composable (SettingsDestination) -> Unit,
+) {
+    NavDisplay(
+        backStack = navigationState.backStack,
+        modifier = modifier,
+        transitionSpec = {
+            slideInHorizontally { it } togetherWith slideOutHorizontally { -it }
+        },
+        entryProvider = entryProvider {
+            entry<SearchResults> { content(it) }
+            entry<Root> { content(it) }
+            entry<SearchEngine> { content(it) }
+            entry<Tabs> { content(it) }
+            entry<Home> { content(it) }
+            entry<Customize> { content(it) }
+            entry<Passwords> { content(it) }
+            entry<Autofill> { content(it) }
+            entry<Accessibility> { content(it) }
+            entry<Language> { content(it) }
+            entry<Translations> { content(it) }
+            entry<PrivateBrowsing> { content(it) }
+            entry<HttpsOnly> { content(it) }
+            entry<TrackingProtection> { content(it) }
+            entry<DnsOverHttps> { content(it) }
+            entry<SitePermissions> { content(it) }
+            entry<DeleteBrowsingData> { content(it) }
+            entry<DeleteBrowsingDataOnQuit> { content(it) }
+            entry<DataChoices> { content(it) }
+            entry<Addons> { content(it) }
+            entry<LinkSharing> { content(it) }
+            entry<OpenLinksInApps> { content(it) }
+            entry<Downloads> { content(it) }
+            entry<About> { content(it) }
+            entry<SecretSettings> { content(it) }
+            entry<SecretDebugInfo> { content(it) }
+            entry<NimbusExperiments> { content(it) }
+            entry<SyncDebug> { content(it) }
+        },
+    )
+}

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/store/SettingsAction.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/store/SettingsAction.kt
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.store
+
+import mozilla.components.lib.state.Action
+import org.mozilla.fenix.settings.navigation.SettingsDestination
+
+/**
+ * Actions specific to the [SettingsStore].
+ */
+sealed class SettingsAction : Action {
+    /**
+     * Loading new settings data is currently in progress.
+     */
+    data object SettingsAreLoading : SettingsAction()
+
+    /**
+     * User navigated to a new settings screen
+     *
+     * @param destination The [SettingsDestination] that was navigated to.
+     */
+    data class DestinationChanged(val destination: SettingsDestination) : SettingsAction()
+
+    /**
+     * New settings data has been loaded for the current settings screen.
+     *
+     * @param items The new settings items.
+     */
+    data class SettingsLoaded(val items: List<SettingsItem>) : SettingsAction()
+
+    /**
+     * User clicked on a settings item.
+     */
+    data class ItemClicked(val item: SettingsItem) : SettingsAction()
+
+    /**
+     * User toggled on/off a setting item.
+     *
+     * @param preferenceKey The key of the preference that was toggled.
+     * @param newValue The new value of the preference.
+     */
+    data class ItemToggled(
+        val preferenceKey: Int,
+        val newValue: Boolean,
+    ) : SettingsAction()
+
+    /**
+     * Search started.
+     */
+    data object SearchStarted : SettingsAction()
+
+    /**
+     * Search finished.
+     */
+    data object SearchEnded : SettingsAction()
+
+    /**
+     * The list of all settings items that can be searched for has been updated.
+     *
+     * @param items The new list of all settings items that can be searched for.
+     */
+    data class SearchableItemsUpdated(val items: List<SettingsItem>) : SettingsAction()
+
+    /**
+     * Search query changed.
+     *
+     * @param query The new search query.
+     */
+    data class SearchQueryUpdated(val query: String) : SettingsAction()
+
+    /**
+     * Search results updated based on the current user query.
+     *
+     * @param items The new search results.
+     */
+    data class SearchResultsUpdated(val items: List<SettingsItem>) : SettingsAction()
+
+    /**
+     * Important message about a setting operation.
+     *
+     * @param message User friendly message about the status or result of a recent setting operation.
+     */
+    data class SettingsUpdateFeedbackAvailable(val message: String) : SettingsAction()
+}

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/store/SettingsState.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/store/SettingsState.kt
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.store
+
+import androidx.annotation.StringRes
+import mozilla.components.lib.state.State
+import org.mozilla.fenix.R
+import org.mozilla.fenix.settings.ui.TextValue
+
+/**
+ * State for the Settings screen following MVI pattern.
+ *
+ * @property isLoading Whether the settings are currently loading and not ready for display.
+ * @property settingsItems List of the settings items to display.
+ * @property searchQuery Current search query (if searching).
+ * @property allSearchableItems All settings items that can be searched for.
+ * @property filteredItems Filtered settings items based on search (if searching).
+ */
+data class SettingsState(
+    val currentDestinationId: Int = R.string.settings,
+    val isLoading: Boolean = true,
+    val settingsItems: List<SettingsItem> = emptyList(),
+    val searchQuery: String = "",
+    val allSearchableItems: List<SettingsItem> = emptyList(),
+    val filteredItems: List<SettingsItem> = emptyList(),
+) : State
+
+/**
+ * Generic setting item.
+ * Items are identified by their [title]'s resource ID for uniqueness.
+ *
+ * @property title The title of the setting item.
+ * @property summary Optional summary of the setting item.
+ * @property icon Optional icon for the setting item.
+ * @property isVisible Whether the setting item is visible.
+ * @property isEnabled Whether the setting item is enabled.
+ */
+sealed class SettingsItem {
+    abstract val title: TextValue
+    abstract val summary: TextValue?
+    abstract val icon: Int?
+    abstract val isVisible: Boolean
+    abstract val isEnabled: Boolean
+
+    /**
+     * General settings item - a simple clickable preference.
+     */
+    data class SimplePreference(
+        override val title: TextValue,
+        override val summary: TextValue? = null,
+        override val icon: Int? = null,
+        override val isVisible: Boolean = true,
+        override val isEnabled: Boolean = true,
+        val id: Int = title.resId,
+        val keywords: List<String> = emptyList(),
+    ) : SettingsItem()
+
+    /**
+     * A toggle/switch preference.
+     */
+    data class TogglePreference(
+        override val title: TextValue,
+        override val summary: TextValue? = null,
+        override val icon: Int? = null,
+        override val isVisible: Boolean = true,
+        override val isEnabled: Boolean = true,
+        val isChecked: Boolean,
+        @param:StringRes val preferenceKey: Int,
+        val id: Int = title.resId,
+        val keywords: List<String> = emptyList(),
+    ) : SettingsItem()
+
+    /**
+     * Category/group header that can contain child settings items.
+     *
+     * @property items List of child settings items within this category.
+     */
+    data class Category(
+        override val title: TextValue,
+        override val summary: TextValue? = null,
+        override val icon: Int? = null,
+        override val isVisible: Boolean = true,
+        override val isEnabled: Boolean = true,
+        val items: List<SettingsItem> = emptyList(),
+    ) : SettingsItem()
+}

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/store/SettingsStore.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/store/SettingsStore.kt
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.store
+
+import mozilla.components.lib.state.Middleware
+import mozilla.components.lib.state.Store
+import org.mozilla.fenix.settings.store.SettingsAction.DestinationChanged
+import org.mozilla.fenix.settings.store.SettingsAction.ItemClicked
+import org.mozilla.fenix.settings.store.SettingsAction.ItemToggled
+import org.mozilla.fenix.settings.store.SettingsAction.SearchEnded
+import org.mozilla.fenix.settings.store.SettingsAction.SearchQueryUpdated
+import org.mozilla.fenix.settings.store.SettingsAction.SearchResultsUpdated
+import org.mozilla.fenix.settings.store.SettingsAction.SearchStarted
+import org.mozilla.fenix.settings.store.SettingsAction.SearchableItemsUpdated
+import org.mozilla.fenix.settings.store.SettingsAction.SettingsAreLoading
+import org.mozilla.fenix.settings.store.SettingsAction.SettingsLoaded
+import org.mozilla.fenix.settings.store.SettingsAction.SettingsUpdateFeedbackAvailable
+
+/**
+ * The [Store] for holding the [SettingsState] and applying [SettingsAction]s.
+ */
+class SettingsStore(
+    initialState: SettingsState = SettingsState(),
+    middlewares: List<Middleware<SettingsState, SettingsAction>> = emptyList(),
+) : Store<SettingsState, SettingsAction>(
+    initialState = initialState,
+    reducer = SettingsReducer::reduce,
+    middleware = middlewares,
+)
+
+/**
+ * Reducer for [SettingsState].
+ */
+object SettingsReducer {
+    fun reduce(state: SettingsState, action: SettingsAction): SettingsState {
+        return when (action) {
+            is SettingsAreLoading -> state.copy(isLoading = true)
+
+            is SettingsLoaded -> state.copy(
+                isLoading = false,
+                settingsItems = action.items,
+            )
+
+            is SearchQueryUpdated -> state.copy(
+                searchQuery = action.query,
+            )
+
+            is SearchableItemsUpdated -> state.copy(
+                allSearchableItems = action.items,
+            )
+
+            is SearchResultsUpdated -> state.copy(
+                filteredItems = action.items,
+            )
+
+            // These actions don't change state and handled by middlewares
+            is DestinationChanged,
+            is ItemClicked,
+            is ItemToggled,
+            is SettingsUpdateFeedbackAvailable,
+            is SearchStarted,
+            is SearchEnded,
+                -> state
+        }
+    }
+}

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/ui/SearchSettingsScreen.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/ui/SearchSettingsScreen.kt
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import mozilla.components.lib.state.ext.observeAsComposableState
+import org.mozilla.fenix.R
+import org.mozilla.fenix.settings.store.SettingsAction.ItemClicked
+import org.mozilla.fenix.settings.store.SettingsAction.ItemToggled
+import org.mozilla.fenix.settings.store.SettingsItem
+import org.mozilla.fenix.settings.store.SettingsState
+import org.mozilla.fenix.settings.store.SettingsStore
+import org.mozilla.fenix.theme.FirefoxTheme
+
+/**
+ * Screen showing settings search results.
+ *
+ * @param store The [SettingsStore] backing the settings functionality.
+ */
+@Composable
+fun SearchSettingsScreen(
+    store: SettingsStore,
+) {
+    val state by store.observeAsComposableState { it }
+
+    if (state.filteredItems.isEmpty()) {
+        EmptySearchResultsView()
+    } else {
+        SearchResults(
+            state = state,
+            onItemClick = { item ->
+                store.dispatch(ItemClicked(item))
+            },
+            onToggleChange = { preferenceKey, newValue ->
+                store.dispatch(ItemToggled(preferenceKey, newValue))
+            },
+        )
+    }
+}
+
+/**
+ * The content of the settings screen.
+ */
+@Composable
+private fun SearchResults(
+    state: SettingsState,
+    onItemClick: (SettingsItem) -> Unit,
+    onToggleChange: (Int, Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface),
+    ) {
+        if (state.isLoading) {
+            CircularProgressIndicator(
+                modifier = Modifier.align(Alignment.Center),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                items(state.filteredItems.filter { it.isVisible }) { item ->
+                    item.render(
+                        onItemClick = onItemClick,
+                        onToggleChange = { preferenceKey, newValue ->
+                            onToggleChange(preferenceKey, newValue)
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptySearchResultsView(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Image(
+                modifier = Modifier.size(77.dp),
+                painter = painterResource(R.drawable.fox_exclamation_alert),
+                contentDescription = null,
+            )
+
+            Text(
+                text = stringResource(R.string.settings_search_no_results_title),
+                textAlign = TextAlign.Center,
+                style = FirefoxTheme.typography.headline7,
+            )
+            Text(
+                text = stringResource(R.string.settings_search_no_results_message),
+                textAlign = TextAlign.Center,
+                style = FirefoxTheme.typography.body2,
+            )
+        }
+    }
+}

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/ui/SettingsItemRender.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/ui/SettingsItemRender.kt
@@ -1,0 +1,185 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import org.mozilla.fenix.settings.store.SettingsItem
+
+/**
+ * Renders a settings item as a Composable based on its type.
+ *
+ * @param onItemClick Callback for when the item is clicked.
+ * @param onToggleChange Callback for when a toggle preference changes allowing to know of
+ * the preference key backing the toggle and the new value.
+ */
+@Composable
+fun SettingsItem.render(
+    onItemClick: (SettingsItem) -> Unit,
+    onToggleChange: (Int, Boolean) -> Unit,
+) {
+    when (this) {
+        is SettingsItem.Category -> render(onItemClick, onToggleChange)
+        is SettingsItem.SimplePreference -> render(onItemClick)
+        is SettingsItem.TogglePreference -> render(onToggleChange)
+    }
+}
+
+/**
+ * Renders a category header and recursively renders all child items.
+ *
+ * @param onItemClick Callback when an item is clicked.
+ * @param onToggleChange Callback for when a toggle preference changes allowing to know of
+ * the preference key backing the toggle and the new value.
+ */
+@Composable
+fun SettingsItem.Category.render(
+    onItemClick: (SettingsItem) -> Unit,
+    onToggleChange: (Int, Boolean) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface),
+    ) {
+        Text(
+            text = title.resolve(),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+        )
+
+        items.forEach { item ->
+            if (item.isVisible) {
+                item.render(
+                    onItemClick = onItemClick,
+                    onToggleChange = onToggleChange,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Renders a simple preference item (clickable, navigates to another screen).
+ *
+ * @param onItemClick Callback for when the item is clicked.
+ */
+@Composable
+fun SettingsItem.SimplePreference.render(
+    onItemClick: (SettingsItem) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = isEnabled) { onItemClick(this@render) }
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = title.resolve(),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = if (isEnabled) {
+                        MaterialTheme.colorScheme.onSurface
+                    } else {
+                        MaterialTheme.colorScheme.inverseOnSurface
+                    },
+                )
+                summary?.let { summaryValue ->
+                    Text(
+                        text = summaryValue.resolve(),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (isEnabled) {
+                            MaterialTheme.colorScheme.onSurface
+                        } else {
+                            MaterialTheme.colorScheme.inverseOnSurface
+                        },
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Renders a toggle preference item (switch).
+ *
+ * @param onToggleChange Callback for when a toggle preference changes allowing to know of
+ * the preference key backing the toggle and the new value.
+ */
+@Composable
+fun SettingsItem.TogglePreference.render(
+    onToggleChange: (Int, Boolean) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .clickable {
+                    onToggleChange(preferenceKey, !isChecked)
+                }
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = title.resolve(),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = if (isEnabled) {
+                        MaterialTheme.colorScheme.onSurface
+                    } else {
+                        MaterialTheme.colorScheme.inverseOnSurface
+                    },
+                )
+                summary?.let { summaryValue ->
+                    Text(
+                        text = summaryValue.resolve(),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSecondary,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
+            }
+            Switch(
+                checked = isChecked,
+                onCheckedChange = { checked ->
+                    onToggleChange(preferenceKey, checked)
+                },
+                enabled = isEnabled,
+            )
+        }
+    }
+}

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/ui/SettingsScreen.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/ui/SettingsScreen.kt
@@ -1,0 +1,137 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import mozilla.components.lib.state.ext.observeAsState
+import org.mozilla.fenix.settings.navigation.SettingsDestination
+import org.mozilla.fenix.settings.store.SettingsAction.DestinationChanged
+import org.mozilla.fenix.settings.store.SettingsAction.ItemClicked
+import org.mozilla.fenix.settings.store.SettingsAction.ItemToggled
+import org.mozilla.fenix.settings.store.SettingsItem
+import org.mozilla.fenix.settings.store.SettingsState
+import org.mozilla.fenix.settings.store.SettingsStore
+import org.mozilla.fenix.theme.FirefoxTheme
+
+/**
+ * The main settings screen.
+ *
+ * @param store The [SettingsStore] backing the settings functionality.
+ */
+@Composable
+fun SettingsScreen(
+    destination: SettingsDestination,
+    store: SettingsStore,
+) {
+    val state by store.observeAsState(initialValue = store.state) { it }
+
+    LaunchedEffect(destination) {
+        store.dispatch(DestinationChanged(destination))
+    }
+
+    SettingsContent(
+        state = state,
+        onItemClick = { item ->
+            store.dispatch(ItemClicked(item))
+        },
+        onToggleChange = { preferenceKey, newValue ->
+            store.dispatch(ItemToggled(preferenceKey, newValue))
+        },
+    )
+}
+
+/**
+ * The content of the settings screen.
+ */
+@Composable
+private fun SettingsContent(
+    state: SettingsState,
+    onItemClick: (SettingsItem) -> Unit,
+    onToggleChange: (Int, Boolean) -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface),
+    ) {
+        if (state.isLoading) {
+            CircularProgressIndicator(
+                modifier = Modifier.align(Alignment.Center),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                itemsIndexed(
+                    items = state.settingsItems,
+                    key = { _, item -> item.title.resId },
+                ) { index, item ->
+                    if (item.isVisible) {
+                        val hasPreviousVisibleItem =
+                            (0 until index).any { state.settingsItems[it].isVisible }
+
+                        if (hasPreviousVisibleItem && item is SettingsItem.Category) {
+                            HorizontalDivider(
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                        }
+
+                        item.render(
+                            onItemClick = onItemClick,
+                            onToggleChange = { preferenceKey, newValue ->
+                                onToggleChange(preferenceKey, newValue)
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@PreviewLightDark
+private fun SettingsScreenPreview() {
+    FirefoxTheme {
+        val previewState = SettingsState(
+            isLoading = false,
+            settingsItems = listOf(
+                SettingsItem.Category(
+                    title = TextValue.fromRes(android.R.string.untitled),
+                ),
+                SettingsItem.SimplePreference(
+                    title = TextValue.fromRes(android.R.string.search_go),
+                    summary = TextValue.fromRes(android.R.string.ok),
+                ),
+                SettingsItem.TogglePreference(
+                    title = TextValue.fromRes(android.R.string.paste),
+                    summary = TextValue.fromRes(android.R.string.ok),
+                    isChecked = true,
+                    preferenceKey = android.R.string.copy,
+                ),
+            ),
+        )
+
+        SettingsContent(
+            state = previewState,
+            onItemClick = {},
+            onToggleChange = { _, _ -> },
+        )
+    }
+}

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/ui/TextValue.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/ui/TextValue.kt
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.ui
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+
+/**
+ * Represents a text value backed by a string resource ID.
+ * This allows for lazy resolution of strings in Compose.
+ *
+ * @property resId The string resource ID.
+ * @property formatArgs Optional format arguments for the string resource.
+ *                      These can be strings, numbers, or other TextValue instances.
+ */
+data class TextValue(
+    @param:StringRes val resId: Int,
+    val formatArgs: List<Any> = emptyList(),
+) {
+    /**
+     * Resolves a [TextValue] to a string in a Composable context.
+     * Format arguments can be:
+     * - Plain values (String, Int, etc.) - used directly
+     * - @StringRes Int - resolved via stringResource
+     * - TextValue - resolved recursively
+     *
+     * @return The resolved string value.
+     */
+    fun resolve(context: Context): String {
+        if (formatArgs.isEmpty()) return context.getString(resId)
+
+        val resolvedArgs = formatArgs.map {
+            when (it) {
+                is TextValue -> it.resolve(context)
+                is Int -> context.getString(it)
+                else -> it
+            }
+        }.toTypedArray()
+
+        return context.getString(resId, *resolvedArgs)
+    }
+
+    /**
+     * Resolves a [TextValue] to a string in a Composable context.
+     * Format arguments can be:
+     * - Plain values (String, Int, etc.) - used directly
+     * - @StringRes Int - resolved via stringResource
+     * - TextValue - resolved recursively
+     *
+     * @return The resolved string value.
+     */
+    @Composable
+    fun resolve(): String = resolve(LocalContext.current)
+
+    companion object {
+        /**
+         * Creates a [TextValue] from a string resource ID.
+         *
+         * @param resId The string resource ID.
+         * @param formatArgs Optional format arguments.
+         */
+        fun fromRes(@StringRes resId: Int, vararg formatArgs: Any): TextValue =
+            TextValue(resId, formatArgs.toList())
+    }
+}

--- a/mobile/android/fenix/app/src/main/res/navigation/nav_graph.xml
+++ b/mobile/android/fenix/app/src/main/res/navigation/nav_graph.xml
@@ -438,6 +438,13 @@
         <action
             android:id="@+id/action_browserFragment_to_webCompatReporterFragment"
             app:destination="@id/webCompatReporterFragment" />
+        <action
+            android:id="@+id/action_browserFragment_to_composableSettingsFragment"
+            app:destination="@id/composableSettingsFragment"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right" />
     </fragment>
 
     <fragment
@@ -564,6 +571,11 @@
             app:destination="@id/savedLogins"
             app:popUpTo="@id/savedLoginsFragment"
             app:popUpToInclusive="true"/>
+
+    <fragment
+        android:id="@+id/composableSettingsFragment"
+        android:name="org.mozilla.fenix.settings.ComposeSettingsFragment"
+        android:label="@string/settings_title" />
 
     <fragment
         android:id="@+id/settingsFragment"


### PR DESCRIPTION
Quick exploration into how the settings functionality could work:
- pure repository to offer the data about all settings items
  - uses a custom DSL for a natural way of building the tree of settings items for each screen
  - it handles also the logic for customizing certain items - different summary/enabled/toggled status before exposing the settings items details 
- all logic handled in one Middleware
  - if a single Middleware becomes too complex we can introduce others for more specific usecases - telemetry, search
- "dumb" View that will only display the available data and emit Actions for user interactions
  - one Fragment allowing to integrate this within all other screens of the application
  - all nested settings screens implemented as composables
  - all setting item types implemented in compose and reused across different screens
- search functionality that uses the same data backing all settings screens as the data that can be queried by the user
  - in conjunction with the repository functionality it showcases how easy it is to include separate metadata based on which the search results can include more items than the ones of which the title or summary matches.
- [Navigation 3](https://developer.android.com/guide/navigation/navigation-3) for managing the nested graph for all settings screens
  - I don't like that the NavGraph is strongly typed - needs different types for each "NavEntry", would've been great if we could use a generic "id" for knowing where to navigate
  - we could also handle the navigation in the new `SettingsStore` but `Navigation 3` has nice conveniences like animations, back handling with automatic backstack update, etc.
