### PR TITLE
Bug 2024961: Add game screen.

### DIFF
--- a/mobile/android/fenix/app/longfox/build.gradle
+++ b/mobile/android/fenix/app/longfox/build.gradle
@@ -29,9 +29,8 @@ android {
 }
 
 dependencies {
-    implementation libs.androidx.core.ktx
+    implementation libs.androidx.activity.compose
     implementation libs.androidx.appcompat
-    implementation libs.google.material
     implementation platform(libs.androidx.compose.bom)
     implementation libs.androidx.compose.animation
     implementation libs.androidx.compose.foundation
@@ -40,6 +39,8 @@ dependencies {
     implementation libs.androidx.compose.ui
     implementation libs.androidx.compose.ui.tooling.preview
     implementation libs.androidx.compose.ui.graphics
+    implementation libs.androidx.core.ktx
+    implementation libs.google.material
     testImplementation libs.junit4
     androidTestImplementation libs.androidx.test.junit
     androidTestImplementation libs.androidx.test.espresso.core

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/GameCanvas.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/GameCanvas.kt
@@ -32,10 +32,9 @@ import org.mozilla.fenix.longfox.GameState.Companion.CELL_SIZE_DP
  * body, head, tail and food.
  *
  * @param state the current game state
- * @param onSize a callback that is called when the canvas is resized
  */
 @Composable
-fun GameCanvas(state: GameState, onSize: (Size) -> Unit) {
+fun GameCanvas(state: GameState) {
     val context = LocalContext.current
     val cellSize = state.cellSize.toInt()
 
@@ -77,7 +76,6 @@ fun GameCanvas(state: GameState, onSize: (Size) -> Unit) {
             .background(color = Color.Black)
             .size((CELL_SIZE_DP * state.numCellsWide).dp),
     ) {
-        onSize(size)
         drawHead(state, kitHead)
         drawBody(state, shouldersPath, bottomPath)
         drawTail(state, kitTail)
@@ -89,6 +87,6 @@ fun GameCanvas(state: GameState, onSize: (Size) -> Unit) {
 @Composable
 fun GameCanvasPreview() {
     MaterialTheme {
-        GameCanvas(GameState(size = Size(600f, 1000f)), onSize = { _ -> })
+        GameCanvas(GameState(size = Size(600f, 1000f)))
     }
 }

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/GameState.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/GameState.kt
@@ -45,6 +45,7 @@ data class GameState(
 
     companion object {
         const val CELL_SIZE_DP = 20f
+        const val GAME_INTERVAL_TIME_MS = 100L
     }
 
     val numCellsWide = numCells
@@ -62,6 +63,11 @@ data class GameState(
         fox.size < 3 -> direction
         else -> fox[fox.size - 2].directionTo(fox[fox.size - 3])
     }
+
+    /**
+     * Audio state machine: beep boop beep boop....
+     */
+    fun toggleBeepNext(): GameState = copy(beepNext = !beepNext)
 
     /**
      * This function moves the fox in its current direction.

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/LongFoxFeature.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/LongFoxFeature.kt
@@ -6,5 +6,41 @@
 
 package org.mozilla.fenix.longfox
 
-@SuppressWarnings("unused")
-class LongFoxFeature
+import android.view.ViewGroup
+import androidx.activity.compose.BackHandler
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+
+/**
+ * Initialises Long Fox 🟧🟧🟧🟧🦊
+ *
+ * Adds a compose view with the game to whichever view is passed in.
+ * When back is pressed, gets rid of this game ComposeView.
+ *
+ */
+@Suppress("unused")
+class LongFoxFeature {
+
+    /**
+     * If you want to include the game somewhere, call this with a view you want to attach it to.
+     * @param container the view that you want to put the game in
+     */
+    fun start(container: ViewGroup) {
+        val context = container.context ?: return
+        container.addView(
+            ComposeView(context).apply {
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+                setContent {
+                    MaterialTheme {
+                        LongFoxGameScreen()
+                    }
+                    BackHandler {
+                        container.removeView(this)
+                        disposeComposition()
+                    }
+                }
+            },
+        )
+    }
+}

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/LongFoxGameScreen.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/LongFoxGameScreen.kt
@@ -1,0 +1,119 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.mozilla.fenix.longfox
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.tooling.preview.Preview
+import kotlinx.coroutines.delay
+import org.mozilla.fenix.longfox.GameState.Companion.CELL_SIZE_DP
+import org.mozilla.fenix.longfox.GameState.Companion.GAME_INTERVAL_TIME_MS
+
+/**
+ * The main composable container for the game.
+ * Holds the game state and callbacks for resizing the screen, handling touch, playing sounds etc.
+ */
+@Composable
+fun LongFoxGameScreen() {
+    BoxWithConstraints(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Blue),
+    ) {
+        // Make a square game grid that fits on the screen
+        val density = LocalDensity.current.density
+        val numCells = (minOf(maxWidth, maxHeight).value / CELL_SIZE_DP).toInt()
+        val canvasSizePx = CELL_SIZE_DP * numCells * density
+        var gameState by remember(numCells) {
+            mutableStateOf(GameState(numCells = numCells, size = Size(canvasSizePx, canvasSizePx), isGameOver = true))
+        }
+        val restartGame = { gameState = GameState(numCells = numCells, size = Size(canvasSizePx, canvasSizePx)) }
+
+        // Tap events need to be passed through to the game.
+        // Position should be recalculated if the screen is resized / configuration changed.
+        val canvasOffsetXPx = (maxWidth.value * density - canvasSizePx) / 2f
+        val canvasOffsetYPx = (maxHeight.value * density - canvasSizePx) / 2f
+        val onTap by rememberUpdatedState { offset: Offset ->
+            gameState = gameState.onTap(
+                Offset(offset.x - canvasOffsetXPx, offset.y - canvasOffsetYPx),
+            )
+        }
+        val context = LocalContext.current
+        val soundEffectsPlayer = remember { SoundEffectsPlayer(context) }
+        DisposableEffect(soundEffectsPlayer) {
+            onDispose { soundEffectsPlayer.release() }
+        }
+        LaunchedEffect(gameState.isGameOver) {
+            if (gameState.isGameOver) soundEffectsPlayer.playSound(R.raw.sadwobble)
+        }
+        // This is the main game loop:
+        // While the game is not over, wait a clock tick, move the fox and check for collisions.
+        // Play a sound effect if that seems appropriate.
+        LaunchedEffect(gameState) {
+            while (!gameState.isGameOver) {
+                delay(GAME_INTERVAL_TIME_MS)
+                val oldScore = gameState.score
+                gameState = gameState.moveFox()
+                val newScore = gameState.score
+                if (newScore > oldScore) {
+                    soundEffectsPlayer.playSound(R.raw.eatfood)
+                } else {
+                    if (gameState.beepNext) {
+                        soundEffectsPlayer.playSound(R.raw.beep)
+                    } else {
+                        soundEffectsPlayer.playSound(R.raw.boop)
+                    }
+                }
+                gameState = gameState.toggleBeepNext()
+            }
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    detectTapGestures(onTap = { onTap(it) })
+                },
+            contentAlignment = Alignment.Center,
+        ) {
+            if (gameState.isGameOver) {
+                restartGame()
+            }
+            GameCanvas(gameState)
+        }
+        if (!gameState.isGameOver) {
+            ScoreContainer(gameState.score)
+        }
+    }
+}
+
+@Preview
+@Composable
+fun LongFoxGameScreenPreview() {
+    MaterialTheme {
+        LongFoxGameScreen()
+    }
+}

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/ScoreContainer.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/ScoreContainer.kt
@@ -1,0 +1,40 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.mozilla.fenix.longfox
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Shows the player's current score in the top end corner.
+ */
+@Composable
+fun ScoreContainer(score: Int) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(6.dp),
+        contentAlignment = Alignment.CenterEnd,
+    ) {
+        Text(
+            //TODO: extract string resource for score - this will have to be landed separately
+            text = "Score: $score",
+            color = Color.White,
+            fontWeight = FontWeight.Bold,
+            fontSize = 32.sp,
+        )
+    }
+}

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/SoundEffectsPlayer.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/SoundEffectsPlayer.kt
@@ -10,7 +10,6 @@ import android.content.Context
 import android.media.MediaPlayer
 import androidx.annotation.RawRes
 
-@Suppress("unused")
 class SoundEffectsPlayer(private val context: Context) {
 
     private val activePlayers = mutableSetOf<MediaPlayer>()


### PR DESCRIPTION
This wires together the canvas, the game state and the sound effects, and sizes the game grid appropriately for the device.

Hoisted the screen size calculation out of the canvas to the new `LongFoxGameScreen` to simplify a bit.

NB there's no intro screen, sound on off. etc yet, that is to follow. Also it's not plumbed in anywhere in the actual browser yet, but we're adding the `LongfoxFeature.start()` function in this PR to allow you to do that soon :)