### PR TITLE
Bug 2029610 - Changes the color of the Firefox logo on the summarization loading screen

### DIFF
--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/ui/SummarizingContent.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/ui/SummarizingContent.kt
@@ -102,7 +102,7 @@ internal fun SummarizingContent(
             painter = painterResource(id = iconsR.drawable.mozac_ic_logo_firefox_24),
             contentDescription = null,
             modifier = Modifier.size(48.dp),
-            tint = contentColor,
+            tint = MaterialTheme.colorScheme.onPrimary,
         )
 
         Text(


### PR DESCRIPTION
<img width="304" height="710" alt="image" src="https://github.com/user-attachments/assets/44e56d28-82cd-45f8-aa5f-882957d17602" />
