### PR TITLE
Bug 2011184 - check fragment is added before finding nav controller.

### DIFF
--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -747,13 +747,15 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
                                 dialog.cancel()
                             }
                             setPositiveButton(R.string.qr_scanner_dialog_positive) { dialog: DialogInterface, _ ->
-                                findNavController().openToBrowser()
-                                requireComponents.useCases.fenixBrowserUseCases.loadUrlOrSearch(
-                                    searchTermOrURL = normalizedUrl,
-                                    newTab = store.state.tabId == null,
-                                    flags = EngineSession.LoadUrlFlags.external(),
-                                )
-                                dialog.dismiss()
+                                if (isAdded) {
+                                    findNavController().openToBrowser()
+                                    requireComponents.useCases.fenixBrowserUseCases.loadUrlOrSearch(
+                                        searchTermOrURL = normalizedUrl,
+                                        newTab = store.state.tabId == null,
+                                        flags = EngineSession.LoadUrlFlags.external(),
+                                    )
+                                    dialog.dismiss()
+                                }
                             }
                             create().withCenterAlignedButtons()
                         }.show()


### PR DESCRIPTION
We are seeing `IllegalStateException`s in the play store from calling `findNavController` when the fragment is not associated with a transaction (the parentFragmentManager is null) `isAdded()` is the recommended way to find out if this fragment is attached to an activity and  `findNavController()` is safe to call

NB this fix is based on static analysis only - plan is to keep an eye on the crash logs after it lands to confirm it works.

[running a try here](https://treeherder.mozilla.org/jobs?repo=try&revision=f74abab716cd9b4f9af2b1742294c4712f80644c) but it seems to have included every commit since dinosaurs roamed the earth, not sure what happened there