### PR TITLE
Bug 2024964: Add intro screen

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ coordinatorlayout = "1.3.0"
 core = "1.18.0"
 core-splashscreen = "1.2.0"
 datastore = "1.2.1"
+datastore-core = "1.2.1"
 documentfile = "1.1.0"
 drawerlayout = "1.2.0"
 emoji2 = "1.6.0"
@@ -152,6 +153,7 @@ androidx-core = { module = "androidx.core:core", version.ref = "core" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "core-splashscreen" }
 androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "datastore" }
+androidx-datastore-core = { group = "androidx.datastore", name = "datastore-core", version.ref = "datastore-core" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 androidx-documentfile = { module = "androidx.documentfile:documentfile", version.ref = "documentfile" }
 androidx-drawerlayout = { module = "androidx.drawerlayout:drawerlayout", version.ref = "drawerlayout" }

--- a/mobile/android/fenix/app/longfox/build.gradle
+++ b/mobile/android/fenix/app/longfox/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation libs.androidx.compose.ui.tooling.preview
     implementation libs.androidx.compose.ui.graphics
     implementation libs.androidx.core.ktx
+    implementation libs.androidx.datastore.core
+    implementation libs.androidx.datastore.preferences
     implementation libs.google.material
     testImplementation libs.junit4
     androidTestImplementation libs.androidx.test.junit

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/DrawFood.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/DrawFood.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
  * @param food the food bitmap
  */
 fun DrawScope.drawFood(state: GameState, food: ImageBitmap?) {
-    if (food == null) return
+    if (food == null || state.food == null) return
     drawImage(
         image = food,
         topLeft = Offset(state.food.x * state.cellSize, state.food.y * state.cellSize),

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/GameState.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/GameState.kt
@@ -35,7 +35,7 @@ import kotlin.random.Random
 data class GameState(
     val size: Size = Size(0f, 0f),
     val fox: List<GridPoint> = listOf(GridPoint(5, 5), GridPoint(5, 4), GridPoint(5, 3), GridPoint(5, 2)),
-    val food: GridPoint = GridPoint(8, 8),
+    val food: GridPoint? = GridPoint(8, 8),
     val direction: Direction = DOWN,
     val isGameOver: Boolean = false,
     val score: Int = 0,
@@ -75,13 +75,7 @@ data class GameState(
      * or has it just shifted along a space?
      */
     fun moveFox(): GameState {
-        val head = fox.first()
-        val newHead = when (direction) {
-            UP -> head.copy(y = head.y - 1)
-            DOWN -> head.copy(y = head.y + 1)
-            LEFT -> head.copy(x = head.x - 1)
-            RIGHT -> head.copy(x = head.x + 1)
-        }
+        val newHead = makeNewHead(direction, fox.first())
 
         val collidedWithSelf = newHead in fox.dropLast(1)
         val collidedWithEdge = !withinBounds(newHead)
@@ -101,6 +95,33 @@ data class GameState(
                 isGameOver = isGameOver,
             )
         }
+    }
+
+    fun foxAnimationDemo(): GameState {
+        val head = fox.first()
+
+        val newDirection = when {
+            head.y >= numCellsTall - 2 -> {
+                if (head.x < numCellsWide - 2) RIGHT else UP
+            }
+            head.y < 2 -> {
+                if (head.x >= 2) LEFT else DOWN
+            }
+            else -> direction
+        }
+
+        val newFox = listOf(makeNewHead(newDirection, head)) + fox.dropLast(1)
+        return copy(fox = newFox, direction = newDirection)
+    }
+
+    private fun makeNewHead(
+        newDirection: Direction,
+        head: GridPoint,
+    ): GridPoint = when (newDirection) {
+        UP -> head.copy(y = head.y - 1)
+        DOWN -> head.copy(y = head.y + 1)
+        LEFT -> head.copy(x = head.x - 1)
+        RIGHT -> head.copy(x = head.x + 1)
     }
 
     /**

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/LongFoxDataStore.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/LongFoxDataStore.kt
@@ -1,0 +1,59 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.mozilla.fenix.longfox
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "longfox")
+
+/**
+ * A preferences style key-value data store for the game settings.
+ */
+class LongFoxDataStore(private val context: Context) {
+    private val hiscoreKey = intPreferencesKey("hiscore")
+    private val soundOnKey = booleanPreferencesKey("soundOn")
+
+    fun hiscoreFlow(): Flow<Int> = context.dataStore.data.map { preferences ->
+        preferences[hiscoreKey] ?: 0
+    }
+
+    fun soundOnFlow(): Flow<Boolean> = context.dataStore.data.map { preferences ->
+        preferences[soundOnKey] ?: false
+    }
+
+    /**
+     * If the new score is higher than the current high score, save it in the data store.
+     * @param newScore the latest score
+     */
+    suspend fun saveIfHiscore(newScore: Int) {
+        context.dataStore.updateData { preferences ->
+            if (newScore <= (preferences[hiscoreKey] ?: 0))
+                preferences
+            else preferences.toMutablePreferences().also { preferences ->
+                preferences[hiscoreKey] = newScore
+            }
+        }
+    }
+
+    /**
+     * Flip and save the setting for the sound being on or off.
+     */
+    suspend fun toggleSoundOn() {
+        context.dataStore.updateData { preferences ->
+            preferences.toMutablePreferences().also { preferences ->
+                preferences[soundOnKey] = !(preferences[soundOnKey] ?: false)
+            }
+        }
+    }
+}

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/LongFoxGameScreen.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/LongFoxGameScreen.kt
@@ -15,9 +15,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -30,6 +32,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.mozilla.fenix.longfox.GameState.Companion.CELL_SIZE_DP
 import org.mozilla.fenix.longfox.GameState.Companion.GAME_INTERVAL_TIME_MS
 
@@ -63,7 +66,11 @@ fun LongFoxGameScreen() {
             )
         }
         val context = LocalContext.current
-        val soundEffectsPlayer = remember { SoundEffectsPlayer(context) }
+        val coroutineScope = rememberCoroutineScope()
+        val longFoxDataStore = remember(context) { LongFoxDataStore(context) }
+        val soundOn by longFoxDataStore.soundOnFlow()
+            .collectAsState(initial = false, coroutineScope.coroutineContext)
+        val soundEffectsPlayer = remember(soundOn) { SoundEffectsPlayer(context, soundOn) }
         DisposableEffect(soundEffectsPlayer) {
             onDispose { soundEffectsPlayer.release() }
         }
@@ -90,6 +97,7 @@ fun LongFoxGameScreen() {
                 }
                 gameState = gameState.toggleBeepNext()
             }
+            coroutineScope.launch { longFoxDataStore.saveIfHiscore(gameState.score) }
         }
         Box(
             modifier = Modifier
@@ -100,9 +108,14 @@ fun LongFoxGameScreen() {
             contentAlignment = Alignment.Center,
         ) {
             if (gameState.isGameOver) {
-                restartGame()
+                NewGameScreen(
+                    longFoxDataStore = longFoxDataStore,
+                    initialGameState = gameState,
+                    startGame = restartGame,
+                )
+            } else {
+                GameCanvas(gameState)
             }
-            GameCanvas(gameState)
         }
         if (!gameState.isGameOver) {
             ScoreContainer(gameState.score)

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/NewGameScreen.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/NewGameScreen.kt
@@ -1,0 +1,144 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.mozilla.fenix.longfox
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.mozilla.fenix.longfox.GameState.Companion.CELL_SIZE_DP
+import org.mozilla.fenix.longfox.GameState.Companion.GAME_INTERVAL_TIME_MS
+
+/**
+ * A little intro screen to launch the game and provide high score and sound on/off switch.
+ * @param initialGameState the current game state.
+ * @param longFoxDataStore a data store to save game default preferences.
+ * @param startGame a callback to start the game.
+ */
+@Composable
+fun NewGameScreen(
+    initialGameState: GameState,
+    longFoxDataStore: LongFoxDataStore,
+    startGame: () -> Unit,
+) {
+    val coroutineScope = rememberCoroutineScope()
+
+    val hiscore by longFoxDataStore.hiscoreFlow()
+        .collectAsState(initial = 0, coroutineScope.coroutineContext)
+    val soundOn by longFoxDataStore.soundOnFlow()
+        .collectAsState(initial = false, coroutineScope.coroutineContext)
+    var gameState by remember(initialGameState.numCells) {
+        mutableStateOf(
+            initialGameState.copy(
+                fox = listOf(
+                    GridPoint(1, 5),
+                    GridPoint(1, 4),
+                    GridPoint(1, 3),
+                    GridPoint(1, 2)
+                ),
+                direction = Direction.DOWN,
+                food = null,
+            )
+        )
+    }
+
+    LaunchedEffect(gameState) {
+        while (true) {
+            delay(GAME_INTERVAL_TIME_MS)
+            gameState = gameState.foxAnimationDemo()
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .size((CELL_SIZE_DP * gameState.numCellsWide).dp)
+            .background(Color.DarkGray)
+            .clickable { startGame() },
+    ) {
+        GameCanvas(
+            state = gameState,
+        )
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                fontSize = 28.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color(0xffff5500),
+                text = "LONGFOX"
+            )
+            Text(
+                fontSize = 14.sp,
+                color = Color.Yellow,
+                text = "🍪 likes cookies 🍪"
+            )
+            Text(
+                modifier = Modifier.padding(top = 8.dp),
+                fontSize = 16.sp,
+                fontStyle = FontStyle.Italic,
+                color = Color.Green,
+                text = "tap to play !"
+            )
+            Text(
+                modifier = Modifier.padding(top = 36.dp, bottom = 36.dp),
+                fontSize = 22.sp,
+                color = Color.Cyan,
+                text = "HISCORE: $hiscore"
+            )
+            Text(
+                modifier = Modifier
+                    .border(width = 2.dp, Color.DarkGray)
+                    .padding(8.dp)
+                    .clickable { coroutineScope.launch { longFoxDataStore.toggleSoundOn() } },
+                fontSize = 16.sp,
+                color = if (soundOn) Color.White else Color.Gray,
+                text = if (soundOn) "🔈 sound on" else "🔇 sound off"
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun NewGameScreenPreview() {
+    val numCells = 18
+    val canvasSizePx = CELL_SIZE_DP * numCells * LocalDensity.current.density
+    NewGameScreen(
+        initialGameState = GameState(numCells = numCells, size = Size(canvasSizePx, canvasSizePx), isGameOver = true),
+        longFoxDataStore = LongFoxDataStore(LocalContext.current),
+        startGame = {},
+    )
+}

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/SoundEffectsPlayer.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/SoundEffectsPlayer.kt
@@ -10,11 +10,12 @@ import android.content.Context
 import android.media.MediaPlayer
 import androidx.annotation.RawRes
 
-class SoundEffectsPlayer(private val context: Context) {
+class SoundEffectsPlayer(private val context: Context, private val soundOn: Boolean) {
 
     private val activePlayers = mutableSetOf<MediaPlayer>()
 
     fun playSound(@RawRes soundResId: Int) {
+        if (!soundOn) return
         MediaPlayer.create(context, soundResId)?.apply {
             activePlayers.add(this)
             start()


### PR DESCRIPTION
* Follows https://github.com/mozilla-firefox/firefox/pull/149

Bug 2024964: Add intro screen.

- Adds a place to launch the game from and show a high score and sound on / off toggle.
- TODO: move strings into string resources for translation. That will follow separately as a Phabricator PR.
- TODO: improve my high score.

