### PR TITLE
Bug 1846829 - Remove the max-history-rows pref used in Fx View

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -3420,7 +3420,7 @@ pref("browser.firefox-view.feature-tour", "{\"screen\":\"FIREFOX_VIEW_SPOTLIGHT\
 // Number of times the user visited about:firefoxview via the button/hidden tab in the past 30 days
 pref("browser.firefox-view.button-clicks", "{\"count\":0,\"lastCountTime\":\"\"}");
 // Maximum number of rows to show on the "History" page (0 = unlimited).
-pref("browser.firefox-view.max-history-rows", 0);
+
 // Enables virtual list functionality in Firefox View.
 pref("browser.firefox-view.virtual-list.enabled", true);
 

--- a/browser/components/firefoxview/HistoryController.sys.mjs
+++ b/browser/components/firefoxview/HistoryController.sys.mjs
@@ -11,16 +11,7 @@ ChromeUtils.defineESModuleGetters(lazy, {
   PlacesUtils: "resource://gre/modules/PlacesUtils.sys.mjs",
 });
 
-let XPCOMUtils = ChromeUtils.importESModule(
-  "resource://gre/modules/XPCOMUtils.sys.mjs"
-).XPCOMUtils;
 
-XPCOMUtils.defineLazyPreferenceGetter(
-  lazy,
-  "maxRowsPref",
-  "browser.firefox-view.max-history-rows",
-  -1
-);
 
 const HISTORY_MAP_L10N_IDS = {
   sidebar: {
@@ -523,7 +514,7 @@ export class HistoryController {
   async #fetchHistory() {
     return this.placesQuery.getHistory({
       daysOld: 60,
-      limit: lazy.maxRowsPref,
+      limit: -1,
       sortBy: this.sortOption,
     });
   }


### PR DESCRIPTION
Bug 1846829 - Remove the max-history-rows pref used in Fx View

## Changes Made

- Removed `XPCOMUtils.defineLazyPreferenceGetter` for `maxRowsPref` 
  from `HistoryController.sys.mjs`
- Removed unused `XPCOMUtils` import from `HistoryController.sys.mjs`
- Replaced `lazy.maxRowsPref` with `-1` in the `fetchHistory` method
- Removed `pref("browser.firefox-view.max-history-rows", 0)` 
  from `browser/app/profile/firefox.js`

## Why

The `browser.firefox-view.max-history-rows` pref is unnecessary 
as the history list is already unlimited by default and virtual 
lists make a row limit redundant.

Outreachy applicant contribution.