### PR TITLE
Bug 2028237 - Cleans up summarization middleware

### DIFF
--- a/mobile/android/android-components/components/concept/llm/src/main/java/mozilla/components/concept/llm/Llm.kt
+++ b/mobile/android/android-components/components/concept/llm/src/main/java/mozilla/components/concept/llm/Llm.kt
@@ -23,10 +23,12 @@ value class ErrorCode(val value: Int)
  */
 interface Llm {
     /**
-     * A prompt request delivered to the LLM for inference, which will stream a series
-     * of [Response]s as they are made available.
+     * A prompt request delivered to the LLM for inference.
+     *
+     * @param prompt a [Prompt] that will be sent to the [Llm].
+     * @return a [Flow] of [String] of the response from the [Llm].
      */
-    suspend fun prompt(prompt: Prompt): Flow<Response>
+    suspend fun prompt(prompt: Prompt): Flow<String>
 
     /**
      * An exception thrown by an LLM, equipped with an [ErrorCode] to differentiate
@@ -48,33 +50,5 @@ interface Llm {
                 errorCode = ErrorCode(0),
             )
         }
-    }
-
-    /**
-     * A response from prompting a LLM.
-     */
-    sealed class Response {
-
-        /**
-         * A successful response from the LLM has occurred. This may include partial data,
-         * or be an indication that the reply has completed.
-         */
-        sealed class Success : Response() {
-            /**
-             * A (potentially) partial reply from the LLM. This may be a complete reply if
-             * it is short or the underlying implementation does not stream responses.
-             */
-            data class ReplyPart(val value: String) : Success()
-
-            /**
-             * An indication that the reply from the LLM is finishes.
-             */
-            data object ReplyFinished : Success()
-        }
-
-        /**
-         * A failure response from a LLM.
-         */
-        data class Failure(val exception: Llm.Exception) : Response()
     }
 }

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationAction.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationAction.kt
@@ -46,7 +46,7 @@ sealed interface LlmProviderAction : SummarizationAction {
 /**
  * There was a failure in summarizing content from the current page.
  */
-data class SummarizationFailed(val exception: Llm.Exception) : SummarizationAction
+data class SummarizationFailed(val throwable: Throwable) : SummarizationAction
 
 /**
  * We've requested a response from a Llm.
@@ -54,14 +54,14 @@ data class SummarizationFailed(val exception: Llm.Exception) : SummarizationActi
 data class SummarizationRequested(val info: LlmProvider.Info) : SummarizationAction
 
 /**
+ * The Summarization has completed successfully.
+ */
+data object SummarizationCompleted : SummarizationAction
+
+/**
  * We've received a new parsed document.
  */
 data class ReceivedParsedDocument(val document: RichDocument) : SummarizationAction
-
-/**
- * We've received a response from the Llm.
- */
-data class ReceivedLlmResponse(val response: Llm.Response) : SummarizationAction
 
 /**
  * Page content has been extracted and is ready to be sent to the LLM.

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationAction.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationAction.kt
@@ -6,7 +6,7 @@ package mozilla.components.feature.summarize
 
 import mozilla.components.concept.llm.Llm
 import mozilla.components.concept.llm.LlmProvider
-import mozilla.components.feature.summarize.content.PageMetadata
+import mozilla.components.feature.summarize.content.Content
 import mozilla.components.lib.state.Action
 import mozilla.components.ui.richtext.ir.RichDocument
 
@@ -66,10 +66,7 @@ data class ReceivedParsedDocument(val document: RichDocument) : SummarizationAct
 /**
  * Page content has been extracted and is ready to be sent to the LLM.
  */
-data class ContentExtracted(
-    val pageMetadata: PageMetadata,
-    val charCount: Int,
-) : SummarizationAction
+data class ContentExtracted(val content: Content) : SummarizationAction
 
 /**
  * Actions for the consent step of the shake to summarize user flow when using an on-device model.

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationAction.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationAction.kt
@@ -67,10 +67,8 @@ data class ReceivedParsedDocument(val document: RichDocument) : SummarizationAct
  * Page content has been extracted and is ready to be sent to the LLM.
  */
 data class ContentExtracted(
-    val instructions: String,
-    val content: String,
-    val pageMetadata: PageMetadata?,
-    val llm: Llm,
+    val pageMetadata: PageMetadata,
+    val charCount: Int,
 ) : SummarizationAction
 
 /**

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationMiddleware.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationMiddleware.kt
@@ -5,10 +5,11 @@
 package mozilla.components.feature.summarize
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.scan
-import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.launch
 import mozilla.components.concept.llm.CloudLlmProvider
 import mozilla.components.concept.llm.Llm
@@ -58,19 +59,15 @@ class SummarizationMiddleware(
                 observePrompt(store, action.llm)
             }
             is SummarizationFailed -> scope.launch {
-                errorReporter.report(action.exception)
+                errorReporter.report(action.throwable)
             }
             is ContentExtracted -> scope.launch {
                 val parser = Parser()
                 action.llm.prompt(Prompt("${action.instructions} ${action.content}"))
                     // We want to accumulate and parse the values that we get from [ReplyPart]
                     // So we emit them and dispatch any other value we get from the [Llm]
-                    .transform {
-                        when (it) {
-                            is Llm.Response.Success.ReplyPart -> emit(it.value)
-                            else -> store.dispatch(ReceivedLlmResponse(it))
-                        }
-                    }
+                    .catch { store.dispatch(SummarizationFailed(it)) }
+                    .onCompletion { if (it == null) store.dispatch(SummarizationCompleted) }
                     .scan("") { acc, i -> acc + i }
                     .map { parser.parse(it) }
                     .collect { store.dispatch(ReceivedParsedDocument(it)) }
@@ -95,11 +92,7 @@ class SummarizationMiddleware(
             ),
         )
     }.onFailure {
-        store.dispatch(
-            SummarizationFailed(
-                it as? Llm.Exception ?: Llm.Exception.unknown("Unknown exception while prompting"),
-            ),
-        )
+        store.dispatch(SummarizationFailed(it))
     }
 
     private suspend fun observeCloudLlmProvider(

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationMiddleware.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationMiddleware.kt
@@ -61,17 +61,6 @@ class SummarizationMiddleware(
             is SummarizationFailed -> scope.launch {
                 errorReporter.report(action.throwable)
             }
-            is ContentExtracted -> scope.launch {
-                val parser = Parser()
-                action.llm.prompt(Prompt("${action.instructions} ${action.content}"))
-                    // We want to accumulate and parse the values that we get from [ReplyPart]
-                    // So we emit them and dispatch any other value we get from the [Llm]
-                    .catch { store.dispatch(SummarizationFailed(it)) }
-                    .onCompletion { if (it == null) store.dispatch(SummarizationCompleted) }
-                    .scan("") { acc, i -> acc + i }
-                    .map { parser.parse(it) }
-                    .collect { store.dispatch(ReceivedParsedDocument(it)) }
-            }
         }
 
         next(action)
@@ -83,14 +72,18 @@ class SummarizationMiddleware(
 
         val content = pageContentExtractor.getPageContent().getOrThrow()
 
-        store.dispatch(
-            ContentExtracted(
-                instructions = pageMetadata.systemPrompt,
-                content = content,
-                pageMetadata = pageMetadata,
-                llm = llm,
-            ),
-        )
+        store.dispatch(ContentExtracted(pageMetadata, content.length))
+
+        val parser = Parser()
+
+        llm.prompt(Prompt("${pageMetadata.systemPrompt} $content"))
+            // We want to accumulate and parse the values that we get from [ReplyPart]
+            // So we emit them and dispatch any other value we get from the [Llm]
+            .catch { store.dispatch(SummarizationFailed(it)) }
+            .onCompletion { if (it == null) store.dispatch(SummarizationCompleted) }
+            .scan("") { acc, i -> acc + i }
+            .map { parser.parse(it) }
+            .collect { store.dispatch(ReceivedParsedDocument(it)) }
     }.onFailure {
         store.dispatch(SummarizationFailed(it))
     }

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationMiddleware.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationMiddleware.kt
@@ -4,32 +4,30 @@
 
 package mozilla.components.feature.summarize
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.launch
 import mozilla.components.concept.llm.CloudLlmProvider
 import mozilla.components.concept.llm.Llm
-import mozilla.components.concept.llm.Prompt
-import mozilla.components.feature.summarize.content.PageContentExtractor
-import mozilla.components.feature.summarize.content.PageMetadata
-import mozilla.components.feature.summarize.content.PageMetadataExtractor
+import mozilla.components.feature.summarize.content.ContentProvider
+import mozilla.components.feature.summarize.ext.fetchLlm
+import mozilla.components.feature.summarize.ext.mapToRichDocument
+import mozilla.components.feature.summarize.ext.prompt
 import mozilla.components.feature.summarize.settings.SummarizationSettings
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.Store
-import mozilla.components.ui.richtext.parsing.Parser
 
 /** The initial middleware for the summarization feature */
 class SummarizationMiddleware(
     private val settings: SummarizationSettings,
     private val llmProvider: CloudLlmProvider,
-    private val pageContentExtractor: PageContentExtractor,
-    private val pageMetadataExtractor: PageMetadataExtractor,
+    private val contentProvider: ContentProvider,
     private val errorReporter: ErrorReporter,
     private val scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : Middleware<SummarizationState, SummarizationAction> {
 
     override fun invoke(
@@ -67,105 +65,23 @@ class SummarizationMiddleware(
     }
 
     private suspend fun observePrompt(store: SummarizationStore, llm: Llm) = runCatching {
-        val pageMetadata = pageMetadataExtractor.getPageMetadata()
-            .getOrDefault(PageMetadata())
+        val content = contentProvider.getContent().getOrThrow()
 
-        val content = pageContentExtractor.getPageContent().getOrThrow()
+        store.dispatch(ContentExtracted(content))
 
-        store.dispatch(ContentExtracted(pageMetadata, content.length))
-
-        val parser = Parser()
-
-        llm.prompt(Prompt("${pageMetadata.systemPrompt} $content"))
-            // We want to accumulate and parse the values that we get from [ReplyPart]
-            // So we emit them and dispatch any other value we get from the [Llm]
-            .catch { store.dispatch(SummarizationFailed(it)) }
+        llm.prompt(content.prompt)
+            .mapToRichDocument(dispatcher)
             .onCompletion { if (it == null) store.dispatch(SummarizationCompleted) }
-            .scan("") { acc, i -> acc + i }
-            .map { parser.parse(it) }
             .collect { store.dispatch(ReceivedParsedDocument(it)) }
-    }.onFailure {
-        store.dispatch(SummarizationFailed(it))
-    }
+    }.onFailure { store.dispatch(SummarizationFailed(it)) }
 
     private suspend fun observeCloudLlmProvider(
         store: SummarizationStore,
         llmProvider: CloudLlmProvider,
-    ) {
-        store.dispatch(SummarizationRequested(llmProvider.info))
-        llmProvider.state.map { state ->
-            when (state) {
-                CloudLlmProvider.State.Available -> LlmProviderAction.ProviderAvailable
-                is CloudLlmProvider.State.Unavailable -> LlmProviderAction.ProviderFailed(state.exception)
-                is CloudLlmProvider.State.Ready -> LlmProviderAction.ProviderInitialized(state.llm)
-            }
-        }.collect { store.dispatch(it) }
-    }
+    ) = llmProvider.fetchLlm.collect { store.dispatch(it) }
 
     private suspend fun needsShakeConsent(state: SummarizationState): Boolean =
         state is SummarizationState.Inert &&
             state.initializedWithShake &&
             !settings.getHasConsentedToShake().first()
 }
-
-private val PageMetadata.isRecipe get() = structuredDataTypes.any { it.lowercase() == "recipe" }
-private val PageMetadata.systemPrompt get() = if (isRecipe) {
-    recipeInstructions(language)
-} else {
-    defaultInstructions(language)
-}
-
-internal fun defaultInstructions(language: String) = """
-        You are an expert at creating mobile-optimized summaries.
-        You MUST respond entirely in $language. Do not mix languages.
-        Process:
-        Step 1: Identify the type of content.
-        Step 2: Based on content type, prioritize:
-        Recipe - Servings, Total time, Ingredients list, Key steps, Tips.
-        News - What happened, when, where. How-to - Total time, Materials, Key steps, Warnings.
-        Review - Bottom line rating, price. Opinion - Main arguments, Key evidence.
-        Personal Blog - Author, main points. Fiction - Author, summary of plot.
-        All other content types - Provide a brief summary of no more than 6 sentences.
-        Step 3: Format for mobile using concise language and paragraphs with 3 sentences maximum.
-        Bold critical details (numbers, warnings, key terms).
-    """.trimIndent()
-
-internal fun recipeInstructions(language: String) = """
-        You are an expert at creating mobile-optimized recipe summaries.
-
-        You MUST respond entirely in $language. Do not mix languages.
-        Translate all visible section headers and labels into **{lang}**.
-        Output ONLY the formatted result. Do not add any closing phrases.
-        If a field is null, empty, or missing, omit that section entirely.
-        Always replace placeholders with actual values.
-        Convert time values to minutes and hours.
-
-        FORMAT:
-        **Servings:** {servings}
-
-        **Total Time:** {total_time}
-
-        **Prep Time:** {prep_time}
-
-        **Cook Time:** {cook_time}
-
-        ## 🥕 Ingredients
-        - ingredient 1
-        - ingredient 2
-        - ingredient 3
-
-        ## 📋 Instructions
-        1. step 1
-        2. step 2
-        3. step 3
-
-        ## ⭐️ Tips
-        - tip 1
-        - tip 2
-
-        ## 🥗 Nutrition
-        - Calories: {calories}
-        - Protein: {protein} g
-        - Carbs: {carbs} g
-        - Fat: {fat} g
-    """.trimIndent()

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationReducer.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/SummarizationReducer.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.summarize
 
+import mozilla.components.concept.llm.ErrorCode
 import mozilla.components.concept.llm.Llm
 import mozilla.components.ui.richtext.ir.RichDocument
 
@@ -20,7 +21,8 @@ fun summarizationReducer(state: SummarizationState, action: SummarizationAction)
     OffDeviceSummarizationShakeConsentAction.LearnMoreClicked -> SummarizationState.Finished.LearnMoreAboutShakeConsent
     OnDeviceSummarizationShakeConsentAction.LearnMoreClicked -> SummarizationState.Finished.LearnMoreAboutShakeConsent
     is SummarizationRequested -> SummarizationState.Loading(action.info)
-    is ReceivedLlmResponse -> state.applyResponse(action.response)
+    is SummarizationCompleted -> state.complete()
+    is SummarizationFailed -> SummarizationState.Error(action.throwable.summarizationError())
     is ReceivedParsedDocument -> state.updateDocument(action.document)
     is SettingsClicked -> when (state) {
         is SummarizationState.Summarized -> SummarizationState.Settings(info = state.info, document = state.document)
@@ -30,27 +32,23 @@ fun summarizationReducer(state: SummarizationState, action: SummarizationAction)
         is SummarizationState.Settings -> SummarizationState.Summarized(info = state.info, document = state.document)
         else -> state
     }
-    is SummarizationFailed -> SummarizationState.Error(SummarizationError.SummarizationFailed(action.exception))
     is LlmProviderAction.ProviderFailed -> SummarizationState.Error(
         SummarizationError.SummarizationFailed(action.exception),
     )
     else -> state
 }
 
-internal fun SummarizationState.applyResponse(response: Llm.Response): SummarizationState {
+private fun SummarizationState.complete(): SummarizationState {
     if (this !is SummarizationState.Summarizing) return this
-    return when (response) {
-        is Llm.Response.Failure -> {
-            val contentTooLongErrorCode = 1005
-            when (response.exception.errorCode.value) {
-                contentTooLongErrorCode -> SummarizationState.Error(SummarizationError.ContentTooLong)
-                else -> SummarizationState.Error(
-                    SummarizationError.SummarizationFailed(response.exception),
-                )
-            }
-        }
-        Llm.Response.Success.ReplyFinished -> SummarizationState.Summarized(info = info, document)
-        else -> this
+    return SummarizationState.Summarized(info, document)
+}
+
+private fun Throwable.summarizationError(): SummarizationError {
+    val exception = (this as? Llm.Exception) ?: Llm.Exception.unknown(message)
+    val contentTooLong = 1005
+    return when (exception.errorCode) {
+        ErrorCode(contentTooLong) -> SummarizationError.ContentTooLong
+        else -> SummarizationError.SummarizationFailed(exception)
     }
 }
 

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/content/ContentProvider.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/content/ContentProvider.kt
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.summarize.content
+
+/**
+ * Represents the extracted content of a web page, combining its textual body and metadata.
+ *
+ * @property metadata Metadata associated with the page, such as title and author.
+ * @property body The main textual content of the page.
+ */
+
+data class Content(
+    val metadata: PageMetadata = PageMetadata(),
+    val body: String = "",
+)
+
+/**
+ * Provides the [Content] of a web page for summarization.
+ *
+ * Use [fromPage] to create an instance backed by a [PageContentExtractor] and
+ * [PageMetadataExtractor], or supply a custom implementation.
+ */
+fun interface ContentProvider {
+    /**
+     * Returns the page [Content], or a failure if the content could not be retrieved.
+     */
+    suspend fun getContent(): Result<Content>
+
+    companion object {
+        /**
+         * Creates a [ContentProvider] that derives [Content] from the given extractors.
+         *
+         * Metadata failures are non-fatal and fall back to a default [PageMetadata].
+         * Content failures are propagated and cause the returned [Result] to fail.
+         *
+         * @param pageContentExtractor Extracts the main textual content of the page.
+         * @param pageMetadataExtractor Extracts metadata such as the page title and author.
+         */
+        fun fromPage(
+            pageContentExtractor: PageContentExtractor,
+            pageMetadataExtractor: PageMetadataExtractor,
+        ) = ContentProvider {
+            runCatching {
+                val metadata = pageMetadataExtractor.getPageMetadata().getOrDefault(PageMetadata())
+                val content = pageContentExtractor.getPageContent().getOrThrow()
+
+                Content(metadata, content)
+            }
+        }
+    }
+}

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/ext/Content.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/ext/Content.kt
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.summarize.ext
+
+import mozilla.components.concept.llm.Prompt
+import mozilla.components.feature.summarize.content.Content
+import mozilla.components.feature.summarize.content.PageMetadata
+
+val Content.prompt get() = Prompt("${metadata.systemPrompt} $body")
+
+private val PageMetadata.isRecipe get() = structuredDataTypes.any { it.lowercase() == "recipe" }
+private val PageMetadata.systemPrompt get() = if (isRecipe) {
+    recipeInstructions(language)
+} else {
+    defaultInstructions(language)
+}
+
+internal fun defaultInstructions(language: String) = """
+        You are an expert at creating mobile-optimized summaries.
+        You MUST respond entirely in $language. Do not mix languages.
+        Process:
+        Step 1: Identify the type of content.
+        Step 2: Based on content type, prioritize:
+        Recipe - Servings, Total time, Ingredients list, Key steps, Tips.
+        News - What happened, when, where. How-to - Total time, Materials, Key steps, Warnings.
+        Review - Bottom line rating, price. Opinion - Main arguments, Key evidence.
+        Personal Blog - Author, main points. Fiction - Author, summary of plot.
+        All other content types - Provide a brief summary of no more than 6 sentences.
+        Step 3: Format for mobile using concise language and paragraphs with 3 sentences maximum.
+        Bold critical details (numbers, warnings, key terms).
+    """.trimIndent()
+
+internal fun recipeInstructions(language: String) = """
+        You are an expert at creating mobile-optimized recipe summaries.
+
+        You MUST respond entirely in $language. Do not mix languages.
+        Translate all visible section headers and labels into **{lang}**.
+        Output ONLY the formatted result. Do not add any closing phrases.
+        If a field is null, empty, or missing, omit that section entirely.
+        Always replace placeholders with actual values.
+        Convert time values to minutes and hours.
+
+        FORMAT:
+        **Servings:** {servings}
+
+        **Total Time:** {total_time}
+
+        **Prep Time:** {prep_time}
+
+        **Cook Time:** {cook_time}
+
+        ## 🥕 Ingredients
+        - ingredient 1
+        - ingredient 2
+        - ingredient 3
+
+        ## 📋 Instructions
+        1. step 1
+        2. step 2
+        3. step 3
+
+        ## ⭐️ Tips
+        - tip 1
+        - tip 2
+
+        ## 🥗 Nutrition
+        - Calories: {calories}
+        - Protein: {protein} g
+        - Carbs: {carbs} g
+        - Fat: {fat} g
+    """.trimIndent()

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/ext/Flow.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/ext/Flow.kt
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.summarize.ext
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.transform
+import mozilla.components.ui.richtext.ir.RichDocument
+import mozilla.components.ui.richtext.parsing.Parser
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+internal fun Flow<String>.mapToRichDocument(dispatcher: CoroutineDispatcher): Flow<RichDocument> {
+    val parser = Parser()
+    val responseBuilder = StringBuilder()
+
+    return map { responseBuilder.append(it) }
+        .sampledMap { parser.parse(it.toString()) }
+        .flowOn(dispatcher)
+}
+
+private val PARSE_THROTTLE = 120.milliseconds
+
+/**
+ * Maps the input flow using the [transform] function, every [period] duration.
+ *
+ * Values emitted between the samples, are completed dropped.
+ *
+ * @param period The period to wait between samples
+ * @param transform The transformation/mapping operation
+ */
+private fun <T, R> Flow<T>.sampledMap(
+    period: Duration = PARSE_THROTTLE,
+    transform: (T) -> R,
+): Flow<R> {
+    return conflate()
+        .transform {
+            emit(transform(it))
+            delay(period)
+        }
+}

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/ext/LlmProvider.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/ext/LlmProvider.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.summarize.ext
+
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import mozilla.components.concept.llm.CloudLlmProvider
+import mozilla.components.feature.summarize.LlmProviderAction
+import mozilla.components.feature.summarize.SummarizationRequested
+
+internal val CloudLlmProvider.fetchLlm get() = flow {
+    emit(SummarizationRequested(info))
+    emitAll(state.map { it.action })
+}
+
+internal val CloudLlmProvider.State.action get() = when (this) {
+    CloudLlmProvider.State.Available -> LlmProviderAction.ProviderAvailable
+    is CloudLlmProvider.State.Unavailable -> LlmProviderAction.ProviderFailed(exception)
+    is CloudLlmProvider.State.Ready -> LlmProviderAction.ProviderInitialized(llm)
+}

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/fakes/Llm.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/fakes/Llm.kt
@@ -40,15 +40,15 @@ data class FakeCloudProvider(
  * Emits each item in [responses] sequentially, with a 2-second delay between
  * each emission to simulate real LLM streaming latency.
  *
- * @property responses The ordered list of [Llm.Response] values to emit when [prompt] is called.
+ * @property responses values to emit.
  */
 data class FakeLlm(
-    val responses: List<Llm.Response> = listOf(),
+    val responses: List<String> = listOf(),
 ) : Llm {
 
     var promptCapture = ""
 
-    override suspend fun prompt(prompt: Prompt): Flow<Llm.Response> = flow {
+    override suspend fun prompt(prompt: Prompt): Flow<String> = flow {
         for (response in responses) {
             emit(response)
             delay(2.seconds)
@@ -60,10 +60,9 @@ data class FakeLlm(
     companion object {
         val successful get() = FakeLlm(
             listOf(
-                Llm.Response.Success.ReplyPart("# This is the article\n"),
-                Llm.Response.Success.ReplyPart("This is some content...\n"),
-                Llm.Response.Success.ReplyPart("This is some *bold* content.\n"),
-                Llm.Response.Success.ReplyFinished,
+               "# This is the article\n",
+               "This is some content...\n",
+               "This is some *bold* content.\n",
             ),
         )
     }

--- a/mobile/android/android-components/components/feature/summarize/src/test/java/mozilla/components/feature/summarize/SummarizationStoreTest.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/test/java/mozilla/components/feature/summarize/SummarizationStoreTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.summarize
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import mozilla.components.feature.summarize.SummarizationState.Finished
 import mozilla.components.feature.summarize.SummarizationState.Inert
@@ -16,6 +17,8 @@ import mozilla.components.feature.summarize.SummarizationState.Summarized
 import mozilla.components.feature.summarize.SummarizationState.Summarizing
 import mozilla.components.feature.summarize.content.PageContentExtractor
 import mozilla.components.feature.summarize.content.PageMetadata
+import mozilla.components.feature.summarize.ext.defaultInstructions
+import mozilla.components.feature.summarize.ext.recipeInstructions
 import mozilla.components.feature.summarize.fakes.FakeCloudProvider
 import mozilla.components.feature.summarize.fakes.FakeLlm
 import mozilla.components.feature.summarize.settings.SummarizationSettings
@@ -55,6 +58,7 @@ class SummarizationStoreTest {
                     pageMetadataExtractor = { Result.success(PageMetadata(listOf(), 0, "en")) },
                     errorReporter = noopReporter,
                     scope = backgroundScope,
+                    dispatcher = StandardTestDispatcher(testScheduler),
                 ),
             ),
         )
@@ -98,6 +102,7 @@ class SummarizationStoreTest {
                     pageMetadataExtractor = { Result.success(PageMetadata(listOf(), 0, "en")) },
                     errorReporter = noopReporter,
                     scope = backgroundScope,
+                    dispatcher = StandardTestDispatcher(testScheduler),
                 ),
             ),
         )
@@ -140,6 +145,7 @@ class SummarizationStoreTest {
                     pageMetadataExtractor = { Result.success(PageMetadata(listOf("Article"), 0, "en")) },
                     errorReporter = noopReporter,
                     scope = backgroundScope,
+                    dispatcher = StandardTestDispatcher(testScheduler),
                 ),
             ),
         )
@@ -181,6 +187,7 @@ class SummarizationStoreTest {
                     pageMetadataExtractor = { Result.success(PageMetadata(listOf(), 0, "en")) },
                     errorReporter = errorReporter,
                     scope = backgroundScope,
+                    dispatcher = StandardTestDispatcher(testScheduler),
                 ),
             ),
         )
@@ -220,6 +227,7 @@ class SummarizationStoreTest {
                     pageMetadataExtractor = { Result.success(PageMetadata(listOf("Recipe"), 0, "en")) },
                     errorReporter = noopReporter,
                     scope = backgroundScope,
+                    dispatcher = StandardTestDispatcher(testScheduler),
                 ),
             ),
         )
@@ -262,6 +270,7 @@ class SummarizationStoreTest {
                     pageMetadataExtractor = { Result.success(PageMetadata(listOf("Recipe"), 0, "es")) },
                     errorReporter = noopReporter,
                     scope = backgroundScope,
+                    dispatcher = StandardTestDispatcher(testScheduler),
                 ),
             ),
         )
@@ -304,6 +313,7 @@ class SummarizationStoreTest {
                     pageMetadataExtractor = { Result.failure(IllegalStateException()) },
                     errorReporter = noopReporter,
                     scope = backgroundScope,
+                    dispatcher = StandardTestDispatcher(testScheduler),
                 ),
             ),
         )

--- a/mobile/android/android-components/components/feature/summarize/src/test/java/mozilla/components/feature/summarize/SummarizationStoreTest.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/test/java/mozilla/components/feature/summarize/SummarizationStoreTest.kt
@@ -15,6 +15,8 @@ import mozilla.components.feature.summarize.SummarizationState.Loading
 import mozilla.components.feature.summarize.SummarizationState.ShakeConsentRequired
 import mozilla.components.feature.summarize.SummarizationState.Summarized
 import mozilla.components.feature.summarize.SummarizationState.Summarizing
+import mozilla.components.feature.summarize.content.Content
+import mozilla.components.feature.summarize.content.ContentProvider
 import mozilla.components.feature.summarize.content.PageContentExtractor
 import mozilla.components.feature.summarize.content.PageMetadata
 import mozilla.components.feature.summarize.ext.defaultInstructions
@@ -54,8 +56,7 @@ class SummarizationStoreTest {
                 SummarizationMiddleware(
                     settings = settings,
                     llmProvider = provider,
-                    pageContentExtractor = { Result.success("") },
-                    pageMetadataExtractor = { Result.success(PageMetadata(listOf(), 0, "en")) },
+                    contentProvider = { Result.success(Content()) },
                     errorReporter = noopReporter,
                     scope = backgroundScope,
                     dispatcher = StandardTestDispatcher(testScheduler),
@@ -98,8 +99,7 @@ class SummarizationStoreTest {
                 SummarizationMiddleware(
                     settings = settings,
                     llmProvider = FakeCloudProvider(llm = FakeLlm.successful),
-                    pageContentExtractor = { Result.success("") },
-                    pageMetadataExtractor = { Result.success(PageMetadata(listOf(), 0, "en")) },
+                    contentProvider = { Result.success(Content()) },
                     errorReporter = noopReporter,
                     scope = backgroundScope,
                     dispatcher = StandardTestDispatcher(testScheduler),
@@ -141,8 +141,7 @@ class SummarizationStoreTest {
                 SummarizationMiddleware(
                     llmProvider = provider,
                     settings = SummarizationSettings.inMemory(hasConsentedToShake = true),
-                    pageContentExtractor = { Result.success(content) },
-                    pageMetadataExtractor = { Result.success(PageMetadata(listOf("Article"), 0, "en")) },
+                    contentProvider = { Result.success(Content(PageMetadata(listOf("Article"), 0, "en"), content)) },
                     errorReporter = noopReporter,
                     scope = backgroundScope,
                     dispatcher = StandardTestDispatcher(testScheduler),
@@ -183,8 +182,7 @@ class SummarizationStoreTest {
                 SummarizationMiddleware(
                     llmProvider = provider,
                     settings = SummarizationSettings.inMemory(hasConsentedToShake = true),
-                    pageContentExtractor = { Result.failure(failureThrowable) },
-                    pageMetadataExtractor = { Result.success(PageMetadata(listOf(), 0, "en")) },
+                    contentProvider = { Result.failure(failureThrowable) },
                     errorReporter = errorReporter,
                     scope = backgroundScope,
                     dispatcher = StandardTestDispatcher(testScheduler),
@@ -223,8 +221,7 @@ class SummarizationStoreTest {
                 SummarizationMiddleware(
                     settings = SummarizationSettings.inMemory(hasConsentedToShake = true),
                     llmProvider = provider,
-                    pageContentExtractor = { Result.success(content) },
-                    pageMetadataExtractor = { Result.success(PageMetadata(listOf("Recipe"), 0, "en")) },
+                    contentProvider = { Result.success(Content(PageMetadata(listOf("Recipe"), 0, "en"), content)) },
                     errorReporter = noopReporter,
                     scope = backgroundScope,
                     dispatcher = StandardTestDispatcher(testScheduler),
@@ -266,8 +263,18 @@ class SummarizationStoreTest {
                 SummarizationMiddleware(
                     settings = SummarizationSettings.inMemory(hasConsentedToShake = true),
                     llmProvider = provider,
-                    pageContentExtractor = { Result.success(content) },
-                    pageMetadataExtractor = { Result.success(PageMetadata(listOf("Recipe"), 0, "es")) },
+                    contentProvider = {
+                        Result.success(
+                            Content(
+                                PageMetadata(
+                                    listOf("Recipe"),
+                                    0,
+                                    "es",
+                                ),
+                                    content,
+                            ),
+                        )
+                    },
                     errorReporter = noopReporter,
                     scope = backgroundScope,
                     dispatcher = StandardTestDispatcher(testScheduler),
@@ -288,55 +295,21 @@ class SummarizationStoreTest {
             Inert(true),
             Loading(provider.info),
             Summarizing(provider.info, parser.parse("# This is the article\n")),
-            Summarizing(provider.info, parser.parse("# This is the article\nThis is some content...\n")),
-            Summarizing(provider.info, parser.parse("# This is the article\nThis is some content...\nThis is some *bold* content.\n")),
-            Summarized(provider.info, parser.parse("# This is the article\nThis is some content...\nThis is some *bold* content.\n")),
+            Summarizing(
+                provider.info,
+                parser.parse("# This is the article\nThis is some content...\n"),
+            ),
+            Summarizing(
+                provider.info,
+                parser.parse("# This is the article\nThis is some content...\nThis is some *bold* content.\n"),
+            ),
+            Summarized(
+                provider.info,
+                parser.parse("# This is the article\nThis is some content...\nThis is some *bold* content.\n"),
+            ),
         )
 
         assertEquals(expected, states)
         assertEquals("${recipeInstructions("es")} $content", llm.promptCapture)
-    }
-
-    @Test
-    fun `if extracting page metadata fails, the llm is prompted with the default instructions`() = runTest {
-        val llm = FakeLlm.successful
-        val content = "this is expected content."
-        val provider = FakeCloudProvider(llm = llm)
-        val store = SummarizationStore(
-            initialState = Inert(true),
-            reducer = ::summarizationReducer,
-            middleware = listOf(
-                SummarizationMiddleware(
-                    settings = SummarizationSettings.inMemory(hasConsentedToShake = true),
-                    llmProvider = provider,
-                    pageContentExtractor = { Result.success(content) },
-                    pageMetadataExtractor = { Result.failure(IllegalStateException()) },
-                    errorReporter = noopReporter,
-                    scope = backgroundScope,
-                    dispatcher = StandardTestDispatcher(testScheduler),
-                ),
-            ),
-        )
-
-        val states = mutableListOf<SummarizationState>()
-        backgroundScope.launch {
-            store.stateFlow.toList(states)
-        }
-        testScheduler.advanceTimeBy(1.seconds)
-
-        store.dispatch(ViewAppeared)
-        testScheduler.advanceTimeBy(15.seconds)
-
-        val expected = listOf<SummarizationState>(
-            Inert(true),
-            Loading(provider.info),
-            Summarizing(provider.info, parser.parse("# This is the article\n")),
-            Summarizing(provider.info, parser.parse("# This is the article\nThis is some content...\n")),
-            Summarizing(provider.info, parser.parse("# This is the article\nThis is some content...\nThis is some *bold* content.\n")),
-            Summarized(provider.info, parser.parse("# This is the article\nThis is some content...\nThis is some *bold* content.\n")),
-        )
-
-        assertEquals(expected, states)
-        assertEquals("${defaultInstructions("en")} $content", llm.promptCapture)
     }
 }

--- a/mobile/android/android-components/components/feature/summarize/src/test/java/mozilla/components/feature/summarize/content/ContentProviderTest.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/test/java/mozilla/components/feature/summarize/content/ContentProviderTest.kt
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.summarize.content
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ContentProviderTest {
+    @Test
+    fun `that we can provide the page content`() = runTest {
+        val content = ContentProvider.fromPage(
+            { Result.success("This is the page content") },
+            { Result.success(PageMetadata(wordCount = 500)) },
+        ).getContent().getOrThrow()
+
+        assertEquals("This is the page content", content.body)
+        assertEquals(PageMetadata(wordCount = 500), content.metadata)
+    }
+
+    @Test
+    fun `that if we fail to extract content we return a failure`() = runTest {
+        val content = ContentProvider.fromPage(
+            { Result.failure(PageContentExtractor.Exception()) },
+            { Result.success(PageMetadata()) },
+        ).getContent().exceptionOrNull()
+
+        assertTrue(content is PageContentExtractor.Exception)
+    }
+
+    @Test
+    fun `that if extracting page metadata fails we recover with default metadata`() = runTest {
+        val content = ContentProvider.fromPage(
+            { Result.success("This is the page content") },
+            { Result.failure(IllegalStateException()) },
+        ).getContent().getOrThrow()
+
+        assertEquals("This is the page content", content.body)
+        assertEquals(PageMetadata(), content.metadata)
+    }
+}

--- a/mobile/android/android-components/components/lib/llm-gemininano/src/main/java/mozilla/components/lib/llm/gemini/nano/GeminiNanoLlm.kt
+++ b/mobile/android/android-components/components/lib/llm-gemininano/src/main/java/mozilla/components/lib/llm/gemini/nano/GeminiNanoLlm.kt
@@ -29,25 +29,24 @@ internal class GeminiNanoLlm(
         buildModel()
     }
 
-    override suspend fun prompt(prompt: Prompt): Flow<Llm.Response> = flow {
+    override suspend fun prompt(prompt: Prompt): Flow<String> = flow {
         streamPromptResponses(prompt)
     }
 
-    private suspend fun FlowCollector<Llm.Response>.streamPromptResponses(prompt: Prompt) = try {
+    private suspend fun FlowCollector<String>.streamPromptResponses(prompt: Prompt) = try {
         // consume replies from the model until it provides a finish reason
         logger("Beginning model response stream")
         model.generateContentStream(prompt.value).onEach { response ->
-            emit(Llm.Response.Success.ReplyPart(response.candidates[0].text))
+            emit(response.candidates[0].text)
         }.first {
             val finishReason = it.candidates[0].finishReason
             (finishReason != null).also {
                 logger("Model stream completed with: $finishReason")
             }
         }
-        emit(Llm.Response.Success.ReplyFinished)
     } catch (e: GenAiException) {
         val message = "Gemini Nano inference failed: ${e.message}"
         logger(message)
-        emit(Llm.Response.Failure(Llm.Exception.unknown(message)))
+        throw Llm.Exception.unknown(message)
     }
 }

--- a/mobile/android/android-components/components/lib/llm-gemininano/src/test/java/mozilla/components/lib/llm/gemini/nano/GeminiNanoLlmTest.kt
+++ b/mobile/android/android-components/components/lib/llm-gemininano/src/test/java/mozilla/components/lib/llm/gemini/nano/GeminiNanoLlmTest.kt
@@ -8,7 +8,6 @@ import com.google.mlkit.genai.common.FeatureStatus
 import com.google.mlkit.genai.common.GenAiException
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
-import mozilla.components.concept.llm.ErrorCode
 import mozilla.components.concept.llm.Llm
 import mozilla.components.concept.llm.Prompt
 import mozilla.components.lib.llm.gemini.nano.fakes.FakeGenerativeModel
@@ -28,9 +27,8 @@ class GeminiNanoLlmTest {
 
         val results = llm.prompt(Prompt("test prompt")).toList()
 
-        assertEquals(2, results.size)
-        assertEquals(Llm.Response.Success.ReplyPart("test response"), results[0])
-        assertEquals(Llm.Response.Success.ReplyFinished, results[1])
+        assertEquals(1, results.size)
+        assertEquals("test response", results[0])
         assertEquals("test prompt", fakeModel.lastPromptProcessed)
     }
 
@@ -42,13 +40,11 @@ class GeminiNanoLlmTest {
         )
 
         val llm = GeminiNanoLlm(buildModel = { fakeModel })
+        val result = runCatching { llm.prompt(Prompt("test prompt")).toList() }
 
-        val results = llm.prompt(Prompt("test prompt")).toList()
-
-        assertEquals(1, results.size)
-        val failure = results[0] as Llm.Response.Failure
-        assertEquals(0, failure.exception.errorCode.value)
-        assertTrue(failure.exception.message?.startsWith("Gemini Nano inference failed:") == true)
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is Llm.Exception)
+        assertEquals("Gemini Nano inference failed: [ErrorCode 4] Request doesn't pass certain policy check. Please try a different input.", result.exceptionOrNull()?.message)
     }
 
     @Test

--- a/mobile/android/android-components/components/lib/llm-mlpa/src/main/java/mozilla/components/lib/llm/mlpa/MlpaLlm.kt
+++ b/mobile/android/android-components/components/lib/llm-mlpa/src/main/java/mozilla/components/lib/llm/mlpa/MlpaLlm.kt
@@ -5,8 +5,6 @@
 package mozilla.components.lib.llm.mlpa
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flow
 import mozilla.components.concept.llm.Llm
 import mozilla.components.concept.llm.Prompt
 import mozilla.components.lib.llm.mlpa.service.AuthorizationToken
@@ -19,9 +17,10 @@ internal class MlpaLlm(
     val chatService: ChatService,
     val authorizationToken: AuthorizationToken,
 ) : Llm {
-    override suspend fun prompt(prompt: Prompt): Flow<String> = flow {
-        emitAll(chatService.completion(authorizationToken, prompt.asRequest))
-    }
+    override suspend fun prompt(prompt: Prompt): Flow<String> = chatService.completion(
+        authorizationToken,
+        request = prompt.asRequest,
+    )
 }
 
 internal val Prompt.asRequest

--- a/mobile/android/android-components/components/lib/llm-mlpa/src/main/java/mozilla/components/lib/llm/mlpa/MlpaLlm.kt
+++ b/mobile/android/android-components/components/lib/llm-mlpa/src/main/java/mozilla/components/lib/llm/mlpa/MlpaLlm.kt
@@ -5,9 +5,8 @@
 package mozilla.components.lib.llm.mlpa
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.onCompletion
-import mozilla.components.concept.llm.ErrorCode
 import mozilla.components.concept.llm.Llm
 import mozilla.components.concept.llm.Prompt
 import mozilla.components.lib.llm.mlpa.service.AuthorizationToken
@@ -20,22 +19,9 @@ internal class MlpaLlm(
     val chatService: ChatService,
     val authorizationToken: AuthorizationToken,
 ) : Llm {
-    override suspend fun prompt(prompt: Prompt): Flow<Llm.Response> = flow {
-        chatService.completion(authorizationToken, prompt.asRequest)
-            .onCompletion { cause ->
-                val action = cause
-                    ?.let {
-                        val exception = it as? Llm.Exception
-                            ?: Llm.Exception(it.message ?: "unknown chat error", unknownLlmErrorCode)
-                        Llm.Response.Failure(exception)
-                    }
-                    ?: Llm.Response.Success.ReplyFinished
-                emit(action)
-            }
-            .collect { emit(Llm.Response.Success.ReplyPart(it)) }
+    override suspend fun prompt(prompt: Prompt): Flow<String> = flow {
+        emitAll(chatService.completion(authorizationToken, prompt.asRequest))
     }
-
-    private val unknownLlmErrorCode = ErrorCode(1012)
 }
 
 internal val Prompt.asRequest

--- a/mobile/android/android-components/components/lib/llm-mlpa/src/test/java/mozilla/components/lib/llm/mlpa/MlpaLlmProviderTest.kt
+++ b/mobile/android/android-components/components/lib/llm-mlpa/src/test/java/mozilla/components/lib/llm/mlpa/MlpaLlmProviderTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.lib.llm.mlpa
 
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.llm.CloudLlmProvider
@@ -66,7 +67,9 @@ class MlpaLlmProviderTest {
 
             provider.prepare()
 
-            (provider.state.value as? CloudLlmProvider.State.Ready)?.llm?.prompt(Prompt("This is a test prompt"))?.first()
+            (provider.state.value as? CloudLlmProvider.State.Ready)?.llm?.prompt(Prompt("This is a test prompt"))
+                ?.catch {}
+                ?.collect {}
 
             assertTrue(provider.state.value is CloudLlmProvider.State.Available)
         }
@@ -88,7 +91,9 @@ class MlpaLlmProviderTest {
 
             provider.prepare()
 
-            (provider.state.value as? CloudLlmProvider.State.Ready)?.llm?.prompt(Prompt("This is a test prompt"))?.first()
+            (provider.state.value as? CloudLlmProvider.State.Ready)?.llm?.prompt(Prompt("This is a test prompt"))
+                ?.catch {}
+                ?.collect {}
 
             assertTrue(provider.state.value is CloudLlmProvider.State.Unavailable)
         }

--- a/mobile/android/android-components/components/lib/llm-mlpa/src/test/java/mozilla/components/lib/llm/mlpa/MlpaLlmTest.kt
+++ b/mobile/android/android-components/components/lib/llm-mlpa/src/test/java/mozilla/components/lib/llm/mlpa/MlpaLlmTest.kt
@@ -35,10 +35,7 @@ class MlpaLlmTest {
         )
 
         val actual = llm.prompt(Prompt("This is my prompt")).toList()
-        val expected = listOf(
-            Llm.Response.Success.ReplyPart("Hello World!"),
-            Llm.Response.Success.ReplyFinished,
-        )
+        val expected = listOf("Hello World!")
 
         assertEquals(expectedToken?.value, AuthorizationToken.Integrity("my-test-token").value)
         assertEquals(expected, actual)

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/debugsettings/llm/LlmTools.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/debugsettings/llm/LlmTools.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 import mozilla.components.compose.base.button.FilledButton
 import mozilla.components.concept.llm.CloudLlmProvider.State
@@ -71,15 +72,9 @@ private fun ReadyState(
             onClick = {
                 scope.launch {
                     llmResponse = ""
-                    llm.prompt(Prompt("Hello World")).collect { response ->
-                        when (response) {
-                            is Llm.Response.Failure -> {
-                                llmResponse = "There was a problem. Error code: ${response.exception.errorCode}"
-                            }
-                            is Llm.Response.Success.ReplyPart -> llmResponse += response.value
-                            else -> {}
-                        }
-                    }
+                    llm.prompt(Prompt("Hello World"))
+                        .catch { llmResponse = "There was a problem. Error: ${it.message ?: "Unknown"}" }
+                        .collect { llmResponse += it }
                 }
             },
         )

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/summarization/SummarizationStoreViewModel.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/summarization/SummarizationStoreViewModel.kt
@@ -13,6 +13,7 @@ import mozilla.components.feature.summarize.ErrorReporter
 import mozilla.components.feature.summarize.SummarizationMiddleware
 import mozilla.components.feature.summarize.SummarizationState
 import mozilla.components.feature.summarize.SummarizationStore
+import mozilla.components.feature.summarize.content.ContentProvider
 import mozilla.components.feature.summarize.content.PageContentExtractor
 import mozilla.components.feature.summarize.content.PageMetadataExtractor
 import mozilla.components.feature.summarize.settings.SummarizationSettings
@@ -47,8 +48,7 @@ class SummarizationStoreViewModel(
             SummarizationMiddleware(
                 settings = settings,
                 llmProvider = llmProvider,
-                pageContentExtractor = pageContentExtractor,
-                pageMetadataExtractor = pageMetadataExtractor,
+                contentProvider = ContentProvider.fromPage(pageContentExtractor, pageMetadataExtractor),
                 errorReporter = errorReporter,
                 scope = viewModelScope,
             ),

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/summarization/SummarizationTelemetryMiddleware.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/summarization/SummarizationTelemetryMiddleware.kt
@@ -8,8 +8,9 @@ import mozilla.components.concept.llm.Llm
 import mozilla.components.feature.summarize.ContentExtracted
 import mozilla.components.feature.summarize.OffDeviceSummarizationShakeConsentAction
 import mozilla.components.feature.summarize.OnDeviceSummarizationShakeConsentAction
-import mozilla.components.feature.summarize.ReceivedLlmResponse
 import mozilla.components.feature.summarize.SummarizationAction
+import mozilla.components.feature.summarize.SummarizationCompleted
+import mozilla.components.feature.summarize.SummarizationFailed
 import mozilla.components.feature.summarize.SummarizationRequested
 import mozilla.components.feature.summarize.SummarizationState
 import mozilla.components.feature.summarize.ViewAppeared
@@ -77,7 +78,8 @@ class SummarizationTelemetryMiddleware(
                 sessionTelemetry = sessionTelemetry.copy(model = action.info.nameRes.toString())
             }
             is ContentExtracted -> handleExtractedContent(action)
-            is ReceivedLlmResponse -> handleReceivedResponse(action)
+            is SummarizationCompleted -> recordSummarizationCompleted()
+            is SummarizationFailed -> recordSummarizationCompleted(success = false, action.throwable.errorType)
             ViewDismissed -> {
                 AiSummarize.closed.record(
                     AiSummarize.ClosedExtra(
@@ -148,23 +150,7 @@ class SummarizationTelemetryMiddleware(
         )
     }
 
-    private fun handleReceivedResponse(action: ReceivedLlmResponse) {
-        when (action.response) {
-            is Llm.Response.Success.ReplyFinished -> {
-                recordSummarizationCompleted(success = true, errorType = null)
-            }
-            is Llm.Response.Failure -> {
-                recordSummarizationCompleted(
-                    success = false,
-                    errorType = (action.response as? Llm.Response.Failure)
-                        ?.exception?.errorCode?.value?.toString(),
-                )
-            }
-            else -> {}
-        }
-    }
-
-    private fun recordSummarizationCompleted(success: Boolean, errorType: String?) {
+    private fun recordSummarizationCompleted(success: Boolean = true, errorType: String? = null) {
         timerId?.let {
             AiSummarize.duration.stopAndAccumulate(it)
             timerId = null
@@ -185,3 +171,5 @@ class SummarizationTelemetryMiddleware(
         )
     }
 }
+
+private val Throwable.errorType get() = (this as? Llm.Exception)?.errorCode?.value?.toString()

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/summarization/SummarizationTelemetryMiddleware.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/summarization/SummarizationTelemetryMiddleware.kt
@@ -15,6 +15,7 @@ import mozilla.components.feature.summarize.SummarizationRequested
 import mozilla.components.feature.summarize.SummarizationState
 import mozilla.components.feature.summarize.ViewAppeared
 import mozilla.components.feature.summarize.ViewDismissed
+import mozilla.components.feature.summarize.content.Content
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.Store
 import mozilla.telemetry.glean.GleanTimerId
@@ -77,7 +78,7 @@ class SummarizationTelemetryMiddleware(
             is SummarizationRequested -> {
                 sessionTelemetry = sessionTelemetry.copy(model = action.info.nameRes.toString())
             }
-            is ContentExtracted -> handleExtractedContent(action)
+            is ContentExtracted -> handleExtractedContent(action.content)
             is SummarizationCompleted -> recordSummarizationCompleted()
             is SummarizationFailed -> recordSummarizationCompleted(success = false, action.throwable.errorType)
             ViewDismissed -> {
@@ -130,13 +131,13 @@ class SummarizationTelemetryMiddleware(
         }
     }
 
-    private fun handleExtractedContent(action: ContentExtracted) {
+    private fun handleExtractedContent(content: Content) {
         sessionTelemetry = sessionTelemetry.copy(
             contentMetrics = ContentMetrics(
-                wordCount = action.pageMetadata.wordCount,
-                charCount = action.charCount,
-                contentType = action.pageMetadata.structuredDataTypes.toString(),
-                language = action.pageMetadata.language,
+                wordCount = content.metadata.wordCount,
+                charCount = content.body.length,
+                contentType = content.metadata.structuredDataTypes.toString(),
+                language = content.metadata.language,
             ),
         )
         AiSummarize.started.record(

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/summarization/SummarizationTelemetryMiddleware.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/summarization/SummarizationTelemetryMiddleware.kt
@@ -133,10 +133,10 @@ class SummarizationTelemetryMiddleware(
     private fun handleExtractedContent(action: ContentExtracted) {
         sessionTelemetry = sessionTelemetry.copy(
             contentMetrics = ContentMetrics(
-                wordCount = action.pageMetadata?.wordCount ?: -1,
-                charCount = action.content.length,
-                contentType = action.pageMetadata?.structuredDataTypes?.toString(),
-                language = action.pageMetadata?.language ?: "",
+                wordCount = action.pageMetadata.wordCount,
+                charCount = action.charCount,
+                contentType = action.pageMetadata.structuredDataTypes.toString(),
+                language = action.pageMetadata.language,
             ),
         )
         AiSummarize.started.record(

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/summarization/SummarizationTelemetryMiddlewareTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/summarization/SummarizationTelemetryMiddlewareTest.kt
@@ -18,6 +18,7 @@ import mozilla.components.feature.summarize.SummarizationRequested
 import mozilla.components.feature.summarize.SummarizationState
 import mozilla.components.feature.summarize.ViewAppeared
 import mozilla.components.feature.summarize.ViewDismissed
+import mozilla.components.feature.summarize.content.Content
 import mozilla.components.feature.summarize.content.PageMetadata
 import mozilla.components.lib.state.Store
 import mozilla.components.support.test.robolectric.testContext
@@ -241,10 +242,7 @@ class SummarizationTelemetryMiddlewareTest {
     private fun createContentExtractedAction(
         content: String = "test content",
         pageMetadata: PageMetadata = PageMetadata(),
-    ) = ContentExtracted(
-        pageMetadata = pageMetadata,
-        charCount = content.length
-    )
+    ) = ContentExtracted(Content(pageMetadata, content))
 
     private fun invokeMiddleware(action: SummarizationAction) {
         middleware(

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/summarization/SummarizationTelemetryMiddlewareTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/summarization/SummarizationTelemetryMiddlewareTest.kt
@@ -240,12 +240,10 @@ class SummarizationTelemetryMiddlewareTest {
 
     private fun createContentExtractedAction(
         content: String = "test content",
-        pageMetadata: PageMetadata? = null,
+        pageMetadata: PageMetadata = PageMetadata(),
     ) = ContentExtracted(
-        instructions = "summarize this",
-        content = content,
         pageMetadata = pageMetadata,
-        llm = mockk(relaxed = true),
+        charCount = content.length
     )
 
     private fun invokeMiddleware(action: SummarizationAction) {

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/summarization/SummarizationTelemetryMiddlewareTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/summarization/SummarizationTelemetryMiddlewareTest.kt
@@ -11,8 +11,9 @@ import mozilla.components.concept.llm.Llm
 import mozilla.components.concept.llm.LlmProvider
 import mozilla.components.feature.summarize.ContentExtracted
 import mozilla.components.feature.summarize.OffDeviceSummarizationShakeConsentAction
-import mozilla.components.feature.summarize.ReceivedLlmResponse
 import mozilla.components.feature.summarize.SummarizationAction
+import mozilla.components.feature.summarize.SummarizationCompleted
+import mozilla.components.feature.summarize.SummarizationFailed
 import mozilla.components.feature.summarize.SummarizationRequested
 import mozilla.components.feature.summarize.SummarizationState
 import mozilla.components.feature.summarize.ViewAppeared
@@ -111,13 +112,11 @@ class SummarizationTelemetryMiddlewareTest {
     }
 
     @Test
-    fun `WHEN Llm Reply is received THEN summarization_completed is recorded with success true`() {
+    fun `WHEN SummarizationCompleted is received THEN summarization_completed is recorded with success true`() {
         assertNull(AiSummarize.completed.testGetValue())
 
         setupFullSession()
-        invokeMiddleware(
-            ReceivedLlmResponse(Llm.Response.Success.ReplyFinished),
-        )
+        invokeMiddleware(SummarizationCompleted)
 
         val snapshot = AiSummarize.completed.testGetValue()!!
         assertEquals(1, snapshot.size)
@@ -131,14 +130,12 @@ class SummarizationTelemetryMiddlewareTest {
     }
 
     @Test
-    fun `WHEN Failure response is received THEN summarization_completed is recorded with success false`() {
+    fun `WHEN SummarizationFailed is received THEN summarization_completed is recorded with success false`() {
         assertNull(AiSummarize.completed.testGetValue())
 
         setupFullSession()
         val exception = Llm.Exception("Error", ErrorCode(1001))
-        invokeMiddleware(
-            ReceivedLlmResponse(Llm.Response.Failure(exception)),
-        )
+        invokeMiddleware(SummarizationFailed(exception))
 
         val snapshot = AiSummarize.completed.testGetValue()!!
         assertEquals(1, snapshot.size)
@@ -216,21 +213,17 @@ class SummarizationTelemetryMiddlewareTest {
         assertNull(AiSummarize.duration.testGetValue())
 
         setupFullSession()
-        invokeMiddleware(
-            ReceivedLlmResponse(Llm.Response.Success.ReplyFinished),
-        )
+        invokeMiddleware(SummarizationCompleted)
 
         assertNotNull(AiSummarize.duration.testGetValue())
     }
 
     @Test
-    fun `GIVEN cellular connection WHEN summarization completes THEN connection_type is CELLULAR`() {
+    fun `GIVEN cellular connection WHEN SummarizationCompleted THEN connection_type is CELLULAR`() {
         middleware = SummarizationTelemetryMiddleware(ConnectionType.CELLULAR)
 
         setupFullSession()
-        invokeMiddleware(
-            ReceivedLlmResponse(Llm.Response.Success.ReplyFinished),
-        )
+        invokeMiddleware(SummarizationCompleted)
 
         val extras = AiSummarize.completed.testGetValue()!!.first().extra!!
         assertEquals("CELLULAR", extras["connection_type"])


### PR DESCRIPTION
This patch does a few things:

1. Removes the `Llm.Response` abstraction and leans on `Flow`.
2. Cleans up the content extracted action for the telemetry middleware
3. Pulls the business logic for observing the `Llm` and `LlmProvider` into extensions to clean up the `SummarizationMiddleware`