### PR TITLE
Bug 2030739 - Hides the error code until a user long presses the error icon

### DIFF
--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/ui/InfoError.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/ui/InfoError.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.summarize.ui
 
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,8 +15,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -30,11 +36,15 @@ internal fun InfoError(
     modifier: Modifier = Modifier,
     errorCode: ErrorCode,
 ) {
+    var showErrorCode by remember { mutableStateOf(false) }
+
     Column(modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         Icon(
             painter = painterResource(mozilla.components.ui.icons.R.drawable.mozac_ic_warning_fill_24),
             contentDescription = null,
-            modifier = Modifier.padding(end = 8.dp),
+            modifier = Modifier
+                .padding(end = 8.dp)
+                .onLongPress { showErrorCode = true },
         )
 
         Spacer(modifier = Modifier.height(AcornTheme.layout.space.static300))
@@ -49,13 +59,29 @@ internal fun InfoError(
         Spacer(modifier = Modifier.height(AcornTheme.layout.space.static100))
 
         Text(
-            text = stringResource(R.string.mozac_summarize_info_error_message, errorCode.value),
+            text = stringResource(R.string.mozac_summarize_info_error_message),
             style = AcornTheme.typography.body2,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
         )
 
+        if (showErrorCode) {
+            Text(
+                text = stringResource(R.string.mozac_summarize_info_error_code, errorCode.value),
+                style = AcornTheme.typography.body2,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+
         Spacer(modifier = Modifier.height(AcornTheme.layout.space.static200))
+    }
+}
+
+@Composable
+private fun Modifier.onLongPress(onLongPress: () -> Unit): Modifier {
+    return this.pointerInput(Unit) {
+        detectTapGestures(onLongPress = { onLongPress() })
     }
 }
 

--- a/mobile/android/android-components/components/feature/summarize/src/main/res/values/static_strings.xml
+++ b/mobile/android/android-components/components/feature/summarize/src/main/res/values/static_strings.xml
@@ -81,8 +81,11 @@
     <!-- Title for the info error screen -->
     <string name="mozac_summarize_info_error_title">Can’t summarize right now</string>
 
-    <!-- Generic fallback message for the info error screen. %1$d is an error code. -->
-    <string name="mozac_summarize_info_error_message">Try again later. Error code: %1$d</string>
+    <!-- Generic fallback message for the info error screen -->
+    <string name="mozac_summarize_info_error_message">Try again later.</string>
+
+    <!-- Error code shown on long press of the error icon. %1$d is an error code. -->
+    <string name="mozac_summarize_info_error_code">Error code: %1$d</string>
 
     <!-- Loading text displayed while a page summary is being generated -->
     <string name="mozac_feature_summarize_loading_title" translatable="false">Summarizing…</string>


### PR DESCRIPTION
<img width="1080" height="2092" alt="image" src="https://github.com/user-attachments/assets/2bf05e20-eeaa-4eba-b16b-a31618371da8" />
