### PR TITLE
Bug 2015009 - truncate very long dialog messages.

### DIFF
--- a/mobile/android/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/AbstractPromptTextDialogFragment.kt
+++ b/mobile/android/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/AbstractPromptTextDialogFragment.kt
@@ -14,6 +14,7 @@ import androidx.annotation.IdRes
 import androidx.core.view.isVisible
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import mozilla.components.feature.prompts.R
+import mozilla.components.feature.prompts.ext.Truncation
 
 internal const val KEY_MANY_ALERTS = "KEY_MANY_ALERTS"
 internal const val KEY_USER_CHECK_BOX = "KEY_USER_CHECK_BOX"
@@ -47,7 +48,7 @@ internal abstract class AbstractPromptTextDialogFragment : PromptDialogFragment(
         val inflater = LayoutInflater.from(requireContext())
         val view = inflater.inflate(R.layout.mozac_feature_prompt_with_check_box, null)
         val textView = view.findViewById<TextView>(R.id.message)
-        textView.text = message
+        textView.text = truncateMessage(message)
         textView.movementMethod = ScrollingMovementMethod()
 
         addCheckBoxIfNeeded(view)
@@ -55,6 +56,18 @@ internal abstract class AbstractPromptTextDialogFragment : PromptDialogFragment(
         builder.setView(view)
 
         return builder
+    }
+
+    /**
+     * Truncates the message to prevent ANR during text measurement.
+     * Long strings can cause Android's native text layout engine to timeout.
+     */
+    private fun truncateMessage(text: String): String {
+        return if (text.length > Truncation.MAX_MESSAGE_LENGTH) {
+            text.substring(0, Truncation.MAX_MESSAGE_LENGTH) + "…"
+        } else {
+            text
+        }
     }
 
     internal fun addCheckBoxIfNeeded(

--- a/mobile/android/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/AuthenticationDialogFragment.kt
+++ b/mobile/android/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/AuthenticationDialogFragment.kt
@@ -18,6 +18,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.Companion.PRIVATE
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import mozilla.components.feature.prompts.R
+import mozilla.components.feature.prompts.ext.Truncation
 import mozilla.components.ui.widgets.withCenterAlignedButtons
 
 private const val KEY_USERNAME_EDIT_TEXT = "KEY_USERNAME_EDIT_TEXT"
@@ -55,7 +56,7 @@ internal class AuthenticationDialogFragment : PromptDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val builder = MaterialAlertDialogBuilder(requireContext())
             .setupTitle()
-            .setMessage(message)
+            .setMessage(truncateMessage(message))
             .setCancelable(true)
             .setNegativeButton(R.string.mozac_feature_prompts_cancel) { _, _ ->
                 feature?.onCancel(sessionId, promptRequestUID)
@@ -64,6 +65,17 @@ internal class AuthenticationDialogFragment : PromptDialogFragment() {
                 onPositiveClickAction()
             }
         return addLayout(builder).create().withCenterAlignedButtons()
+    }
+
+    /**
+     * Truncates the message to prevent ANR during text measurement.
+     */
+    private fun truncateMessage(text: String): String {
+        return if (text.length > Truncation.MAX_MESSAGE_LENGTH) {
+            text.substring(0, Truncation.MAX_MESSAGE_LENGTH) + "…"
+        } else {
+            text
+        }
     }
 
     override fun onCancel(dialog: DialogInterface) {

--- a/mobile/android/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/TextPromptDialogFragment.kt
+++ b/mobile/android/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/TextPromptDialogFragment.kt
@@ -17,6 +17,7 @@ import android.widget.TextView
 import androidx.core.view.inputmethod.EditorInfoCompat.IME_FLAG_NO_PERSONALIZED_LEARNING
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import mozilla.components.feature.prompts.R
+import mozilla.components.feature.prompts.ext.Truncation
 import mozilla.components.ui.widgets.withCenterAlignedButtons
 
 private const val KEY_USER_EDIT_TEXT = "KEY_USER_EDIT_TEXT"
@@ -78,14 +79,26 @@ internal class TextPromptDialogFragment : AbstractPromptTextDialogFragment(), Te
         val label = view.findViewById<TextView>(R.id.input_label)
         val editText = view.findViewById<EditText>(R.id.input_value)
 
-        label.text = labelInput
-        editText.setText(defaultInputValue)
+        label.text = truncateText(labelInput)
+        editText.setText(truncateText(defaultInputValue))
         editText.addTextChangedListener(this)
         editText.imeOptions = if (private == true) IME_FLAG_NO_PERSONALIZED_LEARNING else IME_NULL
 
         addCheckBoxIfNeeded(view)
 
         return builder.setView(view)
+    }
+
+    /**
+     * Truncates text to prevent ANR during text measurement.
+     */
+    private fun truncateText(text: String?): String {
+        if (text == null) return ""
+        return if (text.length > Truncation.MAX_MESSAGE_LENGTH) {
+            text.substring(0, Truncation.MAX_MESSAGE_LENGTH) + "…"
+        } else {
+            text
+        }
     }
 
     override fun afterTextChanged(editable: Editable) {

--- a/mobile/android/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/ext/Truncation.kt
+++ b/mobile/android/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/ext/Truncation.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts.ext
+
+/**
+ * Handles text truncation limit
+ */
+object Truncation {
+    /**
+     * Maximum length for dialog message text to prevent ANR during text measurement.
+     * Very long strings can cause Android's text layout engine to timeout on the main thread.
+     */
+    const val MAX_MESSAGE_LENGTH = 1200
+}

--- a/mobile/android/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/identitycredential/PrivacyPolicyDialogFragment.kt
+++ b/mobile/android/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/identitycredential/PrivacyPolicyDialogFragment.kt
@@ -24,6 +24,7 @@ import mozilla.components.feature.prompts.dialog.KEY_PROMPT_UID
 import mozilla.components.feature.prompts.dialog.KEY_SESSION_ID
 import mozilla.components.feature.prompts.dialog.KEY_SHOULD_DISMISS_ON_LOAD
 import mozilla.components.feature.prompts.dialog.KEY_TITLE
+import mozilla.components.feature.prompts.ext.Truncation
 
 internal const val KEY_ICON = "KEY_ICON"
 
@@ -51,7 +52,12 @@ internal class PrivacyPolicyDialogFragment : AbstractPromptTextDialogFragment() 
         val inflater = LayoutInflater.from(requireContext())
         val view = inflater.inflate(R.layout.mozac_feature_prompt_simple_text, null)
         val textView = view.findViewById<TextView>(R.id.labelView)
-        val text = HtmlCompat.fromHtml(message, HtmlCompat.FROM_HTML_MODE_COMPACT)
+        val truncatedMessage = if (message.length > Truncation.MAX_MESSAGE_LENGTH) {
+            message.substring(0, Truncation.MAX_MESSAGE_LENGTH) + "…"
+        } else {
+            message
+        }
+        val text = HtmlCompat.fromHtml(truncatedMessage, HtmlCompat.FROM_HTML_MODE_COMPACT)
 
         val spannableStringBuilder = SpannableStringBuilder(text)
         spannableStringBuilder.getSpans<URLSpan>().forEach { link ->


### PR DESCRIPTION
We are seeing ANRs in the play store from the compute line break algorithm when it is given extremely long words to process. Truncating these for the various prompts we have which accept any input.

[running a try here](https://treeherder.mozilla.org/jobs?repo=try&revision=5ccdd454cda92c53a620b1da48e218ec52348adc)