### PR TITLE
Bug 2029590 - Removes the NEW label from summarize page when disabled

### DIFF
--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/components/menu/compose/MoreSettingsSubmenu.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/components/menu/compose/MoreSettingsSubmenu.kt
@@ -144,6 +144,13 @@ private fun SummarizationMenuItem(
         } else {
             MenuItemState.DISABLED
         }
+
+        val containerColor = if (summarizationMenuState.enabled) {
+            MaterialTheme.colorScheme.information
+        } else {
+            MaterialTheme.colorScheme.information.copy(alpha = 0.38f)
+        }
+
         MenuItem(
             label = stringResource(id = R.string.browser_menu_summarize_page),
             labelModifier = Modifier.wrapContentWidth(),
@@ -154,7 +161,7 @@ private fun SummarizationMenuItem(
             afterContent = {
                 if (summarizationMenuState.showNewFeatureBadge) {
                     StatusBadge(
-                        containerColor = MaterialTheme.colorScheme.information,
+                        containerColor = containerColor,
                         contentColor = MaterialTheme.colorScheme.onPrimary,
                         status = stringResource(R.string.browser_menu_summarize_page_badge),
                     )

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/compose/list/ListItem.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/compose/list/ListItem.kt
@@ -330,7 +330,7 @@ fun IconListItem(
         contentPadding = contentPaddingListItem,
         beforeListItemAction = {
             IconListItemBeforeIcon(
-                isHighlighted = isBeforeIconHighlighted,
+                isHighlighted = enabled && isBeforeIconHighlighted,
                 painter = beforeIconPainter,
                 description = beforeIconDescription,
                 tint = if (enabled) beforeIconTint else colors.disabledLeadingIconColor,


### PR DESCRIPTION
The badge color is hard coded deeper in the compose tree so I opted to remove it if summarization is disabled.

<img width="1080" height="2092" alt="image" src="https://github.com/user-attachments/assets/2f31d77f-8dea-42ce-8b6a-dedaa7d26e5c" />
