### PR TITLE
Bug 2030791 - Uses `settings.shouldShowVoiceSearch` to control voice search

### DIFF
--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/intent/AssistIntentProcessor.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/intent/AssistIntentProcessor.kt
@@ -28,7 +28,7 @@ class AssistIntentProcessor : HomeIntentProcessor {
                 directions = NavGraphDirections.actionGlobalHome(
                     searchAccessPoint = MetricsUtils.Source.DIGITAL_ASSISTANT,
                     focusOnAddressBar = true,
-                    startVoiceSearch = true,
+                    startVoiceSearch = settings.shouldShowVoiceSearch,
                 ),
             )
         } else {

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/intent/AssistIntentProcessorTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/intent/AssistIntentProcessorTest.kt
@@ -68,6 +68,8 @@ class AssistIntentProcessorTest {
     @Test
     fun `GIVEN an intent with ACTION_ASSIST action WHEN it is processed THEN navigate to the new search UX`() {
         every { settings.shouldUseComposableToolbar } returns true
+        every { settings.shouldShowVoiceSearch } returns true
+
         val intent = Intent().apply {
             action = Intent.ACTION_ASSIST
         }
@@ -81,6 +83,32 @@ class AssistIntentProcessorTest {
                     sessionToStartSearchFor = null,
                     focusOnAddressBar = true,
                     startVoiceSearch = true,
+                    searchAccessPoint = MetricsUtils.Source.DIGITAL_ASSISTANT,
+                ),
+                null,
+            )
+        }
+
+        verify { out wasNot Called }
+    }
+
+    @Test
+    fun `GIVEN an intent with ACTION_ASSIST action and voice search is disabled WHEN it is processed THEN startVoiceSearch should be false`() {
+        every { settings.shouldUseComposableToolbar } returns true
+        every { settings.shouldShowVoiceSearch } returns false
+        val intent = Intent().apply {
+            action = Intent.ACTION_ASSIST
+        }
+
+        AssistIntentProcessor().process(intent, navController, out, settings)
+
+        verify {
+            navController.navigate(
+                NavGraphDirections.actionGlobalHome(
+                    sessionToDelete = null,
+                    sessionToStartSearchFor = null,
+                    focusOnAddressBar = true,
+                    startVoiceSearch = false,
                     searchAccessPoint = MetricsUtils.Source.DIGITAL_ASSISTANT,
                 ),
                 null,


### PR DESCRIPTION
When an application is launched using the assist intent we don't want to show voice search if AI controls are enabled.