### PR TITLE
Bug 2020840 - Fix strict mode violation when initializing `ClientUUID`

### DIFF
--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/components/ClientUUID.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/components/ClientUUID.kt
@@ -17,12 +17,14 @@ import java.util.UUID
  * consistently across [UserIdProvider] and [RequestHashProvider] consumers.
  */
 class ClientUUID(
-    private val prefs: SharedPreferences,
+    private val getPrefs: () -> SharedPreferences,
     private val generateUUID: () -> String = { UUID.randomUUID().toString() },
 ) : UserIdProvider, RequestHashProvider {
     private val uuid: String by lazy {
-        prefs.getString(KEY, null) ?: generateUUID().also {
-            prefs.edit { putString(KEY, it) }
+        getPrefs().let { prefs ->
+            prefs.getString(KEY, null) ?: generateUUID().also {
+                prefs.edit { putString(KEY, it) }
+            }
         }
     }
 
@@ -40,8 +42,7 @@ class ClientUUID(
          * @return an instance of [ClientUUID]
          */
         fun build(context: Context): ClientUUID {
-            val prefs = context.getSharedPreferences("client_uuid", Context.MODE_PRIVATE)
-            return ClientUUID(prefs)
+            return ClientUUID({ context.getSharedPreferences("client_uuid", Context.MODE_PRIVATE) })
         }
     }
 }

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/components/ClientUUIDTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/components/ClientUUIDTest.kt
@@ -14,11 +14,11 @@ class ClientUUIDTest {
     fun `that a client uuid will only be generated the first time`() {
         val prefs = FakeSharedPreferences()
 
-        val first = ClientUUID(prefs) { "my-generated-uuid" }
+        val first = ClientUUID({ prefs }) { "my-generated-uuid" }
         assertEquals(UserId("my-generated-uuid"), first.getUserId())
         assertEquals(UserId("my-generated-uuid"), first.getUserId())
 
-        val second = ClientUUID(prefs) {
+        val second = ClientUUID({ prefs }) {
             throw IllegalStateException("We should not be generating another uuid")
         }
         assertEquals(UserId("my-generated-uuid"), second.getUserId())


### PR DESCRIPTION
[try](https://treeherder.mozilla.org/jobs?repo=try&landoCommitID=183207)