### PR TITLE
Bug 2030040: deal with web notification issue.

### DIFF
--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
@@ -47,6 +47,7 @@ class IntentReceiverActivity : Activity() {
         // assumes it is not. If it's null, then we make a new one and open
         // the HomeActivity.
         val intent = intent?.let { Intent(it) } ?: Intent()
+        intent.setExtrasClassLoader(classLoader)
         intent.sanitize().stripUnwantedFlags()
 
         // DO NOT MOVE the app link intent launch type setting below the super.onCreate call


### PR DESCRIPTION
According to Claude:

> Without this call, the Bundle uses the boot ClassLoader during unparceling — which doesn't know about app or GeckoView classes.