### PR TITLE
chore(ci): make all try tasks emit structured logs

### DIFF
--- a/js/src/tests/lib/jittests.py
+++ b/js/src/tests/lib/jittests.py
@@ -562,12 +562,8 @@ def print_automation_format(ok, res, slog):
     # INFO stdout          > baz
     # INFO stderr         2> TypeError: or something
     # TEST-UNEXPECTED-FAIL | jit_test.py: Test execution interrupted by user
-    result = "TEST-PASS" if ok else "TEST-UNEXPECTED-FAIL"
     message = "Success" if ok else res.describe_failure()
     jitflags = " ".join(res.test.jitflags)
-    print(
-        f'{result} | {res.test.relpath_top} | {message} (code {res.rc}, args "{jitflags}") [{res.dt:.1f} s]'
-    )
 
     details = {
         "message": message,
@@ -579,26 +575,44 @@ def print_automation_format(ok, res, slog):
         details["extra"].update(res.extra)
     slog.test(res.test.relpath_tests, "PASS" if ok else "FAIL", res.dt, **details)
 
+    if not slog.stdout:
+        result = "TEST-PASS" if ok else "TEST-UNEXPECTED-FAIL"
+        print(
+            f'{result} | {res.test.relpath_top} | {message} (code {res.rc}, args "{jitflags}") [{res.dt:.1f} s]'
+        )
+
     # For failed tests, print as much information as we have, to aid debugging.
     if ok:
         return
-    print(f"INFO exit-status     : {res.rc}")
-    print(f"INFO timed-out       : {res.timed_out}")
-    warnings = []
-    for line in res.out.splitlines():
-        # See Bug 1868693
-        if line.startswith("WARNING") and "unused DT entry" in line:
-            warnings.append(line)
-            continue
-        print("INFO stdout          > " + line.strip())
-    for line in res.err.splitlines():
-        # See Bug 1868693
-        if line.startswith("WARNING") and "unused DT entry" in line:
-            warnings.append(line)
-            continue
-        print("INFO stderr         2> " + line.strip())
-    for line in warnings:
-        print("INFO (warn-stderr)  2> " + line.strip())
+    if slog.stdout:
+        slog.log_info(f"exit-status: {res.rc}")
+        slog.log_info(f"timed-out: {res.timed_out}")
+        for line in res.out.splitlines():
+            if line.startswith("WARNING") and "unused DT entry" in line:
+                continue
+            slog.log_info("stdout: " + line.strip())
+        for line in res.err.splitlines():
+            if line.startswith("WARNING") and "unused DT entry" in line:
+                continue
+            slog.log_info("stderr: " + line.strip())
+    else:
+        print(f"INFO exit-status     : {res.rc}")
+        print(f"INFO timed-out       : {res.timed_out}")
+        warnings = []
+        for line in res.out.splitlines():
+            # See Bug 1868693
+            if line.startswith("WARNING") and "unused DT entry" in line:
+                warnings.append(line)
+                continue
+            print("INFO stdout          > " + line.strip())
+        for line in res.err.splitlines():
+            # See Bug 1868693
+            if line.startswith("WARNING") and "unused DT entry" in line:
+                warnings.append(line)
+                continue
+            print("INFO stderr         2> " + line.strip())
+        for line in warnings:
+            print("INFO (warn-stderr)  2> " + line.strip())
 
 
 def print_test_summary(num_tests, failures, complete, slow_tests, doing, options):
@@ -768,10 +782,17 @@ def process_test_results(results, num_tests, pb, options, slog):
     return print_test_summary(num_tests, failures, complete, slow_tests, doing, options)
 
 
+def _is_try():
+    repo = os.environ.get("GECKO_HEAD_REPOSITORY", "")
+    if "try" in repo:
+        return True
+    return "TRY_COMMIT_MSG" in os.environ
+
+
 def run_tests(tests, num_tests, prefix, options, remote=False):
     slog = None
     if options.format == "automation":
-        slog = TestLogger("jittests")
+        slog = TestLogger("jittests", stdout=_is_try())
         slog.suite_start()
 
     if remote:

--- a/js/src/tests/lib/structuredlog.py
+++ b/js/src/tests/lib/structuredlog.py
@@ -7,7 +7,7 @@ from time import time
 
 
 class TestLogger:
-    def __init__(self, source, threadname="main"):
+    def __init__(self, source, threadname="main", stdout=False):
         self.template = {
             "source": source,
             "thread": threadname,
@@ -15,6 +15,7 @@ class TestLogger:
         }
         directory = os.environ.get("MOZ_UPLOAD_DIR", ".")
         self.fh = open(os.path.join(directory, threadname + "_raw.log"), "a")
+        self.stdout = stdout
 
     def _record(self, **kwargs):
         record = self.template.copy()
@@ -24,7 +25,10 @@ class TestLogger:
         return record
 
     def _log_obj(self, obj):
-        print(json.dumps(obj, sort_keys=True), file=self.fh)
+        line = json.dumps(obj, sort_keys=True)
+        print(line, file=self.fh)
+        if self.stdout:
+            print(line)
 
     def _log(self, **kwargs):
         self._log_obj(self._record(**kwargs))

--- a/testing/mozharness/mozharness/mozilla/testing/testbase.py
+++ b/testing/mozharness/mozharness/mozilla/testing/testbase.py
@@ -486,8 +486,16 @@ You can set this by specifying --test-url URL
         )
         self.download_unpack(self.test_url, test_install_dir, extract_dirs=extract_dirs)
 
+    def _is_try(self):
+        branch = self.config.get("branch", "")
+        if branch and ("try" in branch or "Try" in branch):
+            return True
+        return "TRY_COMMIT_MSG" in os.environ
+
     def structured_output(self, suite_category):
         unstructured_suites = self.config.get("unstructured_suites", [])
+        if suite_category in unstructured_suites and self._is_try():
+            return True
         return suite_category not in unstructured_suites
 
     def get_test_output_parser(

--- a/testing/mozharness/scripts/desktop_unittest.py
+++ b/testing/mozharness/scripts/desktop_unittest.py
@@ -964,6 +964,8 @@ class DesktopUnittest(TestingMixin, MercurialScript, MozbaseMixin, CodeCoverageM
         if not unstructured_flavors.get(
             suite_category
         ) or flavor in unstructured_flavors.get(suite_category):
+            if self._is_try():
+                return True
             return False
         return True
 


### PR DESCRIPTION
TestLogger supports optional stdout output
- New stdout parameter (default False)
- When True, JSON lines are printed to stdout in addition to the log file

Structured stdout only on try
- Added _is_try() helper that checks GECKO_HEAD_REPOSITORY and TRY_COMMIT_MSG env vars
- run_tests passes stdout=_is_try() to TestLogger
- print_automation_format suppresses unstructured TEST-PASS/TEST-UNEXPECTED-FAIL text when slog.stdout is active, and emits failure details as structured log_info actions instead

