### PR TITLE
Bug 2011536 - sanitize intent before interacting with it.

### DIFF
--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
@@ -43,6 +43,12 @@ class IntentReceiverActivity : Activity() {
         // DO NOT MOVE ANYTHING ABOVE THIS getProfilerTime CALL.
         val startTimeProfiler = components.core.engine.profiler?.getProfilerTime()
 
+        // The intent property is nullable, but the rest of the code below
+        // assumes it is not. If it's null, then we make a new one and open
+        // the HomeActivity.
+        val intent = intent?.let { Intent(it) } ?: Intent()
+        intent.sanitize().stripUnwantedFlags()
+
         // DO NOT MOVE the app link intent launch type setting below the super.onCreate call
         // as it impacts the activity lifecycle observer and causes false launch type detection.
         // e.g. COLD launch is interpreted as WARM due to [Activity.onActivityCreated] being called
@@ -57,11 +63,6 @@ class IntentReceiverActivity : Activity() {
             super.onCreate(savedInstanceState)
         }
 
-        // The intent property is nullable, but the rest of the code below
-        // assumes it is not. If it's null, then we make a new one and open
-        // the HomeActivity.
-        val intent = intent?.let { Intent(it) } ?: Intent()
-        intent.sanitize().stripUnwantedFlags()
         processIntent(intent)
 
         components.core.engine.profiler?.addMarker(
@@ -158,7 +159,7 @@ class IntentReceiverActivity : Activity() {
         val r = try {
             // NB: referrer can be spoofed by the calling application. Use with caution.
             referrer
-        } catch (e: RuntimeException) {
+        } catch (_: RuntimeException) {
             // this could happen if the referrer intent contains data we can't deserialize
             return
         } ?: return


### PR DESCRIPTION
We are seeing `ClassCastException`s in the crash report - this is likely to be happening because some external intent has serialized some class that our app doesn't know about. Calling this `sanitize()` function strips out unknown classes from the bundle. `Intent.putExtra()` will internally call unparcel(), which assumes the bundle is serializable, so we need to call sanitize before doing this.

[Running a try here](https://treeherder.mozilla.org/jobs?repo=try&revision=9a328763a8bcbf33ecc7e9116aceaa5854f85157)