### PR TITLE
Bug 2003511 - Cancel loading bookmarks if weve navigated from the BookmarksFragment

### DIFF
--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/bookmarks/BookmarkFragment.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/bookmarks/BookmarkFragment.kt
@@ -111,6 +111,7 @@ class BookmarkFragment : Fragment() {
                                 BookmarksSyncMiddleware(requireComponents.backgroundServices.syncStore, lifecycleScope),
                                 BrowserToolbarSyncToBookmarksMiddleware(toolbarStore, lifecycleScope),
                                 BookmarksMiddleware(
+                                    lifecycleScope = lifecycleScope,
                                     bookmarksStorage = requireContext().bookmarkStorage,
                                     clipboardManager = requireActivity().getSystemService(),
                                     addNewTabUseCase = requireComponents.useCases.tabsUseCases.addTab,

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/bookmarks/EditBookmarkFragment.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/bookmarks/EditBookmarkFragment.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.content.getSystemService
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavHostController
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -111,6 +112,7 @@ class EditBookmarkFragment : Fragment(R.layout.fragment_edit_bookmark) {
                                             AppAction.BookmarkAction.BookmarkOperationResultReported(it),
                                         )
                                     },
+                                    lifecycleScope = lifecycleScope,
                                 ),
                             ),
                             bookmarkToLoad = args.guidToEdit,


### PR DESCRIPTION
I also moved the initial folder state to the BookmarksState instead of loading it directly in the middleware. Without the change it prevented us from navigating back on long loads.