### PR TITLE
Bug 2030079: Fix intermittent test failure.

### DIFF
--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/GameState.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/GameState.kt
@@ -157,6 +157,9 @@ data class GameState(
         return copy(direction = newDirection)
     }
 
+    /**
+     * Food can spawn anywhere except right next to the walls, because that's quite annoying
+     */
     private fun randomGridPoint(): GridPoint = GridPoint(
         Random.nextInt(from = 1, until = numCells - 1),
         Random.nextInt(from = 1, until = numCells - 1),

--- a/mobile/android/fenix/app/longfox/src/test/kotlin/org/mozilla/fenix/longfox/GameStateTest.kt
+++ b/mobile/android/fenix/app/longfox/src/test/kotlin/org/mozilla/fenix/longfox/GameStateTest.kt
@@ -316,10 +316,13 @@ class GameStateTest {
 
     @Test
     fun `food moves to new position after being eaten`() {
-        val food = GridPoint(5, 6)
+        // Placing the food at a position it would never naturally spawn at.
+        // Food is not allowed to spawn right next to a wall because it's a bit annoying if it does.
+        // This ensures that when it is eaten, there is no chance it will respawn in the same place.
+        val food = GridPoint(0, 0)
         val state = state(
-            direction = Direction.DOWN,
-            fox = listOf(GridPoint(5, 5), GridPoint(5, 4)),
+            direction = Direction.UP,
+            fox = listOf(GridPoint(0, 1), GridPoint(0, 2)),
             food = food,
         ).moveFox()
         assertNotEquals(food, state.food)


### PR DESCRIPTION
This test was non-deterministic - it went:
- place food
- have the fox eat the food
- respawn the food in a random place
- check that the food is in a different place now

But there was a chance the food would respawn in the same place again (: This can be fixed by initially placing the food outside of the area where it can spawn. There is a "safe zone" for that right up against the walls, because food doesn't naturally spawn there (it makes the game quite annoying to play if it does)