### PR TITLE
Bug 2029606 - Removes leading and trailing insets for the summarization fragment

### DIFF
--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/summarization/SummarizationFragment.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/summarization/SummarizationFragment.kt
@@ -143,7 +143,7 @@ class SummarizationFragment : BottomSheetDialogFragment() {
                 ViewCompat.setOnApplyWindowInsetsListener(bottomSheet) { view, insets ->
                     // edge-to-edge workaround
                     // exclude the bottom insets so that we can handle the insets in compose
-                    view.setPadding(insets.left(), insets.top(), insets.right(), 0)
+                    view.setPadding(0, insets.top(), 0, 0)
                     insets
                 }
                 bottomSheet.setBackgroundResource(android.R.color.transparent)


### PR DESCRIPTION
<img width="1182" height="701" alt="image" src="https://github.com/user-attachments/assets/3708bf12-eff7-460d-8f04-f46688a8a04e" />
