### PR TITLE
Bug 2034301 - Suppress GCC 16 pointer type mismatch warnings

### DIFF
--- a/media/ffvpx/libavcodec/moz.build
+++ b/media/ffvpx/libavcodec/moz.build
@@ -181,6 +181,10 @@ else:
   CXXFLAGS += CONFIG["MOZ_LIBVPX_CFLAGS"]
   OS_LIBS += CONFIG["MOZ_LIBVPX_LIBS"]
 
+# Vendored FFmpeg code has type mismatches between AVCodecParser/FFCodecParser
+# that GCC 16+ treats as errors.
+CFLAGS += ['-Wno-incompatible-pointer-types']
+
 SYMBOLS_FILE = 'avcodec.symbols'
 NoVisibilityFlags()
 


### PR DESCRIPTION
ref: https://bugzilla.mozilla.org/show_bug.cgi?id=2034301