### PR TITLE
Bug 2042934 - When Last Tab is the Opening Screen setting, go back to the homepage if the homepage was the last screen the user was on.

### DIFF
--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -845,6 +845,7 @@ class HomeFragment : Fragment() {
         findNavController().addOnDestinationChangedListener(destinationChangedListener)
 
         subscribeToTabCollections()
+        updateLastHomeActivity()
 
         requireComponents.backgroundServices.accountManagerAvailableQueue.runIfReadyOrQueue {
             // By the time this code runs, we may not be attached to a context or have a view lifecycle owner.
@@ -980,6 +981,7 @@ class HomeFragment : Fragment() {
 
     override fun onStop() {
         super.onStop()
+        updateLastHomeActivity()
 
         findNavController().removeOnDestinationChangedListener(destinationChangedListener)
     }
@@ -1372,6 +1374,16 @@ class HomeFragment : Fragment() {
         }
 
         FxNimbus.features.homescreen.recordExposure()
+    }
+
+    /**
+     * Updates the last time the user was active on the [HomeFragment].
+     * This is useful to determine if the user has to start on the [HomeFragment]
+     * or it should go directly to the [BrowserFragment].
+     */
+    @VisibleForTesting
+    internal fun updateLastHomeActivity() {
+        requireContext().settings().lastHomeActivity = System.currentTimeMillis()
     }
 
     companion object {

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -877,6 +877,19 @@ class Settings(
         default = 0L,
     )
 
+    /**
+     * Indicates the last time when the user was interacting with the [HomeFragment],
+     * This is useful to determine if the user has to start on the [HomeFragment]
+     * or it should go directly to the [BrowserFragment].
+     *
+     * This value defaults to 0L because we want to know if the user never had any interaction
+     * with the [HomeFragment]
+     */
+    var lastHomeActivity by longPreference(
+        appContext.getPreferenceKey(R.string.pref_key_last_home_activity_time),
+        default = 0L,
+    )
+
     private val openingScreenDefault: OpeningScreenOption
         get() = FxNimbus.features.homepageOpeningScreenDefault.value().defaultOption
 
@@ -955,10 +968,22 @@ class Settings(
      */
     fun shouldStartOnHome(): Boolean {
         return when {
-            openHomepageAfterFourHoursOfInactivity -> timeNowInMillis() - lastBrowseActivity >= FOUR_HOURS_MS
-            alwaysOpenTheHomepageWhenOpeningTheApp -> true
-            alwaysOpenTheLastTabWhenOpeningTheApp -> false
-            else -> false
+            openHomepageAfterFourHoursOfInactivity -> {
+                timeNowInMillis() - lastBrowseActivity >= FOUR_HOURS_MS
+            }
+            alwaysOpenTheHomepageWhenOpeningTheApp -> {
+                true
+            }
+            alwaysOpenTheLastTabWhenOpeningTheApp -> {
+                if (lastHomeActivity > lastBrowseActivity) {
+                    true
+                } else {
+                    false
+                }
+            }
+            else -> {
+                false
+            }
         }
     }
 

--- a/mobile/android/fenix/app/src/main/res/values/preference_keys.xml
+++ b/mobile/android/fenix/app/src/main/res/values/preference_keys.xml
@@ -89,6 +89,7 @@
     <string name="pref_key_custom_review_prompt_enabled" translatable="false">pref_key_custom_review_prompt_enabled</string>
     <string name="pref_key_custom_review_prompt_ui_enabled" translatable="false">pref_key_custom_review_prompt_ui_enabled</string>
     <string name="pref_key_last_browse_activity_time" translatable="false">pref_key_last_browse_activity_time</string>
+    <string name="pref_key_last_home_activity_time" translatable="false">pref_key_last_home_activity_time</string>
     <string name="pref_key_last_cfr_shown_time" translatable="false">pref_key_last_cfr_shown_time</string>
     <string name="pref_key_is_first_run" translatable="false">pref_key_is_first_run</string>
     <string name="pref_key_is_first_splash_screen_shown" translatable="false">pref_key_is_first_splash_screen_shown</string>


### PR DESCRIPTION
[try](https://treeherder.mozilla.org/jobs?repo=try&landoInstance=lando-prod-2025&landoCommitID=50826)