### PR TITLE
Bug 2026427 - add errors codes and handle them appropriately

### DIFF
--- a/mobile/android/android-components/components/concept/llm/src/main/java/mozilla/components/concept/llm/Llm.kt
+++ b/mobile/android/android-components/components/concept/llm/src/main/java/mozilla/components/concept/llm/Llm.kt
@@ -13,6 +13,12 @@ import kotlinx.coroutines.flow.Flow
 value class Prompt(val value: String)
 
 /**
+ * An integer error code that can be used to categorize failures.
+ */
+@JvmInline
+value class ErrorCode(val value: Int)
+
+/**
  * An abstract definition of a LLM that can receive prompts.
  */
 interface Llm {
@@ -21,6 +27,28 @@ interface Llm {
      * of [Response]s as they are made available.
      */
     suspend fun prompt(prompt: Prompt): Flow<Response>
+
+    /**
+     * An exception thrown by an LLM, equipped with an [ErrorCode] to differentiate
+     * error types. Implementation modules may subclass this to attach additional context.
+     *
+     * @param message A human-readable description of the failure.
+     * @param errorCode The error code identifying the failure category.
+     */
+    open class Exception(
+        message: String,
+        val errorCode: ErrorCode,
+    ) : kotlin.Exception(message) {
+        companion object {
+            /**
+             * Create an unspecified error with the general error code.
+             */
+            fun unknown(message: String?) = Llm.Exception(
+                message = message ?: "Unknown Llm Exception",
+                errorCode = ErrorCode(0),
+            )
+        }
+    }
 
     /**
      * A response from prompting a LLM.
@@ -47,6 +75,6 @@ interface Llm {
         /**
          * A failure response from a LLM.
          */
-        data class Failure(val reason: String) : Response()
+        data class Failure(val exception: Llm.Exception) : Response()
     }
 }

--- a/mobile/android/android-components/components/concept/llm/src/main/java/mozilla/components/concept/llm/LlmProvider.kt
+++ b/mobile/android/android-components/components/concept/llm/src/main/java/mozilla/components/concept/llm/LlmProvider.kt
@@ -50,8 +50,10 @@ interface CloudLlmProvider : LlmProvider {
 
         /**
          * Indicates that the cloud provider is unavailable.
+         *
+         * @property exception The exception that caused the provider to become unavailable, if known.
          */
-        object Unavailable : State
+        data class Unavailable(val exception: Llm.Exception) : State
 
         /**
          * Indicates that the cloud LLM is fully initialized and ready for use.

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationAction.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationAction.kt
@@ -27,7 +27,7 @@ data object SettingsBackClicked : SummarizationAction
 data object ShakeConsentRequested : SummarizationAction
 
 internal sealed interface LlmProviderAction : SummarizationAction {
-    data object ProviderFailed : LlmProviderAction
+    data class ProviderFailed(val exception: Llm.Exception) : LlmProviderAction
     data object ProviderUnavailable : LlmProviderAction
     data class ProviderInitialized(val llm: Llm) : LlmProviderAction
 }
@@ -35,7 +35,7 @@ internal sealed interface LlmProviderAction : SummarizationAction {
 /**
  * There was a failure in summarizing content from the current page.
  */
-data class SummarizationFailed(val throwable: Throwable) : SummarizationAction
+data class SummarizationFailed(val exception: Llm.Exception) : SummarizationAction
 
 /**
  * We've requested a response from a Llm.

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationMiddleware.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationMiddleware.kt
@@ -30,6 +30,7 @@ class SummarizationMiddleware(
     private val errorReporter: ErrorReporter,
     private val scope: CoroutineScope,
 ) : Middleware<SummarizationState, SummarizationAction> {
+
     override fun invoke(
         store: Store<SummarizationState, SummarizationAction>,
         next: (SummarizationAction) -> Unit,
@@ -57,7 +58,7 @@ class SummarizationMiddleware(
                 observePrompt(store, action.llm)
             }
             is SummarizationFailed -> scope.launch {
-                errorReporter.report(action.throwable)
+                errorReporter.report(action.exception)
             }
         }
 
@@ -85,7 +86,11 @@ class SummarizationMiddleware(
             .map { parser.parse(it) }
             .collect { store.dispatch(ReceivedParsedDocument(it)) }
     }.onFailure {
-        store.dispatch(SummarizationFailed(it))
+        store.dispatch(
+            SummarizationFailed(
+                it as? Llm.Exception ?: Llm.Exception.unknown("Unknown exception while prompting"),
+            ),
+        )
     }
 
     private suspend fun observeCloudLlmProvider(
@@ -96,7 +101,7 @@ class SummarizationMiddleware(
         llmProvider.state.map { state ->
             when (state) {
                 CloudLlmProvider.State.Available -> LlmProviderAction.ProviderUnavailable
-                CloudLlmProvider.State.Unavailable -> LlmProviderAction.ProviderFailed
+                is CloudLlmProvider.State.Unavailable -> LlmProviderAction.ProviderFailed(state.exception)
                 is CloudLlmProvider.State.Ready -> LlmProviderAction.ProviderInitialized(state.llm)
             }
         }.collect { store.dispatch(it) }

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationReducer.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationReducer.kt
@@ -30,16 +30,25 @@ fun summarizationReducer(state: SummarizationState, action: SummarizationAction)
         is SummarizationState.Settings -> SummarizationState.Summarized(info = state.info, document = state.document)
         else -> state
     }
-    is SummarizationFailed -> SummarizationState.Error(SummarizationError.SummarizationFailed(action.throwable))
+    is SummarizationFailed -> SummarizationState.Error(SummarizationError.SummarizationFailed(action.exception))
+    is LlmProviderAction.ProviderFailed -> SummarizationState.Error(
+        SummarizationError.SummarizationFailed(action.exception),
+    )
     else -> state
 }
 
 internal fun SummarizationState.applyResponse(response: Llm.Response): SummarizationState {
     if (this !is SummarizationState.Summarizing) return this
     return when (response) {
-        is Llm.Response.Failure -> SummarizationState.Error(
-            SummarizationError.SummarizationFailed(IllegalStateException(response.reason)),
-        )
+        is Llm.Response.Failure -> {
+            val contentTooLongErrorCode = 1005
+            when (response.exception.errorCode.value) {
+                contentTooLongErrorCode -> SummarizationState.Error(SummarizationError.ContentTooLong)
+                else -> SummarizationState.Error(
+                    SummarizationError.SummarizationFailed(response.exception),
+                )
+            }
+        }
         Llm.Response.Success.ReplyFinished -> SummarizationState.Summarized(info = info, document)
         else -> this
     }

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationScreen.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationScreen.kt
@@ -49,11 +49,13 @@ import mozilla.components.compose.base.annotation.FlexibleWindowLightDarkPreview
 import mozilla.components.compose.base.modifier.thenConditional
 import mozilla.components.compose.base.theme.AcornTheme
 import mozilla.components.concept.llm.LlmProvider
+import mozilla.components.feature.summarize.content.PageMetadataExtractor
 import mozilla.components.feature.summarize.settings.SettingsAppBar
 import mozilla.components.feature.summarize.settings.SummarizeSettingsContent
 import mozilla.components.feature.summarize.settings.SummarizeSettingsState
 import mozilla.components.feature.summarize.settings.SummarizeSettingsStore
 import mozilla.components.feature.summarize.settings.summarizeSettingsReducer
+import mozilla.components.feature.summarize.ui.ContentTooLongError
 import mozilla.components.feature.summarize.ui.DownloadError
 import mozilla.components.feature.summarize.ui.InfoError
 import mozilla.components.feature.summarize.ui.OffDeviceSummarizationConsent
@@ -182,10 +184,11 @@ private fun handleSummarizationState(
         }
 
         is SummarizationState.Error -> {
-            if (state.error is SummarizationError.DownloadFailed) {
-                DownloadError()
-            } else {
-                InfoError()
+            when (state.error) {
+                is SummarizationError.DownloadFailed -> DownloadError()
+                is SummarizationError.ContentTooLong -> ContentTooLongError()
+                is SummarizationError.SummarizationFailed ->
+                    InfoError(errorCode = state.error.exception.errorCode)
             }
         }
 
@@ -272,10 +275,10 @@ private class SummarizationStatePreviewProvider : PreviewParameterProvider<Summa
         SummarizationState.Summarizing(info = info),
         SummarizationState.Summarized(info = info, document = parser.parse(previewSummarizedText)),
         SummarizationState.Settings(info = info, document = RichDocument(listOf())),
-        SummarizationState.Error(SummarizationError.ContentTooLong),
         SummarizationState.ShakeConsentRequired,
         SummarizationState.ShakeConsentWithDownloadRequired,
-        SummarizationState.Error(SummarizationError.NetworkError),
+        SummarizationState.Error(SummarizationError.ContentTooLong),
+        SummarizationState.Error(SummarizationError.SummarizationFailed(PageMetadataExtractor.Exception())),
     )
 }
 

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationState.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationState.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.summarize
 
+import mozilla.components.concept.llm.Llm
 import mozilla.components.concept.llm.LlmProvider
 import mozilla.components.lib.state.State
 import mozilla.components.ui.richtext.ir.RichDocument
@@ -95,35 +96,14 @@ sealed class SummarizationState : State {
 * Describes the possible failure modes of the summarization feature.
 */
 sealed class SummarizationError {
-    /** The user declined the consent prompt. */
-    data object ConsentDenied : SummarizationError()
-
-    /** The page content could not be extracted or is unavailable. */
-    data object ContentUnavailable : SummarizationError()
-
-    /** The page content is too short to summarize. */
-    data object ContentTooShort : SummarizationError()
-
     /** The page content exceeds the maximum supported length. */
     data object ContentTooLong : SummarizationError()
-
-    /** The user declined to download the summarization model. */
-    data object DownloadDenied : SummarizationError()
 
     /** The model download did not complete successfully. */
     data object DownloadFailed : SummarizationError()
 
-    /** The model download was cancelled before completion. */
-    data object DownloadCancelled : SummarizationError()
-
     /** The summarization model failed to produce a result. */
-    data class SummarizationFailed(val throwable: Throwable) : SummarizationError()
-
-    /** The model produced a result that could not be used as a valid summary. */
-    data object InvalidSummary : SummarizationError()
-
-    /** A network error occurred during download or summarization. */
-    data object NetworkError : SummarizationError()
+    data class SummarizationFailed(val exception: Llm.Exception) : SummarizationError()
 }
 
 val SummarizationState.isLoading get() = this is SummarizationState.Loading

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/content/PageContentExtractor.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/content/PageContentExtractor.kt
@@ -4,6 +4,9 @@
 
 package mozilla.components.feature.summarize.content
 
+import mozilla.components.concept.llm.ErrorCode
+import mozilla.components.concept.llm.Llm
+
 /**
  * An interface to conform to do deliver page content for summarization.
  */
@@ -12,4 +15,11 @@ fun interface PageContentExtractor {
      * Retrieve the page content.
      */
     suspend fun getPageContent(): Result<String>
+
+    /**
+     * An exception that occurs in page content extraction.
+     */
+    class Exception : Llm.Exception("Could not extract content", errorCode)
 }
+
+private val errorCode = ErrorCode(2001)

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/content/PageMetadata.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/content/PageMetadata.kt
@@ -4,6 +4,9 @@
 
 package mozilla.components.feature.summarize.content
 
+import mozilla.components.concept.llm.ErrorCode
+import mozilla.components.concept.llm.Llm
+
 /**
  * An interface to conform to do deliver page metadata.
  */
@@ -12,9 +15,16 @@ fun interface PageMetadataExtractor {
      * Retrieve the page metadata.
      */
     suspend fun getPageMetadata(): Result<PageMetadata>
+
+    /**
+     * An exception that occurs in page metadata extraction.
+     */
+    class Exception : Llm.Exception("Could not extract content metadata", errorCode)
 }
 
 /**
  * Page metadata required for logical choices.
  */
 data class PageMetadata(val structuredDataTypes: List<String>, val language: String)
+
+private val errorCode = ErrorCode(2002)

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/ui/ContentTooLongError.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/ui/ContentTooLongError.kt
@@ -22,14 +22,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import mozilla.components.compose.base.theme.AcornTheme
-import mozilla.components.concept.llm.ErrorCode
 import mozilla.components.feature.summarize.R
 
 @Composable
-internal fun InfoError(
-    modifier: Modifier = Modifier,
-    errorCode: ErrorCode,
-) {
+internal fun ContentTooLongError(modifier: Modifier = Modifier) {
     Column(modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         Icon(
             painter = painterResource(mozilla.components.ui.icons.R.drawable.mozac_ic_warning_fill_24),
@@ -40,29 +36,18 @@ internal fun InfoError(
         Spacer(modifier = Modifier.height(AcornTheme.layout.space.static300))
 
         Text(
-            text = stringResource(R.string.mozac_summarize_info_error_title),
+            text = stringResource(R.string.mozac_summarize_content_too_long_error_title),
             style = AcornTheme.typography.headline6,
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
         )
-
-        Spacer(modifier = Modifier.height(AcornTheme.layout.space.static100))
-
-        Text(
-            text = stringResource(R.string.mozac_summarize_info_error_message, errorCode.value),
-            style = AcornTheme.typography.body2,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-        )
-
-        Spacer(modifier = Modifier.height(AcornTheme.layout.space.static200))
     }
 }
 
 @PreviewLightDark
 @Composable
-private fun PreviewInfoError() = AcornTheme {
+private fun PreviewContentTooLongError() = AcornTheme {
     Surface {
-        InfoError(errorCode = ErrorCode(1000))
+        ContentTooLongError()
     }
 }

--- a/mobile/android/android-components/components/feature/summarize/src/main/res/values/static_strings.xml
+++ b/mobile/android/android-components/components/feature/summarize/src/main/res/values/static_strings.xml
@@ -75,11 +75,14 @@
     <!-- Button for the download error screen to cancel -->
     <string name="mozac_summarize_download_error_negative_button">Cancel</string>
 
-    <!-- Title for the info error screen -->
-    <string name="mozac_summarize_info_error_title">Error</string>
+    <!-- Title for the error screen when page is too long to summarize -->
+    <string name="mozac_summarize_content_too_long_error_title">Page too long to summarize</string>
 
-    <!-- Generic fallback message for the info error screen -->
-    <string name="mozac_summarize_info_error_fallback_message">Unknown error</string>
+    <!-- Title for the info error screen -->
+    <string name="mozac_summarize_info_error_title">Can\'t summarize right now</string>
+
+    <!-- Generic fallback message for the info error screen. %1$d is an error code. -->
+    <string name="mozac_summarize_info_error_message">Try again later. Error code: %1$d</string>
 
     <!-- Loading text displayed while a page summary is being generated -->
     <string name="mozac_feature_summarize_loading_title" translatable="false">Summarizing…</string>

--- a/mobile/android/android-components/components/feature/summarize/src/test/java/mozilla/components/feature/summarize/SummarizationStoreTest.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/test/java/mozilla/components/feature/summarize/SummarizationStoreTest.kt
@@ -14,6 +14,7 @@ import mozilla.components.feature.summarize.SummarizationState.Loading
 import mozilla.components.feature.summarize.SummarizationState.ShakeConsentRequired
 import mozilla.components.feature.summarize.SummarizationState.Summarized
 import mozilla.components.feature.summarize.SummarizationState.Summarizing
+import mozilla.components.feature.summarize.content.PageContentExtractor
 import mozilla.components.feature.summarize.content.PageMetadata
 import mozilla.components.feature.summarize.fakes.FakeCloudProvider
 import mozilla.components.feature.summarize.fakes.FakeLlm
@@ -167,7 +168,7 @@ class SummarizationStoreTest {
 
     @Test
     fun `if the page extractor fails, the failure is forwarded as a summarization failure`() = runTest {
-        val failureThrowable = NullPointerException()
+        val failureThrowable = PageContentExtractor.Exception()
         val provider = FakeCloudProvider(llm = FakeLlm.successful)
         val store = SummarizationStore(
             initialState = Inert(true),

--- a/mobile/android/android-components/components/lib/llm-gemininano/src/main/java/mozilla/components/lib/llm/gemini/nano/GeminiNanoLlm.kt
+++ b/mobile/android/android-components/components/lib/llm-gemininano/src/main/java/mozilla/components/lib/llm/gemini/nano/GeminiNanoLlm.kt
@@ -48,6 +48,6 @@ internal class GeminiNanoLlm(
     } catch (e: GenAiException) {
         val message = "Gemini Nano inference failed: ${e.message}"
         logger(message)
-        emit(Llm.Response.Failure(message))
+        emit(Llm.Response.Failure(Llm.Exception.unknown(message)))
     }
 }

--- a/mobile/android/android-components/components/lib/llm-gemininano/src/test/java/mozilla/components/lib/llm/gemini/nano/GeminiNanoLlmTest.kt
+++ b/mobile/android/android-components/components/lib/llm-gemininano/src/test/java/mozilla/components/lib/llm/gemini/nano/GeminiNanoLlmTest.kt
@@ -8,6 +8,7 @@ import com.google.mlkit.genai.common.FeatureStatus
 import com.google.mlkit.genai.common.GenAiException
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import mozilla.components.concept.llm.ErrorCode
 import mozilla.components.concept.llm.Llm
 import mozilla.components.concept.llm.Prompt
 import mozilla.components.lib.llm.gemini.nano.fakes.FakeGenerativeModel
@@ -45,7 +46,9 @@ class GeminiNanoLlmTest {
         val results = llm.prompt(Prompt("test prompt")).toList()
 
         assertEquals(1, results.size)
-        assertEquals(Llm.Response.Failure("Gemini Nano inference failed: [ErrorCode 4] Request doesn't pass certain policy check. Please try a different input."), results[0])
+        val failure = results[0] as Llm.Response.Failure
+        assertEquals(0, failure.exception.errorCode.value)
+        assertTrue(failure.exception.message?.startsWith("Gemini Nano inference failed:") == true)
     }
 
     @Test

--- a/mobile/android/android-components/components/lib/llm-mlpa/src/main/java/mozilla/components/lib/llm/mlpa/MlpaLlm.kt
+++ b/mobile/android/android-components/components/lib/llm-mlpa/src/main/java/mozilla/components/lib/llm/mlpa/MlpaLlm.kt
@@ -7,6 +7,7 @@ package mozilla.components.lib.llm.mlpa
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onCompletion
+import mozilla.components.concept.llm.ErrorCode
 import mozilla.components.concept.llm.Llm
 import mozilla.components.concept.llm.Prompt
 import mozilla.components.lib.llm.mlpa.service.AuthorizationToken
@@ -23,12 +24,18 @@ internal class MlpaLlm(
         chatService.completion(authorizationToken, prompt.asRequest)
             .onCompletion { cause ->
                 val action = cause
-                    ?.let { Llm.Response.Failure("MlpaLlm Failed: ${it.message}") }
+                    ?.let {
+                        val exception = it as? Llm.Exception
+                            ?: Llm.Exception(it.message ?: "unknown chat error", unknownLlmErrorCode)
+                        Llm.Response.Failure(exception)
+                    }
                     ?: Llm.Response.Success.ReplyFinished
                 emit(action)
             }
             .collect { emit(Llm.Response.Success.ReplyPart(it)) }
     }
+
+    private val unknownLlmErrorCode = ErrorCode(1012)
 }
 
 internal val Prompt.asRequest

--- a/mobile/android/android-components/components/lib/llm-mlpa/src/main/java/mozilla/components/lib/llm/mlpa/MlpaLlmProvider.kt
+++ b/mobile/android/android-components/components/lib/llm-mlpa/src/main/java/mozilla/components/lib/llm/mlpa/MlpaLlmProvider.kt
@@ -9,10 +9,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import mozilla.components.concept.llm.CloudLlmProvider
 import mozilla.components.concept.llm.CloudLlmProvider.State
+import mozilla.components.concept.llm.ErrorCode
+import mozilla.components.concept.llm.Llm
 import mozilla.components.concept.llm.LlmProvider
 import mozilla.components.lib.llm.mlpa.service.ChatService
 import mozilla.components.lib.llm.mlpa.service.ChatServiceError
-import mozilla.components.lib.llm.mlpa.service.ChatServiceException
 import mozilla.components.lib.llm.mlpa.service.MlpaService
 
 /**
@@ -55,7 +56,15 @@ class MlpaLlmProvider(
     override suspend fun prepare() {
         tokenProvider.fetchToken()
             .onSuccess { _state.value = State.Ready(MlpaLlm(chatService, it)) }
-            .onFailure { _state.value = State.Unavailable }
+            .onFailure {
+                _state.value = State.Unavailable(
+                it as? Llm.Exception
+                    ?: Llm.Exception(
+                        message = it.message ?: "missing token provider error",
+                        errorCode = unknownTokenProviderError,
+                    ),
+                )
+            }
     }
 
     /**
@@ -64,17 +73,24 @@ class MlpaLlmProvider(
     private val chatService = ChatService { token, request ->
         mlpaService.completion(token, request)
             .catch { throwable ->
-                if (throwable.isRetryable) {
+                if (throwable is ChatServiceError.InvalidToken) {
                     storage.clear()
                     _state.value = State.Available
                 } else {
-                    _state.value = State.Unavailable
+                    _state.value = State.Unavailable(
+                        throwable as? Llm.Exception
+                            ?: Llm.Exception(
+                                message = throwable.message ?: "missing chat service error",
+                                errorCode = unknownChatServiceError,
+                            ),
+                    )
                 }
 
                 // Re-throw the error so downstream consumers can handle the error
                 throw throwable
             }
     }
-}
 
-private val Throwable.isRetryable get() = (this as? ChatServiceException)?.error is ChatServiceError.InvalidToken
+    private val unknownTokenProviderError = ErrorCode(1010)
+    private val unknownChatServiceError = ErrorCode(1011)
+}

--- a/mobile/android/android-components/components/lib/llm-mlpa/src/main/java/mozilla/components/lib/llm/mlpa/MlpaTokenProvider.kt
+++ b/mobile/android/android-components/components/lib/llm-mlpa/src/main/java/mozilla/components/lib/llm/mlpa/MlpaTokenProvider.kt
@@ -8,6 +8,7 @@ import mozilla.components.concept.integrity.IntegrityClient
 import mozilla.components.lib.llm.mlpa.service.AuthenticationService
 import mozilla.components.lib.llm.mlpa.service.AuthenticationService.Request
 import mozilla.components.lib.llm.mlpa.service.AuthorizationToken
+import mozilla.components.lib.llm.mlpa.service.IntegrityHandshakeFailure
 import mozilla.components.lib.llm.mlpa.service.PackageName
 import mozilla.components.lib.llm.mlpa.service.UserId
 import kotlin.time.Duration.Companion.seconds
@@ -87,13 +88,17 @@ fun interface MlpaTokenProvider {
             }
 
             runCatching {
+                val integrityToken = integrityClient.request().getOrElse {
+                    throw IntegrityHandshakeFailure(it.message ?: "Unknown Integrity failure")
+                }
+
                 val request = Request(
                     userId = userIdProvider.getUserId(),
-                    integrityToken = integrityClient.request().getOrThrow(),
+                    integrityToken = integrityToken,
                     packageName = packageName,
                 )
-
                 val response = authenticationService.verify(request).getOrThrow()
+
                 storage.setToken(response.accessToken, response.expiresIn.seconds)
 
                 return@runCatching response.accessToken

--- a/mobile/android/android-components/components/lib/llm-mlpa/src/main/java/mozilla/components/lib/llm/mlpa/service/FetchClientMlpaService.kt
+++ b/mobile/android/android-components/components/lib/llm-mlpa/src/main/java/mozilla/components/lib/llm/mlpa/service/FetchClientMlpaService.kt
@@ -100,9 +100,7 @@ class FetchClientMlpaService(
         return flow {
             val httpResponse = client.fetch(fetchRequest)
 
-            httpResponse.error?.also {
-                throw ChatServiceException(it)
-            }
+            httpResponse.error?.also { throw it }
 
             if (request.stream) {
                 emitAll(httpResponse.contentFlow)
@@ -119,9 +117,9 @@ class FetchClientMlpaService(
     private val Response.retryAfter: Long? get() = headers["Retry-After"]?.toLongOrNull()
     private val Response.error: ChatServiceError? get() = when (status) {
         in 200..299 -> null
-        401 -> ChatServiceError.InvalidToken
-        403 -> ChatServiceError.UserBlocked
-        413 -> ChatServiceError.RequestTooLarge
+        401 -> ChatServiceError.InvalidToken()
+        403 -> ChatServiceError.UserBlocked()
+        413 -> ChatServiceError.RequestTooLarge()
         429 -> when (json.decodeFromString<ChatService.ResponseErrorCode>(bodyString).error) {
             1 -> ChatServiceError.BudgetExceeded(retryAfter)
             2 -> ChatServiceError.RateLimited(retryAfter)

--- a/mobile/android/android-components/components/lib/llm-mlpa/src/main/java/mozilla/components/lib/llm/mlpa/service/MlpaService.kt
+++ b/mobile/android/android-components/components/lib/llm-mlpa/src/main/java/mozilla/components/lib/llm/mlpa/service/MlpaService.kt
@@ -14,57 +14,68 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import mozilla.components.concept.integrity.IntegrityToken
+import mozilla.components.concept.llm.ErrorCode
+import mozilla.components.concept.llm.Llm
+
+private val INTEGRITY_HANDSHAKE_FAILURE = ErrorCode(1001)
+private val VERIFICATION_SERVICE_FAILED = ErrorCode(1002)
+private val INVALID_TOKEN = ErrorCode(1003)
+private val USER_BLOCKED = ErrorCode(1004)
+private val REQUEST_TOO_LARGE = ErrorCode(1005)
+private val BUDGET_EXCEEDED = ErrorCode(1006)
+private val RATE_LIMITED = ErrorCode(1007)
+private val UPSTREAM_ERROR = ErrorCode(1008)
+private val SERVER_ERROR = ErrorCode(1009)
+
+/**
+ * Thrown when the Integrity client experiences a failure, propagating its error message.
+ */
+class IntegrityHandshakeFailure(message: String) : Llm.Exception(message, INTEGRITY_HANDSHAKE_FAILURE)
 
 /**
  * Thrown when the MLPA verification service fails to process or validate a request.
  *
  * @param reason A human-readable explanation of the failure.
  */
-class VerificationServiceFailed(reason: String) : Exception("Verification Service Failed: $reason")
+class VerificationServiceFailed(reason: String) :
+    Llm.Exception("Verification Service Failed: $reason", VERIFICATION_SERVICE_FAILED)
 
 /**
- * Thrown when the MLPA chat/completion service fails to process a request.
- *
- * @param error the [ChatServiceError] that was raised.
+ * Sealed class for describing the type of error a [ChatService] can return.
  */
-class ChatServiceException(val error: ChatServiceError) : Exception(error.toString())
-
-/**
- * Sealed interface for describing the type of error a [ChatService] can return.
- */
-sealed interface ChatServiceError {
+sealed class ChatServiceError(message: String, errorCode: ErrorCode) : Llm.Exception(message, errorCode) {
     /** Token expired or invalid. Re-authenticate via [AuthenticationService.verify]. */
-    data object InvalidToken : ChatServiceError
+    class InvalidToken : ChatServiceError("Invalid token", INVALID_TOKEN)
 
     /** The user has been blocked from accessing the service. */
-    data object UserBlocked : ChatServiceError
+    class UserBlocked : ChatServiceError("User blocked", USER_BLOCKED)
 
     /** The request body exceeded the 10MB limit. */
-    data object RequestTooLarge : ChatServiceError
+    class RequestTooLarge : ChatServiceError("Request too large", REQUEST_TOO_LARGE)
 
     /**
      * The user's total budget has been exhausted.
      *
      * @property retryAfter Duration in seconds before the budget resets (typically 86400s).
      */
-    data class BudgetExceeded(val retryAfter: Long?) : ChatServiceError
+    data class BudgetExceeded(val retryAfter: Long?) : ChatServiceError("Budget exceeded", BUDGET_EXCEEDED)
 
     /**
      * Requests per minute or tokens per minute limit reached.
      *
      * @property retryAfter Duration in seconds before the limit resets (typically 60s).
      */
-    data class RateLimited(val retryAfter: Long?) : ChatServiceError
+    data class RateLimited(val retryAfter: Long?) : ChatServiceError("Rate limited", RATE_LIMITED)
 
     /** The upstream LLM was unreachable or returned an error (502). */
-    data class UpstreamError(val reason: String) : ChatServiceError
+    data class UpstreamError(val reason: String) : ChatServiceError("Upstream error: $reason", UPSTREAM_ERROR)
 
     /**
      * An unexpected server-side error occurred.
      *
      * @property statusCode The HTTP status code returned.
      */
-    data class ServerError(val statusCode: Int) : ChatServiceError
+    data class ServerError(val statusCode: Int) : ChatServiceError("Server error: $statusCode", SERVER_ERROR)
 }
 
 /**

--- a/mobile/android/android-components/components/lib/llm-mlpa/src/test/java/mozilla/components/lib/llm/mlpa/fakes/Fakes.kt
+++ b/mobile/android/android-components/components/lib/llm-mlpa/src/test/java/mozilla/components/lib/llm/mlpa/fakes/Fakes.kt
@@ -19,7 +19,6 @@ import mozilla.components.lib.llm.mlpa.service.AuthenticationService
 import mozilla.components.lib.llm.mlpa.service.AuthorizationToken
 import mozilla.components.lib.llm.mlpa.service.ChatService
 import mozilla.components.lib.llm.mlpa.service.ChatServiceError
-import mozilla.components.lib.llm.mlpa.service.ChatServiceException
 import mozilla.components.lib.llm.mlpa.service.MlpaService
 import mozilla.components.lib.llm.mlpa.service.UserId
 import java.io.ByteArrayInputStream
@@ -67,7 +66,7 @@ val failureChatService = ChatService { token, request ->
 }
 
 val invalidTokenService = ChatService { _, _ ->
-    flow { throw ChatServiceException(ChatServiceError.InvalidToken) }
+    flow { throw ChatServiceError.InvalidToken() }
 }
 
 val streamedResponseBody = """

--- a/mobile/android/android-components/components/lib/llm-mlpa/src/test/java/mozilla/components/lib/llm/mlpa/service/FetchClientMlpaServiceTest.kt
+++ b/mobile/android/android-components/components/lib/llm-mlpa/src/test/java/mozilla/components/lib/llm/mlpa/service/FetchClientMlpaServiceTest.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.MissingFieldException
 import mozilla.components.concept.fetch.MutableHeaders
 import mozilla.components.concept.fetch.Response
 import mozilla.components.concept.integrity.IntegrityToken
+import mozilla.components.concept.llm.Llm
 import mozilla.components.lib.llm.mlpa.fakes.FakeClient
 import mozilla.components.lib.llm.mlpa.fakes.asBody
 import mozilla.components.lib.llm.mlpa.fakes.streamedResponseBody
@@ -249,9 +250,9 @@ class FetchClientMlpaServiceTest {
             }
 
             val cases = listOf(
-                Case(401, ChatServiceError.InvalidToken),
-                Case(403, ChatServiceError.UserBlocked),
-                Case(413, ChatServiceError.RequestTooLarge),
+                Case(401, ChatServiceError.InvalidToken()),
+                Case(403, ChatServiceError.UserBlocked()),
+                Case(413, ChatServiceError.RequestTooLarge()),
                 Case(429, ChatServiceError.BudgetExceeded(8000L)),
                 Case(429, ChatServiceError.BudgetExceeded(null)),
                 Case(429, ChatServiceError.RateLimited(8000L)),
@@ -276,8 +277,8 @@ class FetchClientMlpaServiceTest {
                 response
                     .onEach { _ -> fail("We should have thrown an exception") }
                     .catch {
-                        assertTrue("Should be ChatServiceException but got $it", it is ChatServiceException)
-                        assertEquals(case.expectedError, (it as? ChatServiceException)?.error)
+                        assertTrue("Should be ChatServiceError but got $it", it is ChatServiceError)
+                        assertEquals(case.expectedError.errorCode, (it as Llm.Exception).errorCode)
                     }.collect()
             }
         }

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -557,7 +557,7 @@ open class FenixApplication : Application(), Provider, ThemeProvider {
 
     @OptIn(DelicateCoroutinesApi::class) // GlobalScope usage
     private fun queueIntegrityClientWarmUp(queue: RunWhenReadyQueue) {
-        if (!Config.channel.isReleased) {
+        if (Config.channel != ReleaseChannel.Nightly) {
             return
         }
         runOnVisualCompleteness(queue) {

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/debugsettings/llm/LlmTools.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/debugsettings/llm/LlmTools.kt
@@ -49,7 +49,7 @@ fun LlmTools(
         }
 
         when (state) {
-            State.Unavailable -> UnavailableState()
+            is State.Unavailable -> UnavailableState()
             is State.Available -> AvailableState(llm.mlpaProvider)
             is State.Ready -> ReadyState((state as State.Ready).llm)
         }
@@ -74,7 +74,7 @@ private fun ReadyState(
                     llm.prompt(Prompt("Hello World")).collect { response ->
                         when (response) {
                             is Llm.Response.Failure -> {
-                                llmResponse = "There was a problem: ${response.reason}"
+                                llmResponse = "There was a problem. Error code: ${response.exception.errorCode}"
                             }
                             is Llm.Response.Success.ReplyPart -> llmResponse += response.value
                             else -> {}

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/summarization/SummarizationFragment.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/summarization/SummarizationFragment.kt
@@ -56,7 +56,7 @@ private fun EngineSession?.asPageContentExtractor(): PageContentExtractor = {
                     continuation.resume(content)
                 },
                 onException = { error ->
-                    continuation.resumeWithException(error)
+                    continuation.resumeWithException(PageContentExtractor.Exception())
                 },
             )
         }
@@ -76,7 +76,7 @@ private fun EngineSession?.asPageMetadataExtractor(): PageMetadataExtractor = {
                     )
                 },
                 onException = { error ->
-                    continuation.resumeWithException(error)
+                    continuation.resumeWithException(PageMetadataExtractor.Exception())
                 },
             )
         }


### PR DESCRIPTION
Could have maybe handled this in a few separate bugs, but once I got into it I figured it might be easiest to just get them done. This patch does the following:

1. associates an error code with various errors for reporting in the UI and in telemetry
2. adds the "content too long" error screen and uses it correctly
3. shows the error codes in the info error screen (this doesn't have designs, but I think it's valuable 🙈)
4. handles LLM providers returning an unavailable state better, instead of spinning on the "summarizing" screen

<img width="621" height="368" alt="image" src="https://github.com/user-attachments/assets/8cf19eeb-dddc-43c2-9096-d51904dcdf5a" />
