### PR TITLE
Bug 2024866 - fix classcastexception from using wrong type of switch.

### DIFF
--- a/mobile/android/fenix/app/src/main/res/xml/secret_settings_preferences.xml
+++ b/mobile/android/fenix/app/src/main/res/xml/secret_settings_preferences.xml
@@ -173,7 +173,7 @@
         android:key="@string/pref_key_search_optimization"
         android:title="@string/preferences_debug_settings_search_optimization"
         app:iconSpaceReserved="false"/>
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:key="@string/pref_key_enable_longfox"
         android:title="@string/preferences_debug_settings_enable_longfox"
         app:iconSpaceReserved="false"/>


### PR DESCRIPTION
We've moved from SwitchPreference to SwitchPreferenceCompat, this collided with me adding a new one, so ended up with conflict issues (: