### PR TITLE
Bug 2028367: Add back button.

### DIFF
--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/BrickPattern.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/BrickPattern.kt
@@ -8,7 +8,6 @@ package org.mozilla.fenix.longfox
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.unit.dp
 
@@ -27,7 +26,7 @@ internal fun DrawScope.brickPattern() {
     val brickHeight = 10.dp.toPx()
     val mortarWidth = 2.dp.toPx()
     val halfBrickWidth: Float = brickWidth / 2
-    drawRect(color = Color.Gray)
+    drawRect(color = LongFoxColors.mortarColor)
 
     // draw bricks
     var y = 0f
@@ -36,7 +35,7 @@ internal fun DrawScope.brickPattern() {
         var x = if (row % 2 == 0) 0f else -halfBrickWidth
         while (x < size.width) {
             drawRect(
-                color = Color.Blue,
+                color = LongFoxColors.brickColor,
                 topLeft = Offset(x, y),
                 size = Size(brickWidth, brickHeight)
             )

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/GameCanvas.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/GameCanvas.kt
@@ -93,8 +93,8 @@ fun GameCanvas(state: GameState) {
 
     Canvas(
         modifier = Modifier
-            .background(color = Color.Black)
-            .border(1.dp, Color.Gray)
+            .background(color = LongFoxColors.backgroundColor)
+            .border(1.dp, LongFoxColors.mortarColor)
             .size((CELL_SIZE_DP * state.numCells).dp),
     ) {
         drawHead(state, kitHead)

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/LongFoxColors.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/LongFoxColors.kt
@@ -1,0 +1,18 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.mozilla.fenix.longfox
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * An object to encapsulate the colours used in this game.
+ */
+object LongFoxColors {
+    val backgroundColor: Color = Color.Black
+    val mortarColor: Color = Color(0xFF52525E)
+    val brickColor: Color = Color(0xFF073072)
+}

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/LongFoxGameScreen.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/LongFoxGameScreen.kt
@@ -6,16 +6,23 @@
 
 package org.mozilla.fenix.longfox
 
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -29,7 +36,9 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.mozilla.fenix.longfox.GameState.Companion.CELL_SIZE_DP
@@ -130,8 +139,25 @@ fun LongFoxGameScreen() {
                 active = gameState.justEaten,
             )
         }
-        if (!gameState.isGameOver) {
-            ScoreContainer(gameState.score)
+        Row(modifier = Modifier
+            .padding(12.dp)
+            .fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+            Image(
+                painter = painterResource(id = R.drawable.outline_arrow_back_24),
+                modifier = Modifier
+                    .padding(top = 12.dp, bottom = 12.dp, end = 12.dp)
+                    .clickable {
+                        onBackPressedDispatcher?.onBackPressed()
+                    },
+                contentDescription = "back" // TODO add string
+            )
+            if (gameState.score > 0) {
+                ScoreContainer(gameState.score)
+            }
         }
     }
 }

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/NewGameScreen.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/NewGameScreen.kt
@@ -6,7 +6,6 @@
 
 package org.mozilla.fenix.longfox
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -84,8 +83,7 @@ fun NewGameScreen(
     Box(
         modifier = Modifier
             .size((CELL_SIZE_DP * gameState.numCells).dp)
-            .background(Color.DarkGray)
-            .border(1.dp, Color.Gray)
+            .border(1.dp, LongFoxColors.mortarColor)
             .clickable { startGame() },
     ) {
         GameCanvas(

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/ScoreContainer.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/ScoreContainer.kt
@@ -8,7 +8,6 @@ package org.mozilla.fenix.longfox
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,8 +27,7 @@ import androidx.compose.ui.unit.sp
 fun ScoreContainer(score: Int) {
     Box(
         modifier = Modifier
-            .offset(12.dp, 12.dp)
-            .background(Color.Black)
+            .background(LongFoxColors.backgroundColor)
             .padding(8.dp)
         ,
         contentAlignment = Alignment.Center,
@@ -38,7 +36,7 @@ fun ScoreContainer(score: Int) {
             text = stringResource(R.string.score, score),
             color = Color.White,
             fontWeight = FontWeight.Bold,
-            fontSize = 28.sp,
+            fontSize = 24.sp,
         )
     }
 }

--- a/mobile/android/fenix/app/longfox/src/main/res/drawable/outline_arrow_back_24.xml
+++ b/mobile/android/fenix/app/longfox/src/main/res/drawable/outline_arrow_back_24.xml
@@ -1,0 +1,15 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:autoMirrored="true"
+    android:height="24dp"
+    android:viewportHeight="960"
+    android:viewportWidth="960"
+    android:width="24dp">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M313,520L537,744L480,800L160,480L480,160L537,216L313,440L800,440L800,520L313,520Z" />
+
+</vector>


### PR DESCRIPTION
- also darken the bricks so it has enough contrast to be visible
- extract some colours
- move the score to the opposite corner
- also leave the score in place on the new game screen if it is more than zero, so people can admire their last score

<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/6010bb0f-111a-4b79-8085-ac8e94a28019" />

[try is here](https://treeherder.mozilla.org/jobs?repo=try&revision=aa02d5e0b0fc925de3ce6dbad49aed1d4205b068)