### PR TITLE
Fix variable reference in ScanDominatorsForDefs

### DIFF
--- a/js/src/jit/ValueNumbering.cpp
+++ b/js/src/jit/ValueNumbering.cpp
@@ -217,7 +217,7 @@ static bool BlockHasInterestingDefs(MBasicBlock* block) {
 // which look potentially interesting to GVN.
 static bool ScanDominatorsForDefs(MBasicBlock* block) {
   for (MBasicBlock* i = block;;) {
-    if (BlockHasInterestingDefs(block)) {
+    if (BlockHasInterestingDefs(i)) {
       return true;
     }
 


### PR DESCRIPTION
Bug report:
https://bugzilla.mozilla.org/show_bug.cgi?id=2035965

The loop body uses the parameter block instead of the loop variable i:
```c
static bool ScanDominatorsForDefs(MBasicBlock* block) {
  for (MBasicBlock* i = block;;) {
    if (BlockHasInterestingDefs(block)) {  // <-- should be `i`
      return true;
    }
    MBasicBlock* immediateDominator = i->immediateDominator();
    if (immediateDominator == i) {
      break;
    }
    i = immediateDominator;
  }
  return false;
}
```
Although i is updated on each iteration, it is never used in the loop body.
As a result, the function is effectively equivalent to:

  return BlockHasInterestingDefs(block);
The intended dominator-chain traversal does not actually occur.

Expected results:

The loop should call BlockHasInterestingDefs(i), so that it correctly walks up
the dominator tree and checks each ancestor block.

This matches both the function comment:

"Walk up the dominator tree from block to the root and test for any defs"

and the behavior of the related two-argument overload.