### PR TITLE
Fix tab-preview-panel firing duplicate popupshown events

### DIFF
--- a/browser/components/tabbrowser/content/tab-hover-preview.mjs
+++ b/browser/components/tabbrowser/content/tab-hover-preview.mjs
@@ -393,6 +393,10 @@ class TabPanel extends HoverPanel {
       this.panelElement.state == "open" ||
       this.panelElement.state == "showing"
     ) {
+      // Remove stale listener from previous activation to prevent
+      // duplicate popupshown events when moveToAnchor re-triggers
+      // the popup lifecycle during the "showing" state.
+      this.panelElement.removeEventListener("popupshowing", this);
       this.#updatePreview();
     } else {
       this.panelSet.panelOpener.execute(() => {


### PR DESCRIPTION
## Summary

`panel#tab-preview-panel` fires `popupshown` twice but `popuphidden` only once when the user hovers between tabs quickly while the preview panel is still opening (in `"showing"` state).

This causes Firefox's own sidebar `_hoverBlockerCount` in `browser-sidebar.js` to get permanently stuck (2 increments, 1 decrement), breaking sidebar autohide until the window is closed.

## Root Cause

In `tab-hover-preview.mjs`, `activate()` line 405 registers a `popupshowing` event listener when opening the panel. When the user hovers a different tab while the panel is still in `"showing"` state:

1. `activate(tabB)` is called
2. `moveToAnchor(tabB)` (line 385) re-triggers the popup lifecycle
3. The `popupshowing` listener from Tab A's activation is still registered
4. This causes a second `popupshown` event
5. Only one `popuphidden` fires when the panel closes

## Fix

Remove the stale `popupshowing` listener when re-activating on a different tab while the panel is in `"showing"` or `"open"` state. The listener is only needed for the initial open, and `onBeforeHide()` already removes it on close.

## Test

1. Enable sidebar with expand-on-hover
2. Enable tab hover previews
3. Hover Tab A, then quickly move to Tab B before the preview finishes opening
4. Move mouse away from sidebar
5. **Before fix:** sidebar stays open permanently
6. **After fix:** sidebar collapses normally