### PR TITLE
Bug 2027872 - Improves memory performance of shake detection

### DIFF
--- a/mobile/android/android-components/components/concept/accelerometer/src/main/java/mozilla/components/concept/accelerometer/Accelerometer.kt
+++ b/mobile/android/android-components/components/concept/accelerometer/src/main/java/mozilla/components/concept/accelerometer/Accelerometer.kt
@@ -13,15 +13,15 @@ interface Accelerometer {
     /**
      * The flow of data.
      */
-    fun samples(): Flow<Accelerometer.Sample>
+    fun samples(): Flow<Sample>
 
     /**
-     * A simple data type containing acceleration data at a specific time.
+     * A simple type containing acceleration data at a specific time.
      */
-    data class Sample(
-        val xAccel: Float,
-        val yAccel: Float,
-        val zAccel: Float,
-        val timestampNs: Long,
-    )
+    interface Sample {
+        val xAccel: Float
+        val yAccel: Float
+        val zAccel: Float
+        val timestampNs: Long
+    }
 }

--- a/mobile/android/android-components/components/lib/accelerometer-sensormanager/src/main/java/mozilla/components/lib/accelerometer/sensormanager/LifecycleAwareSensorManagerAccelerometer.kt
+++ b/mobile/android/android-components/components/lib/accelerometer-sensormanager/src/main/java/mozilla/components/lib/accelerometer/sensormanager/LifecycleAwareSensorManagerAccelerometer.kt
@@ -11,8 +11,9 @@ import android.hardware.SensorManager
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import mozilla.components.concept.accelerometer.Accelerometer
 import mozilla.components.support.base.log.logger.Logger
 
@@ -32,35 +33,24 @@ class LifecycleAwareSensorManagerAccelerometer(
     },
 ) : Accelerometer, SensorEventListener, DefaultLifecycleObserver {
 
+    private val sampleBuffer = SampleBuffer(capacity = 10)
+
     private val sensor: Sensor? by lazy {
         sensorManager.getDefaultSensor(Sensor.TYPE_LINEAR_ACCELERATION)
             ?: sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
     }
 
-    private val _samples = MutableSharedFlow<Accelerometer.Sample>(
-        extraBufferCapacity = NUM_BUFFER_CAPACITY,
+    private val _samples = Channel<Accelerometer.Sample>(
+        capacity = NUM_BUFFER_CAPACITY,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
 
-    override fun samples(): Flow<Accelerometer.Sample> = _samples
+    override fun samples(): Flow<Accelerometer.Sample> = _samples.receiveAsFlow()
 
     override fun onAccuracyChanged(sensor: Sensor, accuracy: Int) = Unit
 
     override fun onSensorChanged(event: SensorEvent) {
-        val sample = when (event.sensor.type) {
-            Sensor.TYPE_LINEAR_ACCELERATION ->
-                Accelerometer.Sample(
-                    xAccel = event.values[0],
-                    yAccel = event.values[1],
-                    zAccel = event.values[2],
-                    timestampNs = event.timestamp,
-                )
-
-            Sensor.TYPE_ACCELEROMETER -> event.toLinearAccelerationSample()
-            else -> null
-        }
-
-        sample?.let { _samples.tryEmit(it) }
+        event.toSample()?.also { _samples.trySend(it) }
     }
 
     override fun onResume(owner: LifecycleOwner) {
@@ -73,6 +63,26 @@ class LifecycleAwareSensorManagerAccelerometer(
         super.onPause(owner)
         logger("Unregistering self as sensor listener")
         sensorManager.unregisterListener(this)
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        super.onDestroy(owner)
+        _samples.close()
+    }
+
+    private fun SensorEvent.toSample(): Accelerometer.Sample? = when (sensor.type) {
+        Sensor.TYPE_LINEAR_ACCELERATION -> linearEventToSample()
+        Sensor.TYPE_ACCELEROMETER -> toLinearAccelerationSample()
+        else -> null
+    }
+
+    private fun SensorEvent.linearEventToSample(): Accelerometer.Sample {
+        return sampleBuffer.request(
+            xAccel = values[0],
+            yAccel = values[1],
+            zAccel = values[2],
+            timestampNs = timestamp,
+        )
     }
 
     /**
@@ -121,7 +131,7 @@ class LifecycleAwareSensorManagerAccelerometer(
         val linearY = values[1] - GRAVITY_VALUES[1]
         val linearZ = values[2] - GRAVITY_VALUES[2]
 
-        return Accelerometer.Sample(
+        return sampleBuffer.request(
             xAccel = linearX,
             yAccel = linearY,
             zAccel = linearZ,

--- a/mobile/android/android-components/components/lib/accelerometer-sensormanager/src/main/java/mozilla/components/lib/accelerometer/sensormanager/SensorSample.kt
+++ b/mobile/android/android-components/components/lib/accelerometer-sensormanager/src/main/java/mozilla/components/lib/accelerometer/sensormanager/SensorSample.kt
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.lib.accelerometer.sensormanager
+
+import mozilla.components.concept.accelerometer.Accelerometer
+
+/** Mutable [Accelerometer.Sample] backed by a [SampleBuffer] slot. */
+internal data class SensorSample(
+    override var xAccel: Float = 0f,
+    override var yAccel: Float = 0f,
+    override var zAccel: Float = 0f,
+    override var timestampNs: Long = 0,
+) : Accelerometer.Sample {
+    fun reset(): SensorSample {
+        xAccel = 0f
+        yAccel = 0f
+        zAccel = 0f
+        return this
+    }
+}
+
+/**
+ * A fixed-size ring buffer of reusable [SensorSample] instances to avoid allocation on every sensor
+ * event.
+ *
+ * @param capacity the number of [SensorSample] slots to pre-allocate.
+ */
+internal class SampleBuffer(
+    capacity: Int,
+) {
+    private var samples = Array(capacity) { SensorSample() }
+    private var index = 0
+
+    /**
+     * Returns the next slot in the ring buffer, populated with the given values.
+     */
+    fun request(
+        xAccel: Float,
+        yAccel: Float,
+        zAccel: Float,
+        timestampNs: Long,
+    ): SensorSample {
+        val requestedSample = samples[index].also {
+            it.xAccel = xAccel
+            it.yAccel = yAccel
+            it.zAccel = zAccel
+            it.timestampNs = timestampNs
+        }
+
+        index = (index + 1) % samples.size
+
+        return requestedSample
+    }
+}

--- a/mobile/android/android-components/components/lib/accelerometer-sensormanager/src/test/java/mozilla/components/lib/accelerometer/sensormanager/SensorSampleTest.kt
+++ b/mobile/android/android-components/components/lib/accelerometer-sensormanager/src/test/java/mozilla/components/lib/accelerometer/sensormanager/SensorSampleTest.kt
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.lib.accelerometer.sensormanager
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class SensorSampleTest {
+
+    @Test
+    fun `request populates sample with given values`() {
+        val buffer = SampleBuffer(2)
+        val sample = buffer.request(1f, 2f, 3f, 100L)
+
+        assertEquals(1f, sample.xAccel)
+        assertEquals(2f, sample.yAccel)
+        assertEquals(3f, sample.zAccel)
+        assertEquals(100L, sample.timestampNs)
+    }
+
+    @Test
+    fun `slots within capacity are distinct instances`() {
+        val buffer = SampleBuffer(2)
+        val first = buffer.request(1f, 0f, 0f, 0L)
+        val second = buffer.request(2f, 0f, 0f, 0L)
+
+        assertNotSame(first, second)
+    }
+
+    @Test
+    fun `buffer wraps and reuses the first slot after full cycle`() {
+        val buffer = SampleBuffer(2)
+        val first = buffer.request(1f, 0f, 0f, 0L)
+        buffer.request(2f, 0f, 0f, 0L)
+        val wrapped = buffer.request(3f, 0f, 0f, 0L)
+
+        assertSame(first, wrapped)
+        assertEquals(3f, wrapped.xAccel)
+    }
+
+    @Test
+    fun `reused slot reflects new values, not old ones`() {
+        val buffer = SampleBuffer(1)
+
+        val original = buffer.request(1f, 2f, 3f, 100L)
+        val reused = buffer.request(9f, 8f, 7f, 999L)
+
+        assertEquals(9f, reused.xAccel)
+        assertEquals(8f, reused.yAccel)
+        assertEquals(7f, reused.zAccel)
+        assertEquals(999L, reused.timestampNs)
+    }
+}

--- a/mobile/android/android-components/components/lib/shake/src/main/java/mozilla/components/lib/shake/ShakeDetection.kt
+++ b/mobile/android/android-components/components/lib/shake/src/main/java/mozilla/components/lib/shake/ShakeDetection.kt
@@ -6,9 +6,7 @@ package mozilla.components.lib.shake
 
 import android.hardware.SensorManager
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.scan
+import kotlinx.coroutines.flow.flow
 import mozilla.components.concept.accelerometer.Accelerometer
 import mozilla.components.lib.shake.ShakeSensitivity.Companion.High
 import mozilla.components.lib.shake.ShakeSensitivity.Companion.Low
@@ -36,19 +34,22 @@ fun Accelerometer.detectShakes(
     detectionWindowNs: Long = 350_000_000L,
     cooldownPeriodNs: Long = 800_000_000L,
     minHits: Int = 2,
-): Flow<Unit> =
-    samples()
-        .scan(ShakeState()) { state, sample ->
-            state.next(
-                sample = sample,
-                sensitivity = sensitivity,
-                detectionWindowNs = detectionWindowNs,
-                cooldownPeriodNs = cooldownPeriodNs,
-                minHits = minHits,
-            )
+): Flow<Unit> = flow {
+    val state = ShakeState()
+    samples().collect { sample ->
+        state.process(
+            sample = sample,
+            sensitivity = sensitivity,
+            detectionWindowNs = detectionWindowNs,
+            cooldownPeriodNs = cooldownPeriodNs,
+            minHits = minHits,
+        )
+
+        if (state.hasReachedMinHits) {
+            emit(Unit)
         }
-        .filter { it.hasReachedMinHits }
-        .map { }
+    }
+}
 
 /**
  * Configuration element for the sensitivity of shake detection.
@@ -103,19 +104,19 @@ private enum class ShakeDirection {
  * minimum required.
  */
 private data class ShakeState(
-    val hits: Int = 0,
-    val detectionWindowStartNs: Long = 0L,
-    val lastShakeNs: Long = 0L,
-    val lastShakeDirection: ShakeDirection = ShakeDirection.Unknown,
-    val hasReachedMinHits: Boolean = false,
+    var hits: Int = 0,
+    var detectionWindowStartNs: Long = 0L,
+    var lastShakeNs: Long = 0L,
+    var lastShakeDirection: ShakeDirection = ShakeDirection.Unknown,
+    var hasReachedMinHits: Boolean = false,
 ) {
-    fun next(
+    fun process(
         sample: Accelerometer.Sample,
         sensitivity: ShakeSensitivity,
         detectionWindowNs: Long,
         cooldownPeriodNs: Long,
         minHits: Int,
-    ): ShakeState {
+    ) {
         // Step 0: Unwrap the Sample object & calculate the magnitude of acceleration
         val magnitude = sqrt(
             sample.xAccel * sample.xAccel +
@@ -126,7 +127,10 @@ private data class ShakeState(
 
         // Step 1: Check if acceleration magnitude is below the threshold.
         // If it is below, return and wait for stronger hit.
-        if (magnitude < sensitivity.threshold) return copy(hasReachedMinHits = false)
+        if (magnitude < sensitivity.threshold) {
+            hasReachedMinHits = false
+            return
+        }
 
         // Step 2: Check the approximate shake direction based on the most dominant acceleration
         val currentShakeDirection = sample.approximateShakeDirection()
@@ -155,22 +159,18 @@ private data class ShakeState(
         return if (!inCooldown && newHits >= minHits) {
             // Shake detected: we have enough hits within the window and previous cooldown has passed.
             // Reset state and record this shake's timestamp to start cooldown period.
-            ShakeState(
-                hits = 0,
-                detectionWindowStartNs = 0L,
-                lastShakeNs = timestampNs,
-                lastShakeDirection = ShakeDirection.Unknown,
-                hasReachedMinHits = true,
-            )
+            hits = 0
+            detectionWindowStartNs = 0L
+            lastShakeNs = timestampNs
+            lastShakeDirection = ShakeDirection.Unknown
+            hasReachedMinHits = true
         } else {
             // No shake yet: continue accumulating hits within the current window.
-            ShakeState(
-                hits = newHits,
-                detectionWindowStartNs = newWindowStart,
-                lastShakeNs = lastShakeNs,
-                lastShakeDirection = currentShakeDirection,
-                hasReachedMinHits = false,
-            )
+            hits = newHits
+            detectionWindowStartNs = newWindowStart
+            lastShakeNs = lastShakeNs
+            lastShakeDirection = currentShakeDirection
+            hasReachedMinHits = false
         }
     }
 

--- a/mobile/android/android-components/components/lib/shake/src/test/java/mozilla/components/lib/shake/ShakeDetectionTest.kt
+++ b/mobile/android/android-components/components/lib/shake/src/test/java/mozilla/components/lib/shake/ShakeDetectionTest.kt
@@ -191,7 +191,12 @@ class ShakeDetectionTest {
             z: Float = 1.g,
             timestampNs: Long,
         ): Accelerometer.Sample {
-            return Accelerometer.Sample(x, y, z, timestampNs)
+            return object : Accelerometer.Sample {
+                override val xAccel = x
+                override val yAccel = y
+                override val zAccel = z
+                override val timestampNs = timestampNs
+            }
         }
     }
 }


### PR DESCRIPTION
This patch tries to reduce the number of allocations required while detecting a shake by
1. Introducing a ring buffer for recycling samples.
2. Replaces map/filter on the cold flow with a new flow that collects and emits when needed.
3. Replaces MutableSharedFlow with a Channel.