### PR TITLE
Bug 2011793 - Separate enrolled experiments in the full list r=azinovyev

### DIFF
--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/nimbus/NimbusExperimentsFragment.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/nimbus/NimbusExperimentsFragment.kt
@@ -7,12 +7,20 @@ package org.mozilla.fenix.nimbus
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.fragment.app.Fragment
 import androidx.fragment.compose.content
 import androidx.navigation.fragment.findNavController
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.showToolbar
+import org.mozilla.fenix.nimbus.ext.fetchPartitionedExperimentListsAsync
+import org.mozilla.fenix.nimbus.view.NimbusExperimentItem
 import org.mozilla.fenix.nimbus.view.NimbusExperiments
 import org.mozilla.fenix.theme.FirefoxTheme
 
@@ -32,8 +40,12 @@ class NimbusExperimentsFragment : Fragment() {
         savedInstanceState: Bundle?,
     ) = content {
         FirefoxTheme {
-            val experiments =
-                requireContext().components.nimbus.sdk.getAvailableExperiments()
+            var experiments by remember { mutableStateOf(emptyList<NimbusExperimentItem>()) }
+            val nimbusSdk = LocalContext.current.components.nimbus.sdk
+
+            LaunchedEffect(Unit) {
+                experiments = nimbusSdk.fetchPartitionedExperimentListsAsync()
+            }
 
             NimbusExperiments(
                 experiments = experiments,

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/nimbus/ext/NimbusApi.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/nimbus/ext/NimbusApi.kt
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.nimbus.ext
+
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.withContext
+import mozilla.components.service.nimbus.NimbusApi
+import org.mozilla.fenix.R
+import org.mozilla.fenix.nimbus.view.NimbusExperimentItem
+import org.mozilla.fenix.nimbus.view.NimbusExperimentItem.EmptyState
+import org.mozilla.fenix.nimbus.view.NimbusExperimentItem.Experiment
+import org.mozilla.fenix.nimbus.view.NimbusExperimentItem.Header
+
+/**
+ * Separates the experiment list into an "active" and "inactive" items based on enrollment for
+ * rendering with [org.mozilla.fenix.nimbus.view.NimbusExperiments].
+ */
+internal fun NimbusApi.partitionedExperimentLists(): List<NimbusExperimentItem> {
+    val availableExperiments = getAvailableExperiments()
+    val activeExperimentSlugs = getActiveExperiments().map { it.slug }.toSet()
+
+    val (active, inactive) = availableExperiments.partition { it.slug in activeExperimentSlugs }
+
+    return buildList {
+        add(Header(R.string.preferences_nimbus_experiments_active))
+
+        if (active.isEmpty()) {
+            add(EmptyState(R.string.preferences_nimbus_experiments_no_items))
+        } else {
+            addAll(active.map { Experiment(it) })
+        }
+
+        add(Header(R.string.preferences_nimbus_experiments_inactive))
+
+        if (inactive.isEmpty()) {
+            add(EmptyState(R.string.preferences_nimbus_experiments_no_items))
+        } else {
+            addAll(inactive.map { Experiment(it) })
+        }
+    }
+}
+
+/**
+ * Separates the experiment list into an "active" and "inactive" items based on enrollment for
+ * rendering with [org.mozilla.fenix.nimbus.view.NimbusExperiments] using
+ * the [kotlinx.coroutines.Dispatchers.IO] dispatcher.
+ */
+suspend fun NimbusApi.fetchPartitionedExperimentListsAsync(): List<NimbusExperimentItem> =
+    withContext(IO) { partitionedExperimentLists() }

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/nimbus/view/NimbusExperiments.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/nimbus/view/NimbusExperiments.kt
@@ -4,41 +4,116 @@
 
 package org.mozilla.fenix.nimbus.view
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
 import org.mozilla.experiments.nimbus.AvailableExperiment
+import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.list.TextListItem
 import org.mozilla.fenix.theme.FirefoxTheme
 
 /**
  * List of Nimbus Experiments.
  *
- * @param experiments List of [AvailableExperiment] that are going to be displayed.
+ * @param experiments List of [NimbusExperimentItem] that are going to be displayed.
  * @param onExperimentClick Invoked when the user clicks on an [AvailableExperiment].
  */
 @Composable
 fun NimbusExperiments(
-    experiments: List<AvailableExperiment> = listOf(),
+    experiments: List<NimbusExperimentItem> = listOf(),
     onExperimentClick: (AvailableExperiment) -> Unit,
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
     ) {
-        items(experiments) { experiment ->
-            TextListItem(
-                label = experiment.userFacingName,
-                description = experiment.userFacingDescription,
-                maxDescriptionLines = Int.MAX_VALUE,
-                onClick = {
-                    onExperimentClick(experiment)
-                },
-            )
+        items(experiments) { item ->
+            when (item) {
+                is NimbusExperimentItem.Header -> NimbusExperimentHeader(titleResourceId = item.title)
+                is NimbusExperimentItem.Experiment -> TextListItem(
+                    label = item.experiment.userFacingName,
+                    description = item.experiment.userFacingDescription,
+                    maxDescriptionLines = Int.MAX_VALUE,
+                    onClick = {
+                        onExperimentClick(item.experiment)
+                    },
+                )
+                is NimbusExperimentItem.EmptyState -> NimbusExperimentEmptyState(text = item.text)
+            }
         }
     }
+}
+
+/**
+ * Item types for the list of experiments to be displayed.
+ */
+sealed class NimbusExperimentItem {
+    /**
+     * Title header for an experiment section. Typically, for "enrolled" or "unenrolled" sections.
+     *
+     * @property title the title to display.
+     */
+    data class Header(
+        @param:StringRes val title: Int,
+    ) : NimbusExperimentItem()
+
+    /**
+     * An experiment item.
+     *
+     * @property experiment the experiment to display.
+     */
+    data class Experiment(val experiment: AvailableExperiment) : NimbusExperimentItem()
+
+    /**
+     * An empty section if there are no items to show.
+     *
+     * @property text the string to show when we have an empty state.
+     */
+    data class EmptyState(
+        @param:StringRes val text: Int,
+    ) : NimbusExperimentItem()
+}
+
+@Composable
+private fun NimbusExperimentHeader(
+    @StringRes titleResourceId: Int,
+) {
+    Text(
+        text = stringResource(titleResourceId),
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(
+            start = 16.dp,
+            end = 16.dp,
+            top = 16.dp,
+            bottom = 8.dp,
+        ),
+    )
+}
+
+@Composable
+private fun NimbusExperimentEmptyState(
+    @StringRes text: Int,
+) {
+    Text(
+        text = stringResource(text),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.secondary,
+        modifier = Modifier.padding(
+            start = 16.dp,
+            end = 16.dp,
+            top = 8.dp,
+            bottom = 8.dp,
+        ),
+    )
 }
 
 @Composable
@@ -55,10 +130,11 @@ private fun NimbusExperimentsPreview() {
     FirefoxTheme {
         NimbusExperiments(
             experiments = listOf(
-                testExperiment,
-                testExperiment,
-                testExperiment,
-                testExperiment,
+                NimbusExperimentItem.Header(R.string.preferences_nimbus_experiments_active),
+                NimbusExperimentItem.EmptyState(R.string.preferences_nimbus_experiments_no_items),
+                NimbusExperimentItem.Header(R.string.preferences_nimbus_experiments_inactive),
+                NimbusExperimentItem.Experiment(testExperiment),
+                NimbusExperimentItem.Experiment(testExperiment),
             ),
             onExperimentClick = {},
         )

--- a/mobile/android/fenix/app/src/main/res/values/static_strings.xml
+++ b/mobile/android/fenix/app/src/main/res/values/static_strings.xml
@@ -35,6 +35,12 @@
     <string name="preferences_debug_settings_allow_third_party_root_certs_summary">Allows the use of third party certificates from the Android CA store</string>
     <!-- Label for the Nimbus experiments preference -->
     <string name="preferences_nimbus_experiments">Nimbus Experiments</string>
+    <!-- Label for the title section of active experiments the user is enrolled in. -->
+    <string name="preferences_nimbus_experiments_active">Active Experiments</string>
+    <!-- Label for an empty list of experiments. -->
+    <string name="preferences_nimbus_experiments_no_items">None</string>
+    <!-- Label for the title section of inactive experiments the user is not enrolled in. -->
+    <string name="preferences_nimbus_experiments_inactive">Inactive Experiments</string>
     <!-- Label for using the nimbus collections preview -->
     <string name="preferences_nimbus_use_preview_collection">Use Nimbus Preview Collection (requires restart)</string>
     <!-- Label for custom Glean server URL -->

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/nimbus/ext/ExperimentsListNimbusApiTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/nimbus/ext/ExperimentsListNimbusApiTest.kt
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.nimbus.ext
+
+import io.mockk.every
+import io.mockk.mockk
+import mozilla.components.service.nimbus.NimbusApi
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mozilla.experiments.nimbus.AvailableExperiment
+import org.mozilla.experiments.nimbus.EnrolledExperiment
+import org.mozilla.fenix.R
+import org.mozilla.fenix.nimbus.view.NimbusExperimentItem
+
+class ExperimentsListNimbusApiTest {
+
+    @Test
+    fun `WHEN no experiments available THEN returns headers with empty states`() {
+        val nimbusApi = mockk<NimbusApi>()
+        every { nimbusApi.getAvailableExperiments() } returns emptyList()
+        every { nimbusApi.getActiveExperiments() } returns emptyList()
+
+        val result = nimbusApi.partitionedExperimentLists()
+
+        assertEquals(4, result.size)
+        assertEquals(NimbusExperimentItem.Header(R.string.preferences_nimbus_experiments_active), result[0])
+        assertEquals(NimbusExperimentItem.EmptyState(R.string.preferences_nimbus_experiments_no_items), result[1])
+        assertEquals(NimbusExperimentItem.Header(R.string.preferences_nimbus_experiments_inactive), result[2])
+        assertEquals(NimbusExperimentItem.EmptyState(R.string.preferences_nimbus_experiments_no_items), result[3])
+    }
+
+    @Test
+    fun `WHEN all experiments are active THEN returns only active experiments with inactive empty state`() {
+        val experiment1 = createAvailableExperiment("exp1")
+        val experiment2 = createAvailableExperiment("exp2")
+        val enrolledExperiment1 = createEnrolledExperiment("exp1")
+        val enrolledExperiment2 = createEnrolledExperiment("exp2")
+
+        val nimbusApi = mockk<NimbusApi>()
+        every { nimbusApi.getAvailableExperiments() } returns listOf(experiment1, experiment2)
+        every { nimbusApi.getActiveExperiments() } returns listOf(enrolledExperiment1, enrolledExperiment2)
+
+        val result = nimbusApi.partitionedExperimentLists()
+
+        assertEquals(5, result.size)
+        assertEquals(NimbusExperimentItem.Header(R.string.preferences_nimbus_experiments_active), result[0])
+        assertEquals(NimbusExperimentItem.Experiment(experiment1), result[1])
+        assertEquals(NimbusExperimentItem.Experiment(experiment2), result[2])
+        assertEquals(NimbusExperimentItem.Header(R.string.preferences_nimbus_experiments_inactive), result[3])
+        assertEquals(NimbusExperimentItem.EmptyState(R.string.preferences_nimbus_experiments_no_items), result[4])
+    }
+
+    @Test
+    fun `WHEN all experiments are inactive THEN returns only inactive experiments`() {
+        val experiment1 = createAvailableExperiment("exp1")
+        val experiment2 = createAvailableExperiment("exp2")
+
+        val nimbusApi = mockk<NimbusApi>()
+        every { nimbusApi.getAvailableExperiments() } returns listOf(experiment1, experiment2)
+        every { nimbusApi.getActiveExperiments() } returns emptyList()
+
+        val result = nimbusApi.partitionedExperimentLists()
+
+        assertEquals(5, result.size)
+        assertEquals(NimbusExperimentItem.Header(R.string.preferences_nimbus_experiments_active), result[0])
+        assertEquals(NimbusExperimentItem.EmptyState(R.string.preferences_nimbus_experiments_no_items), result[1])
+        assertEquals(NimbusExperimentItem.Header(R.string.preferences_nimbus_experiments_inactive), result[2])
+        assertEquals(NimbusExperimentItem.Experiment(experiment1), result[3])
+        assertEquals(NimbusExperimentItem.Experiment(experiment2), result[4])
+    }
+
+    @Test
+    fun `WHEN experiments are mixed active and inactive THEN returns both sections with experiments`() {
+        val activeExperiment1 = createAvailableExperiment("active1")
+        val activeExperiment2 = createAvailableExperiment("active2")
+        val inactiveExperiment1 = createAvailableExperiment("inactive1")
+        val inactiveExperiment2 = createAvailableExperiment("inactive2")
+        val enrolledExperiment1 = createEnrolledExperiment("active1")
+        val enrolledExperiment2 = createEnrolledExperiment("active2")
+
+        val nimbusApi = mockk<NimbusApi>()
+        every { nimbusApi.getAvailableExperiments() } returns listOf(
+            activeExperiment1,
+            inactiveExperiment1,
+            activeExperiment2,
+            inactiveExperiment2,
+        )
+        every { nimbusApi.getActiveExperiments() } returns listOf(enrolledExperiment1, enrolledExperiment2)
+
+        val result = nimbusApi.partitionedExperimentLists()
+
+        assertEquals(6, result.size)
+        assertEquals(NimbusExperimentItem.Header(R.string.preferences_nimbus_experiments_active), result[0])
+        assertEquals(NimbusExperimentItem.Experiment(activeExperiment1), result[1])
+        assertEquals(NimbusExperimentItem.Experiment(activeExperiment2), result[2])
+        assertEquals(NimbusExperimentItem.Header(R.string.preferences_nimbus_experiments_inactive), result[3])
+        assertEquals(NimbusExperimentItem.Experiment(inactiveExperiment1), result[4])
+        assertEquals(NimbusExperimentItem.Experiment(inactiveExperiment2), result[5])
+    }
+
+    @Test
+    fun `WHEN single inactive experiment THEN returns correct structure`() {
+        val experiment = createAvailableExperiment("exp1")
+
+        val nimbusApi = mockk<NimbusApi>()
+        every { nimbusApi.getAvailableExperiments() } returns listOf(experiment)
+        every { nimbusApi.getActiveExperiments() } returns emptyList()
+
+        val result = nimbusApi.partitionedExperimentLists()
+
+        assertEquals(4, result.size)
+        assertEquals(NimbusExperimentItem.Header(R.string.preferences_nimbus_experiments_active), result[0])
+        assertEquals(NimbusExperimentItem.EmptyState(R.string.preferences_nimbus_experiments_no_items), result[1])
+        assertEquals(NimbusExperimentItem.Header(R.string.preferences_nimbus_experiments_inactive), result[2])
+        assertEquals(NimbusExperimentItem.Experiment(experiment), result[3])
+    }
+
+    private fun createAvailableExperiment(slug: String) = AvailableExperiment(
+        slug = slug,
+        userFacingName = "Experiment $slug",
+        userFacingDescription = "Description for $slug",
+        branches = emptyList(),
+        referenceBranch = null,
+    )
+
+    private fun createEnrolledExperiment(slug: String) = EnrolledExperiment(
+        featureIds = emptyList(),
+        slug = slug,
+        userFacingName = "Enrolled $slug",
+        userFacingDescription = "Enrolled description for $slug",
+        branchSlug = "control",
+    )
+}


### PR DESCRIPTION
Separates out the available list of experiments into an enrolled section
for easier distinction against the unenrolled.

**🏗️ Try (fenix preset):** https://treeherder.mozilla.org/jobs?repo=try&landoCommitID=174285

| Light | Dark |
|--------|--------|
| <img width="1080" height="2424" alt="Screenshot_20260121_200545" src="https://github.com/user-attachments/assets/898b0a18-97fd-4309-98c9-5110c9f1373f" /> | <img width="1080" height="2424" alt="Screenshot_20260121_221214" src="https://github.com/user-attachments/assets/54df9d60-482f-42d8-a785-845c78e9527a" /> |

