### PR TITLE
Bug 2026481 - Fixed double data store lock

### DIFF
--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/settings/SummarizationSettings.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/settings/SummarizationSettings.kt
@@ -182,7 +182,7 @@ internal class DataStoreBackedSettings(private val dataStore: DataStore<Preferen
                 val updatedCount = (preferences[shakeConsentRejectedCountKey] ?: 0) + 1
                 preferences[shakeConsentRejectedCountKey] = updatedCount
                 if (updatedCount >= MAX_SHAKE_CONSENT_REJECTION) {
-                    setGestureEnabledUserStatus(false)
+                    preferences[gestureEnabledKey] = false
                 }
             }
         }


### PR DESCRIPTION
setGestureEnabledUserStatus would call dataStore.updateData which would attempt to also acquire a lock on the same data causing the crash. 