### PR TITLE
Bug 2039559: Add glean lib & metrics for game launch and game length.

### DIFF
--- a/mobile/android/fenix/app/longfox/build.gradle
+++ b/mobile/android/fenix/app/longfox/build.gradle
@@ -25,6 +25,9 @@ android {
             includeAndroidResources = true
         }
     }
+    buildFeatures {
+        buildConfig true
+    }
 }
 
 dependencies {
@@ -42,6 +45,7 @@ dependencies {
     implementation libs.androidx.datastore.core
     implementation libs.androidx.datastore.preferences
     implementation libs.google.material
+    implementation libs.mozilla.glean
     testImplementation libs.junit4
     testImplementation platform(libs.androidx.compose.bom)
     testImplementation libs.androidx.compose.ui.test
@@ -54,3 +58,14 @@ dependencies {
     debugImplementation libs.androidx.compose.ui.tooling
     debugImplementation libs.androidx.compose.ui.test.manifest
 }
+
+// Generate Kotlin code for the Longfox module's Glean metrics.
+ext {
+    gleanExpireByVersion = Config.majorVersion(project)
+    gleanNamespace = "mozilla.telemetry.glean"
+    gleanPythonEnvDir = gradle.mozconfig.substs.GRADLE_GLEAN_PARSER_VENV
+    gleanYamlFiles = [
+            "${project.projectDir}/metrics.yaml",
+    ]
+}
+apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"

--- a/mobile/android/fenix/app/longfox/metrics.yaml
+++ b/mobile/android/fenix/app/longfox/metrics.yaml
@@ -1,0 +1,47 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+no_lint:
+  - CATEGORY_GENERIC
+
+longfox:
+  entry_point_shown:
+    type: event
+    description: Sent when the longfox entry point CTA is shown on the home page.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=2039559
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=2039559
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: never
+  game_launched:
+    type: event
+    description: Sent when the longfox game is launched (the entry point is clicked).
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=2039559
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=2039559
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: never
+  game_played_length:
+    type: timing_distribution
+    time_unit: millisecond
+    description: Sent when the longfox game is played.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=2039559
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=2039559
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: never

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/LongFoxFeature.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/LongFoxFeature.kt
@@ -11,6 +11,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import org.mozilla.fenix.longfox.GleanMetrics.Longfox
 
 /**
  * Defines the api for using Long Fox.
@@ -22,6 +23,11 @@ interface LongFoxFeatureApi {
      * @param container the view that you want to put the game in
      */
     fun start(container: ViewGroup)
+
+    /**
+     * Call this if you want to send a telemetry event when the entry point is shown.
+     */
+    fun onEntryPointShown()
 }
 
 /**
@@ -37,6 +43,7 @@ class LongFoxFeature : LongFoxFeatureApi {
      */
     override fun start(container: ViewGroup) {
         val context = container.context ?: return
+        Longfox.gameLaunched.record()
         container.addView(
             ComposeView(context).apply {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
@@ -51,5 +58,12 @@ class LongFoxFeature : LongFoxFeatureApi {
                 }
             },
         )
+    }
+
+    /**
+     * When the entry point is shown, send a glean telemetry event.
+     */
+    override fun onEntryPointShown() {
+        Longfox.entryPointShown.record()
     }
 }

--- a/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/LongFoxGameScreen.kt
+++ b/mobile/android/fenix/app/longfox/src/main/kotlin/org/mozilla/fenix/longfox/LongFoxGameScreen.kt
@@ -43,10 +43,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import mozilla.telemetry.glean.GleanTimerId
 import org.mozilla.fenix.longfox.GameState.Companion.CELL_SIZE_DP
 import org.mozilla.fenix.longfox.GameState.Companion.GAME_INTERVAL_TIME_MS
 import org.mozilla.fenix.longfox.GameState.Companion.MAX_JUST_EATEN_COUNTDOWN
 import org.mozilla.fenix.longfox.GameState.Companion.MAX_SCORE_CELEBRATION_COUNTDOWN
+import org.mozilla.fenix.longfox.GleanMetrics.Longfox
 
 /**
  * The main composable container for the game.
@@ -56,6 +58,7 @@ import org.mozilla.fenix.longfox.GameState.Companion.MAX_SCORE_CELEBRATION_COUNT
 fun LongFoxGameScreen() {
     var celebrationShown by remember { mutableStateOf(false) }
     var celebrationSeed by remember { mutableIntStateOf(0) }
+    var gleanTimerId: GleanTimerId? by remember { mutableStateOf(null) }
     GameBackground(celebrationShown, celebrationSeed) {
         // Make a square game grid that fits on the screen
         val density = LocalDensity.current.density
@@ -64,7 +67,10 @@ fun LongFoxGameScreen() {
         var gameState by remember(numCells) {
             mutableStateOf(GameState(numCells = numCells, size = Size(canvasSizePx, canvasSizePx), isGameOver = true))
         }
-        val restartGame = { gameState = GameState(numCells = numCells, size = Size(canvasSizePx, canvasSizePx)) }
+        val startGame = {
+            gleanTimerId = Longfox.gamePlayedLength.start()
+            gameState = GameState(numCells = numCells, size = Size(canvasSizePx, canvasSizePx))
+        }
         SideEffect {
             // this is to satisfy the IDE.
             // the warning seems to be a false positive with compose state
@@ -99,7 +105,12 @@ fun LongFoxGameScreen() {
             onDispose { soundEffectsPlayer.release() }
         }
         LaunchedEffect(gameState.isGameOver) {
-            if (gameState.isGameOver) soundEffectsPlayer.playSound(R.raw.sadwobble)
+            gleanTimerId?.also {
+                if (gameState.isGameOver) {
+                    soundEffectsPlayer.playSound(R.raw.sadwobble)
+                    Longfox.gamePlayedLength.stopAndAccumulate(it)
+                }
+            }
         }
         // This is the main game loop:
         // While the game is not over, wait a clock tick, move the fox and check for collisions.
@@ -158,7 +169,7 @@ fun LongFoxGameScreen() {
                     hiscore = hiscore,
                     soundOn = soundOn,
                     onToggleSoundOn = { coroutineScope.launch { longFoxDataStore.toggleSoundOn() } },
-                    startGame = restartGame,
+                    startGame = startGame,
                     shareHiscore = { coroutineScope.launch { longFoxDataStore.shareHiscore(it) }}
                 )
             } else {

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/logo/LogoControllerTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/logo/LogoControllerTest.kt
@@ -20,6 +20,7 @@ class LogoControllerTest {
         override fun start(container: ViewGroup) {
             started = true
         }
+        override fun onEntryPointShown() { }
     }
 
     class FakeViewGroup : ViewGroup(FakeContext()) {


### PR DESCRIPTION
- Also add the ability to record the entry point being shown into the longfox feature api (but not calling it anywhere yet)
- Rename `restartGame` to `startGame`, as it is called the first time the game is played as well as on subsequent occasions.

[here is a try](https://treeherder.mozilla.org/jobs?repo=try&revision=97f0ad3d8f8563262ddc7362d6bd5ca3e699536d)