### PR TITLE
Bug 2011209 - Fix ALPN field

### DIFF
--- a/netwerk/protocol/http/TlsHandshaker.cpp
+++ b/netwerk/protocol/http/TlsHandshaker.cpp
@@ -161,7 +161,16 @@ nsresult TlsHandshaker::SetupNPNList(nsITLSSocketControl* ssl, uint32_t caps,
   // For NPN, In the case of overlap, matching priority is driven by
   // the order of the server's advertisement - with index 0 used when
   // there is no match.
-  protocolArray.AppendElement("http/1.1"_ns);
+  nsAutoCString val;
+  RefPtr<nsAHttpTransaction> trans = mOwner->Transaction();
+  if (trans && (trans->Caps() & NS_HTTP_CONNECT_ONLY) &&
+      NS_SUCCEEDED(trans->RequestHead()->GetHeader(nsHttp::Upgrade, val)) &&
+      val.Equals("webrtc,c-webrtc"_ns)) {
+    protocolArray.AppendElement("c-webrtc"_ns);
+    protocolArray.AppendElement("webrtc"_ns);
+  } else {
+    protocolArray.AppendElement("http/1.1"_ns);
+  }
 
   if (StaticPrefs::network_http_http2_enabled() &&
       (connectingToProxy || !(caps & NS_HTTP_DISALLOW_SPDY)) &&


### PR DESCRIPTION
Bugzilla : https://bugzilla.mozilla.org/show_bug.cgi?id=2011209


In accordance with RFC 8833, I therefore propose adding a condition so that when the request is a WebRTC request, we set `webrtc,c-webrtc` instead of `http/1.1` in the file `TlsHandshaker.cpp`, in the `SetupNPNList` function.

I haven't found any other solution than the one presented in this fix (namely, retrieving the Upgrade value, as this is the only place I found an indication that we are indeed using WebRTC).

I am open to a better solution if one exists.