### PR TITLE
Bug 2000191: fix intermittent test failure caused by race condition.

### DIFF
--- a/mobile/android/android-components/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorageTest.kt
+++ b/mobile/android/android-components/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorageTest.kt
@@ -49,13 +49,14 @@ class SyncedTabsStorageTest {
         store = BrowserStore(
             BrowserState(
                 tabs = listOf(
-                    createTab(id = "tab1", url = "https://www.mozilla.org", lastAccess = 123L),
-                    createTab(id = "tab2", url = "https://www.foo.bar", lastAccess = 124L),
+                    createTab(id = "tab1", url = "https://www.mozilla.org", lastAccess = 123L, createdAt = 123L),
+                    createTab(id = "tab2", url = "https://www.foo.bar", lastAccess = 124L, createdAt = 124L),
                     createTab(
                         id = "private",
                         url = "https://private.tab",
                         private = true,
                         lastAccess = 125L,
+                        createdAt = 125L,
                     ),
                 ),
                 selectedTabId = "tab1",
@@ -264,8 +265,8 @@ class SyncedTabsStorageTest {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
-                    createTab(id = "tab1", url = "https://www.mozilla.org", lastAccess = 123L),
-                    createTab(id = "tab2", url = "https://www.foo.bar", lastAccess = 124L),
+                    createTab(id = "tab1", url = "https://www.mozilla.org", lastAccess = 123L, createdAt = 123L),
+                    createTab(id = "tab2", url = "https://www.foo.bar", lastAccess = 124L, createdAt = 124L),
                 ),
                 selectedTabId = "tab1",
             ),
@@ -305,8 +306,8 @@ class SyncedTabsStorageTest {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
-                    createUnloadedTab(id = "tab1", url = "https://www.mozilla.org", lastAccess = 123L),
-                    createUnloadedTab(id = "tab2", url = "https://www.foo.bar", lastAccess = 124L),
+                    createUnloadedTab(id = "tab1", url = "https://www.mozilla.org", lastAccess = 123L, createdAt = 123L),
+                    createUnloadedTab(id = "tab2", url = "https://www.foo.bar", lastAccess = 124L, createdAt = 124L),
                 ),
                 selectedTabId = "tab1",
             ),
@@ -373,8 +374,8 @@ class SyncedTabsStorageTest {
         val store = BrowserStore(
             BrowserState(
                 tabs = listOf(
-                    createTab(id = "tab1", url = "https://www.mozilla.org", lastAccess = 123L),
-                    createTab(id = "tab2", url = "https://www.foo.bar", lastAccess = 124L),
+                    createTab(id = "tab1", url = "https://www.mozilla.org", lastAccess = 123L, createdAt = 123L),
+                    createTab(id = "tab2", url = "https://www.foo.bar", lastAccess = 124L, createdAt = 124L),
                 ),
                 selectedTabId = "tab1",
             ),
@@ -409,7 +410,8 @@ class SyncedTabsStorageTest {
         )
     }
 
-    private fun createUnloadedTab(id: String, url: String, lastAccess: Long) = createTab(id = id, url = url, lastAccess = lastAccess).run {
-        copy(content = this.content.copy(loading = true))
-    }
+    private fun createUnloadedTab(id: String, url: String, lastAccess: Long, createdAt: Long = lastAccess) =
+        createTab(id = id, url = url, lastAccess = lastAccess, createdAt = createdAt).run {
+            copy(content = this.content.copy(loading = true))
+        }
 }


### PR DESCRIPTION
Root cause: [Bug 1879332](https://bugzilla.mozilla.org/show_bug.cgi?id=1879332) changed `TabSessionState.isActive()` to use `maxOf(lastAccess, createdAt)`.
Since createTab() defaulted `createdAt = System.currentTimeMillis()`, newly created test tabs have createdAt ≈ now. 
With `maxActiveTime = 0`, the check `now - createdAt <= 0` only returns false when at least 1ms has elapsed, making the result dependent on test execution speed.

Fix: Pass `createdAt = lastAccess` to all `createTab()` calls in tests that use `maxActiveTime = 0` and expect `inactive = true`. 
Since lastAccess values like 123L are epoch-old timestamps, `now - maxOf(123L, 123L)` is always a large positive number, so `isActive(0)` deterministically returns `false` regardless of when the test runs.