### PR TITLE
Bug 2007071 - Align MIDI errors with the web-midi-api spec

### DIFF
--- a/dom/midi/MIDIAccessManager.cpp
+++ b/dom/midi/MIDIAccessManager.cpp
@@ -67,13 +67,13 @@ already_AddRefed<Promise> MIDIAccessManager::RequestMIDIAccess(
     // different from a normal rejection because we don't want websites to use
     // the error as a way to fingerprint users, so we throw a security error
     // as if the request had been rejected by the user.
-    aRv.ThrowSecurityError("Access not allowed");
+    aRv.ThrowNotAllowedError("Access not allowed");
     return nullptr;
   }
 #endif
 
   if (!FeaturePolicyUtils::IsFeatureAllowed(doc, u"midi"_ns)) {
-    aRv.Throw(NS_ERROR_DOM_SECURITY_ERR);
+    aRv.Throw(NS_ERROR_DOM_NOT_ALLOWED_ERR);
     return nullptr;
   }
 

--- a/dom/midi/MIDIOutput.cpp
+++ b/dom/midi/MIDIOutput.cpp
@@ -87,7 +87,7 @@ void MIDIOutput::Send(const Sequence<uint8_t>& aData,
   if (!SysexEnabled()) {
     for (auto& msg : msgArray) {
       if (MIDIUtils::IsSysexMessage(msg)) {
-        aRv.Throw(NS_ERROR_DOM_INVALID_ACCESS_ERR);
+        aRv.Throw(NS_ERROR_DOM_NOT_ALLOWED_ERR);
         return;
       }
     }

--- a/dom/midi/MIDIPermissionRequest.cpp
+++ b/dom/midi/MIDIPermissionRequest.cpp
@@ -68,7 +68,7 @@ MIDIPermissionRequest::GetTypes(nsIArray** aTypes) {
 NS_IMETHODIMP
 MIDIPermissionRequest::Cancel() {
   mCancelTimer = nullptr;
-  mPromise->MaybeRejectWithSecurityError(
+  mPromise->MaybeRejectWithNotAllowedError(
       "WebMIDI requires a site permission add-on to activate");
   return NS_OK;
 }

--- a/dom/midi/MIDIPort.cpp
+++ b/dom/midi/MIDIPort.cpp
@@ -196,7 +196,7 @@ void MIDIPort::FireStateChangeEvent() {
     }
   } else if (Port()->ConnectionState() == MIDIPortConnectionState::Closed) {
     if (mOpeningPromise) {
-      mOpeningPromise->MaybeReject(NS_ERROR_DOM_INVALID_ACCESS_ERR);
+      mOpeningPromise->MaybeReject(NS_ERROR_DOM_NOT_ALLOWED_ERR);
       mOpeningPromise = nullptr;
     }
     if (mClosingPromise) {

--- a/dom/midi/tests/browser_midi_permission_gated.js
+++ b/dom/midi/tests/browser_midi_permission_gated.js
@@ -131,7 +131,7 @@ add_task(async function testRequestMIDIAccess() {
   );
   is(
     rejectionMessage,
-    "SecurityError: WebMIDI requires a site permission add-on to activate"
+    "NotAllowedError: WebMIDI requires a site permission add-on to activate"
   );
 
   assertSitePermissionInstallTelemetryEvents(["site_warning", "cancelled"]);
@@ -185,7 +185,7 @@ add_task(async function testRequestMIDIAccess() {
   );
   is(
     rejectionMessage,
-    "SecurityError: WebMIDI requires a site permission add-on to activate"
+    "NotAllowedError: WebMIDI requires a site permission add-on to activate"
   );
 
   assertSitePermissionInstallTelemetryEvents([
@@ -386,7 +386,7 @@ add_task(async function testRequestMIDIAccess() {
       return errorMessage;
     }
   );
-  is(rejectionMessage, "SecurityError", "requestMIDIAccess was rejected");
+  is(rejectionMessage, "NotAllowedError", "requestMIDIAccess was rejected");
 
   info("Request midi-sysex access again");
   let denyIntervalStart = performance.now();
@@ -407,7 +407,7 @@ add_task(async function testRequestMIDIAccess() {
   );
   is(
     rejectionMessage,
-    "SecurityError",
+    "NotAllowedError",
     "requestMIDIAccess was rejected without user prompt"
   );
   let denyIntervalElapsed = performance.now() - denyIntervalStart;
@@ -560,7 +560,7 @@ add_task(async function testIframeRequestMIDIAccess() {
 
   is(
     rejectionMessage,
-    "SecurityError",
+    "NotAllowedError",
     "requestMIDIAccess from the remote iframe was rejected"
   );
 

--- a/dom/midi/tests/test_midi_device_explicit_open_close.html
+++ b/dom/midi/tests/test_midi_device_explicit_open_close.html
@@ -69,7 +69,7 @@
          await output_opened.open();
          ok(false, "Should've failed to open port!");
        } catch(err) {
-         is(err.name, "InvalidAccessError", "error name " + err.name + " should be InvalidAccessError");
+         is(err.name, "NotAllowedError", "error name " + err.name + " should be NotAllowedError");
          ok(output_opened.connection == "closed", "connection registered as closed");
          ok(true, "Port not opened, test succeeded");
        } finally {


### PR DESCRIPTION
Deprecated `SecurityError` and `InvalidAccessError` in favor of `NotAllowedError`.

## `InvalidAccessError` replaced by `NotAllowedError`:

The change in spec: [WebAudio/web-midi-api@3795f22](https://github.com/WebAudio/web-midi-api/commit/3795f22)
According PR: [WebAudio/web-midi-api#278](https://github.com/WebAudio/web-midi-api/pull/278)
MDN update PR: [mdn/content#42334](https://github.com/mdn/content/pull/42334)

### Affected APIs

1. `.send` method of output MIDI ports
2. `.open` method of MIDI ports

## `SecurityError` replaced by `NotAllowedError`:

The change in spec: [WebAudio/web-midi-api@b7806b8](https://github.com/WebAudio/web-midi-api/commit/b7806b8)
According PR: [WebAudio/web-midi-api#267](https://github.com/WebAudio/web-midi-api/pull/267)
MDN update PR: [mdn/content#41956](https://github.com/mdn/content/pull/41956)

### Affected APIs

1. `navigator.requestMIDIAccess` method