### PR TITLE
Bug 2040784 - Introduce AIFeatureState to handle the "Unknown" states…

### DIFF
--- a/mobile/android/android-components/components/concept/ai-controls/src/main/java/mozilla/components/concept/ai/controls/AIControllableFeature.kt
+++ b/mobile/android/android-components/components/concept/ai-controls/src/main/java/mozilla/components/concept/ai/controls/AIControllableFeature.kt
@@ -6,6 +6,11 @@ package mozilla.components.concept.ai.controls
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.update
+import mozilla.components.concept.ai.controls.AIFeatureState.Disabled
+import mozilla.components.concept.ai.controls.AIFeatureState.Enabled
+import mozilla.components.concept.ai.controls.AIFeatureState.Unknown
 
 /**
  * Metadata defining an AI Feature.
@@ -31,10 +36,38 @@ interface AIFeatureMetadata {
 }
 
 /**
+ * Describes the state of the AI feature. Represents all the possible states as
+ * [Enabled], [Disabled] and [Unknown].
+ */
+sealed class AIFeatureState {
+
+    /**
+     * Describes the state when the AI feature has been enabled.
+     */
+    object Enabled : AIFeatureState()
+
+    /**
+     * Describes the state where the AI feature has been disabled.
+     */
+    object Disabled : AIFeatureState()
+
+    /**
+     * Describes the state where it is not known if the AI feature is enabled or disabled.
+     * This state is likely to occur if we check the AI controls state before the underlying
+     * AI feature is able to say whether it's enabled or not.
+     *
+     * Because it is possible for the [AIFeatureBlock.isBlocked] to be true, for a specific feature
+     * to be turned on, we need to know if that feature is explicitly turned on or if the user
+     * has simply never interacted with the AI controls, and that is when this comes in handy.
+     */
+    object Unknown : AIFeatureState()
+}
+
+/**
  * A feature that can be enabled or disabled by AI controls.
  */
 interface AIControllableFeature : AIFeatureMetadata {
-    val isEnabled: Flow<Boolean>
+    val featureState: Flow<AIFeatureState>
 
     /**
      * Enables or disables this feature.
@@ -48,20 +81,38 @@ interface AIControllableFeature : AIFeatureMetadata {
         fun inMemory(
             id: AIFeatureMetadata.FeatureId = AIFeatureMetadata.FeatureId("inMemory"),
             description: AIFeatureMetadata.Description = AIFeatureMetadata.Description(0, 0, 0),
-            initialEnabled: Boolean = false,
-        ): AIControllableFeature = InMemoryAIControllableFeature(id, description, initialEnabled)
+            initialFeatureState: AIFeatureState = AIFeatureState.Unknown,
+        ): AIControllableFeature = InMemoryAIControllableFeature(id, description, initialFeatureState)
     }
 }
+
+/**
+ * Convenience function for mapping [AIControllableFeature.featureState] to a [Flow] of non-null [Boolean] values.
+ * [AIFeatureState.Unknown] is resolved as not enabled
+ */
+val AIControllableFeature.isEnabled: Flow<Boolean>
+    get() = featureState.mapNotNull {
+        when (it) {
+            is Enabled -> true
+            is Disabled -> false
+            is Unknown -> null
+        }
+    }
 
 private class InMemoryAIControllableFeature(
     override val id: AIFeatureMetadata.FeatureId,
     override val description: AIFeatureMetadata.Description,
-    initialEnabled: Boolean,
+    initialFeatureState: AIFeatureState,
 ) : AIControllableFeature {
-    private val _isEnabled = MutableStateFlow(initialEnabled)
-    override val isEnabled: Flow<Boolean> = _isEnabled
+
+    private val _featureState =
+        MutableStateFlow(initialFeatureState)
+    override val featureState: Flow<AIFeatureState>
+        get() = _featureState
 
     override suspend fun set(enabled: Boolean) {
-        _isEnabled.value = enabled
+        _featureState.update {
+            if (enabled) Enabled else Disabled
+        }
     }
 }

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/PageSummaryFeature.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/PageSummaryFeature.kt
@@ -5,10 +5,10 @@
 package mozilla.components.feature.summarize
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import mozilla.components.concept.ai.controls.AIControllableFeature
 import mozilla.components.concept.ai.controls.AIFeatureMetadata
+import mozilla.components.concept.ai.controls.AIFeatureState
 import mozilla.components.feature.summarize.settings.SummarizationSettings
 import mozilla.components.ui.icons.R as iconsR
 
@@ -19,7 +19,15 @@ class PageSummaryFeature(
     private val settings: SummarizationSettings,
 ) : AIControllableFeature, AIFeatureMetadata by Companion {
 
-    override val isEnabled: Flow<Boolean> = flow { emitAll(settings.getFeatureEnabledUserStatus()) }
+    override val featureState: Flow<AIFeatureState>
+        get() = settings.getFeatureEnabledUserStatus()
+            .map { enabledState ->
+                when {
+                    enabledState == null -> AIFeatureState.Unknown
+                    enabledState -> AIFeatureState.Enabled
+                    else -> AIFeatureState.Disabled
+                }
+            }
 
     override suspend fun set(enabled: Boolean) {
         settings.setFeatureEnabledUserStatus(enabled)

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/settings/SummarizationSettings.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/settings/SummarizationSettings.kt
@@ -28,8 +28,13 @@ interface SummarizationSettings {
     /**
      * @return A [Flow] emitting the user's current preference for whether the summarization
      * feature is enabled.
+     *
+     * - It emits true when the feature is enabled
+     * - false when it's not, or
+     * - null when we don't know this means that the preference for this feature has never been set -
+     * either by the user, or by the app.
      */
-    suspend fun getFeatureEnabledUserStatus(): Flow<Boolean>
+    fun getFeatureEnabledUserStatus(): Flow<Boolean?>
 
     /**
      * Persists the user's preference for whether the summarization feature is enabled.
@@ -81,7 +86,7 @@ interface SummarizationSettings {
          * @return An in-memory [SummarizationSettings] instance.
          */
         fun inMemory(
-            isFeatureEnabled: Boolean = false,
+            isFeatureEnabled: Boolean? = null,
             isGestureEnabled: Boolean = false,
             hasConsentedToShake: Boolean = false,
             shakeConsentRejectedCount: Int = 0,
@@ -94,7 +99,7 @@ interface SummarizationSettings {
                 MutableStateFlow(hasConsentedToShake)
             private var shakeConsentRejectedCount = 0
 
-            override suspend fun getFeatureEnabledUserStatus(): Flow<Boolean> = isFeatureEnabledFlow
+            override fun getFeatureEnabledUserStatus(): Flow<Boolean?> = isFeatureEnabledFlow
 
             override suspend fun setFeatureEnabledUserStatus(newValue: Boolean) {
                 isFeatureEnabledFlow.emit(newValue)
@@ -140,8 +145,8 @@ internal class DataStoreBackedSettings(private val dataStore: DataStore<Preferen
     private val hasConsentedToShakeKey = booleanPreferencesKey("has_consented_to_shake_key")
     private val shakeConsentRejectedCountKey = intPreferencesKey("shake_consent_rejected_count_key")
 
-    override suspend fun getFeatureEnabledUserStatus(): Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[featureEnabledKey] ?: true
+    override fun getFeatureEnabledUserStatus(): Flow<Boolean?> = dataStore.data.map { preferences ->
+        preferences[featureEnabledKey]
     }
 
     override suspend fun setFeatureEnabledUserStatus(newValue: Boolean) {

--- a/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/settings/SummarizeSettingsMiddleware.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/main/java/mozilla/components/feature/summarize/settings/SummarizeSettingsMiddleware.kt
@@ -13,7 +13,7 @@ import mozilla.components.lib.state.Store
 /**
  * Middleware for the summarize settings screen that persists preference changes.
  *
- * @param settings The [SummarizationFeatureSettings] to persist preference changes to.
+ * @param settings The [SummarizationSettings] to persist preference changes to.
  * @param onLearnMoreClicked Callback invoked when the learn more link is clicked.
  */
 class SummarizeSettingsMiddleware(
@@ -35,7 +35,7 @@ class SummarizeSettingsMiddleware(
             ViewAppeared -> scope.launch {
                 store.dispatch(
                     SettingsLoaded(
-                        isFeatureEnabled = settings.getFeatureEnabledUserStatus().first(),
+                        isFeatureEnabled = settings.getFeatureEnabledUserStatus().first() == true,
                         isGestureEnabled = settings.getGestureEnabledUserStatus().first(),
                     ),
                 )

--- a/mobile/android/android-components/components/feature/summarize/src/test/java/mozilla/components/feature/summarize/PageSummaryFeatureTest.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/test/java/mozilla/components/feature/summarize/PageSummaryFeatureTest.kt
@@ -6,6 +6,7 @@ package mozilla.components.feature.summarize
 
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import mozilla.components.concept.ai.controls.isEnabled
 import mozilla.components.feature.summarize.settings.SummarizationSettings
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue

--- a/mobile/android/android-components/components/feature/summarize/src/test/java/mozilla/components/feature/summarize/settings/PageSummariesSettingsMiddlewareTest.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/test/java/mozilla/components/feature/summarize/settings/PageSummariesSettingsMiddlewareTest.kt
@@ -7,8 +7,6 @@ package mozilla.components.feature.summarize.settings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.last
-import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
@@ -41,7 +39,7 @@ class PageSummariesSettingsMiddlewareTest {
         store.dispatch(SummarizePagesPreferenceToggled)
         this.runCurrent()
 
-        assertTrue(settings.getFeatureEnabledUserStatus().first())
+        assertTrue(settings.getFeatureEnabledUserStatus().first() == true)
     }
 
     @Test
@@ -59,7 +57,7 @@ class PageSummariesSettingsMiddlewareTest {
         store.dispatch(SummarizePagesPreferenceToggled)
         this.runCurrent()
 
-        assertFalse(settings.getFeatureEnabledUserStatus().first())
+        assertFalse(settings.getFeatureEnabledUserStatus().first() == true)
     }
 
     @Test
@@ -77,7 +75,7 @@ class PageSummariesSettingsMiddlewareTest {
         store.dispatch(ShakeToSummarizePreferenceToggled)
         this.runCurrent()
 
-        assertTrue(settings.getFeatureEnabledUserStatus().first())
+        assertTrue(settings.getFeatureEnabledUserStatus().first() == true)
     }
 
     @Test
@@ -113,7 +111,7 @@ class PageSummariesSettingsMiddlewareTest {
         store.dispatch(SummarizePagesPreferenceToggled)
         this.runCurrent()
 
-        assertFalse(settings.getFeatureEnabledUserStatus().first())
+        assertFalse(settings.getFeatureEnabledUserStatus().first() == true)
         assertTrue(settings.getGestureEnabledUserStatus().first())
     }
 

--- a/mobile/android/android-components/components/feature/summarize/src/test/java/mozilla/components/feature/summarize/settings/SummarizationSettingsTest.kt
+++ b/mobile/android/android-components/components/feature/summarize/src/test/java/mozilla/components/feature/summarize/settings/SummarizationSettingsTest.kt
@@ -10,14 +10,27 @@ import mozilla.components.support.test.fakes.android.FakePreferencesDataStore
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertNull
 
 class SummarizationSettingsTest {
+
+    @Test
+    fun `that user preference for feature returns null if the value has never been set`() =
+        runTest {
+            val dataStore = FakePreferencesDataStore()
+            val settings = DataStoreBackedSettings(dataStore)
+
+            assertNull(
+                settings.getFeatureEnabledUserStatus().first(),
+                "Expected initial preference to be null because it has not been previous set",
+            )
+        }
+
     @Test
     fun `that user preference for feature is persisted`() = runTest {
         val dataStore = FakePreferencesDataStore()
         val settings = DataStoreBackedSettings(dataStore)
 
-        assertTrue(settings.getFeatureEnabledUserStatus().first())
         settings.setFeatureEnabledUserStatus(false)
         assertFalse(settings.getHasConsentedToShake().first())
     }
@@ -27,7 +40,6 @@ class SummarizationSettingsTest {
         val dataStore = FakePreferencesDataStore()
         val settings = DataStoreBackedSettings(dataStore)
 
-        assertTrue(settings.getGestureEnabledUserStatus().first())
         settings.setGestureEnabledUserStatus(false)
         assertFalse(settings.getHasConsentedToShake().first())
     }
@@ -37,7 +49,6 @@ class SummarizationSettingsTest {
         val dataStore = FakePreferencesDataStore()
         val settings = DataStoreBackedSettings(dataStore)
 
-        assertFalse(settings.getHasConsentedToShake().first())
         settings.setHasConsentedToShake(true)
         assertTrue(settings.getHasConsentedToShake().first())
     }
@@ -47,7 +58,6 @@ class SummarizationSettingsTest {
         val dataStore = FakePreferencesDataStore()
         val settings = DataStoreBackedSettings(dataStore)
 
-        assertTrue(settings.getGestureEnabledUserStatus().first())
         settings.incrementShakeConsentRejectedCount()
         settings.incrementShakeConsentRejectedCount()
         settings.incrementShakeConsentRejectedCount()

--- a/mobile/android/android-components/components/lib/ai-controls/src/main/java/mozilla/components/lib/ai/controls/AIFeatureRegistry.kt
+++ b/mobile/android/android-components/components/lib/ai-controls/src/main/java/mozilla/components/lib/ai/controls/AIFeatureRegistry.kt
@@ -4,14 +4,33 @@
 
 package mozilla.components.lib.ai.controls
 
+import android.content.Context
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import mozilla.components.concept.ai.controls.AIControllableFeature
 import mozilla.components.concept.ai.controls.AIFeatureMetadata
 import mozilla.components.concept.ai.controls.AIFeatureRegistry
+import mozilla.components.concept.ai.controls.AIFeatureState
 
 /**
- * Creates the default implementation of [AIFeatureRegistry], which enforces unique feature IDs.
+ * Creates the implementation of [AIFeatureRegistry], which enforces unique feature IDs.
  */
-fun AIFeatureRegistry.Companion.default() = object : AIFeatureRegistry {
+fun AIFeatureRegistry.Companion.default(
+    scope: CoroutineScope,
+    context: Context,
+): AIFeatureRegistry =
+    DefaultAIFeatureRegistry(scope, AIFeatureBlockStorage.dataStore(context))
+
+/**
+ * Default implementation of [AIFeatureRegistry] that enforces unique feature IDs and
+ * initializes feature states based on the block status stored in [AIFeatureBlockStorage].
+ */
+internal class DefaultAIFeatureRegistry(
+    private val scope: CoroutineScope,
+    private val storage: AIFeatureBlockStorage,
+) : AIFeatureRegistry {
     // LinkedHashMap allows us to maintain the order for later use.
     private val features = LinkedHashMap<AIFeatureMetadata.FeatureId, AIControllableFeature>()
 
@@ -19,6 +38,14 @@ fun AIFeatureRegistry.Companion.default() = object : AIFeatureRegistry {
         check(feature.id !in features.keys) {
             "AI feature with id=${feature.id} is already registered"
         }
+
+        scope.launch(Dispatchers.IO) {
+            if (feature.featureState.first() is AIFeatureState.Unknown) {
+                val aiFeaturesBlocked = storage.isBlocked.first()
+                feature.set(!aiFeaturesBlocked)
+            }
+        }
+
         features[feature.id] = feature
     }
 

--- a/mobile/android/android-components/components/lib/ai-controls/src/test/java/mozilla/components/lib/ai/controls/AIFeatureBlockTest.kt
+++ b/mobile/android/android-components/components/lib/ai-controls/src/test/java/mozilla/components/lib/ai/controls/AIFeatureBlockTest.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.ai.controls.AIControllableFeature
 import mozilla.components.concept.ai.controls.AIFeatureMetadata
 import mozilla.components.concept.ai.controls.AIFeatureRegistry
+import mozilla.components.concept.ai.controls.AIFeatureState
+import mozilla.components.concept.ai.controls.isEnabled
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -18,7 +20,7 @@ class AIFeatureBlockTest {
     @Test
     fun `block sets storage to blocked`() = runTest {
         val storage = AIFeatureBlockStorage.inMemory()
-        val block = DefaultAIFeatureBlock(AIFeatureRegistry.default(), storage)
+        val block = DefaultAIFeatureBlock(AIFeatureRegistry.inMemory(), storage)
 
         block.block()
 
@@ -27,14 +29,14 @@ class AIFeatureBlockTest {
 
     @Test
     fun `block disables all registered features`() = runTest {
-        val registry = AIFeatureRegistry.default()
+        val registry = AIFeatureRegistry.inMemory()
         val featureA = AIControllableFeature.inMemory(
             id = AIFeatureMetadata.FeatureId("a"),
-            initialEnabled = true,
+            initialFeatureState = AIFeatureState.Enabled,
         )
         val featureB = AIControllableFeature.inMemory(
             id = AIFeatureMetadata.FeatureId("b"),
-            initialEnabled = true,
+            initialFeatureState = AIFeatureState.Enabled,
         )
         registry.register(featureA)
         registry.register(featureB)
@@ -49,7 +51,7 @@ class AIFeatureBlockTest {
     @Test
     fun `block with empty registry only updates storage`() = runTest {
         val storage = AIFeatureBlockStorage.inMemory()
-        val block = DefaultAIFeatureBlock(AIFeatureRegistry.default(), storage)
+        val block = DefaultAIFeatureBlock(AIFeatureRegistry.inMemory(), storage)
 
         block.block()
 
@@ -59,7 +61,7 @@ class AIFeatureBlockTest {
     @Test
     fun `unblock sets storage to unblocked`() = runTest {
         val storage = AIFeatureBlockStorage.inMemory(initialBlocked = true)
-        val block = DefaultAIFeatureBlock(AIFeatureRegistry.default(), storage)
+        val block = DefaultAIFeatureBlock(AIFeatureRegistry.inMemory(), storage)
 
         block.unblock()
 
@@ -68,14 +70,14 @@ class AIFeatureBlockTest {
 
     @Test
     fun `unblock enables all registered features`() = runTest {
-        val registry = AIFeatureRegistry.default()
+        val registry = AIFeatureRegistry.inMemory()
         val featureA = AIControllableFeature.inMemory(
             id = AIFeatureMetadata.FeatureId("a"),
-            initialEnabled = false,
+            initialFeatureState = AIFeatureState.Disabled,
         )
         val featureB = AIControllableFeature.inMemory(
             id = AIFeatureMetadata.FeatureId("b"),
-            initialEnabled = false,
+            initialFeatureState = AIFeatureState.Disabled,
         )
         registry.register(featureA)
         registry.register(featureB)
@@ -90,7 +92,7 @@ class AIFeatureBlockTest {
     @Test
     fun `isBlocked reflects storage state`() = runTest {
         val storage = AIFeatureBlockStorage.inMemory()
-        val block = DefaultAIFeatureBlock(AIFeatureRegistry.default(), storage)
+        val block = DefaultAIFeatureBlock(AIFeatureRegistry.inMemory(), storage)
 
         assertFalse(block.isBlocked.first())
 

--- a/mobile/android/android-components/components/lib/ai-controls/src/test/java/mozilla/components/lib/ai/controls/AIFeatureRegistryTest.kt
+++ b/mobile/android/android-components/components/lib/ai-controls/src/test/java/mozilla/components/lib/ai/controls/AIFeatureRegistryTest.kt
@@ -4,21 +4,93 @@
 
 package mozilla.components.lib.ai.controls
 
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.ai.controls.AIControllableFeature
 import mozilla.components.concept.ai.controls.AIFeatureMetadata
 import mozilla.components.concept.ai.controls.AIFeatureRegistry
+import mozilla.components.concept.ai.controls.AIFeatureState
+import mozilla.components.concept.ai.controls.isEnabled
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 
 class AIFeatureRegistryTest {
+
+    private val testScope = TestScope()
+
     @Test(expected = IllegalStateException::class)
     fun `registry cannot re-register features`() {
-        val registry = AIFeatureRegistry.default()
         val featureA = AIControllableFeature.inMemory(
             id = AIFeatureMetadata.FeatureId("a"),
-            initialEnabled = true,
+            initialFeatureState = AIFeatureState.Enabled,
+        )
+        val featureBlockStorage = AIFeatureBlockStorage.inMemory(true)
+        val registry = DefaultAIFeatureRegistry(
+            scope = testScope,
+            storage = featureBlockStorage,
         )
 
         registry.register(featureA)
         registry.register(featureA)
+    }
+
+    @Test
+    fun `registry sets a feature to off if the feature state is unknown and AI features are blocked`() =
+        runTest {
+            // given that AI features are blocked
+            val featureBlockStorage = AIFeatureBlockStorage.inMemory(true)
+            val registry = DefaultAIFeatureRegistry(
+                scope = testScope,
+                storage = featureBlockStorage,
+            )
+
+            // given the feature
+            val feature = createFeature(defaultValue = AIFeatureState.Unknown)
+
+            // when we register the feature
+            registry.register(feature)
+            testScope.testScheduler.advanceUntilIdle()
+
+            assertFalse(
+                "Expected feature to be disabled when AI features are blocked",
+                feature.isEnabled.first(),
+            )
+        }
+
+    @Test
+    fun `registry keeps a feature on if the feature state is unknown and AI features are not blocked`() =
+        runTest {
+            // given that AI features are not blocked
+            val featureBlockStorage = AIFeatureBlockStorage.inMemory(false)
+            val registry = DefaultAIFeatureRegistry(
+                scope = testScope,
+                storage = featureBlockStorage,
+            )
+
+            // given the feature
+            val feature = createFeature(defaultValue = AIFeatureState.Enabled)
+
+            // when we register the feature
+            registry.register(feature)
+            testScope.testScheduler.advanceUntilIdle()
+
+            assertTrue(
+                "Expected feature to be enabled if AI features are allowed",
+                feature.isEnabled.first(),
+            )
+        }
+
+    private fun createFeature(
+        featureId: String = "test-feature",
+        defaultValue: AIFeatureState,
+    ): AIControllableFeature {
+        return AIControllableFeature.inMemory(
+            id = AIFeatureMetadata.FeatureId(featureId),
+            description = AIFeatureMetadata.Description(0, 0, 0),
+            initialFeatureState = defaultValue,
+        )
     }
 }

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -45,6 +45,7 @@ import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.state.selectedOrDefaultPrivateSearchEngine
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.storage.sync.GlobalPlacesDependencyProvider
+import mozilla.components.concept.ai.controls.isEnabled
 import mozilla.components.concept.base.crash.Breadcrumb
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.isUnsupported
@@ -993,7 +994,7 @@ open class FenixApplication : Application(), Provider, ThemeProvider {
         }
 
         val summarizeSettings = SummarizationSettings.dataStore(applicationContext)
-        UserAiSummarize.summarizationEnabled.set(summarizeSettings.getFeatureEnabledUserStatus().first())
+        UserAiSummarize.summarizationEnabled.set(summarizeSettings.getFeatureEnabledUserStatus().first() == true)
         UserAiSummarize.gestureEnabled.set(summarizeSettings.getGestureEnabledUserStatus().first())
         UserAiSummarize.summarizationConsented.set(summarizeSettings.getHasConsentedToShake().first())
 

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.getSystemService
 import com.google.android.play.core.review.ReviewManagerFactory
+import kotlinx.coroutines.MainScope
 import mozilla.components.concept.ai.controls.AIFeatureBlock
 import mozilla.components.concept.ai.controls.AIFeatureRegistry
 import mozilla.components.feature.addons.AddonManager
@@ -504,7 +505,7 @@ class Components(private val context: Context) {
     }
 
     val aiFeatureRegistry by lazyMonitored {
-        AIFeatureRegistry.default().also {
+        AIFeatureRegistry.default(scope = MainScope(), context = context).also {
             if (settings.shakeToSummarizeFeatureFlagEnabled) {
                 it.register(PageSummaryFeature(SummarizationSettings.dataStore(context)))
             }

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/components/lens/GoogleLensAIControlFeature.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/components/lens/GoogleLensAIControlFeature.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import mozilla.components.concept.ai.controls.AIControllableFeature
 import mozilla.components.concept.ai.controls.AIFeatureMetadata
+import mozilla.components.concept.ai.controls.AIFeatureState
 import org.mozilla.fenix.R
 import org.mozilla.fenix.utils.Settings
 import mozilla.components.ui.icons.R as iconsR
@@ -23,7 +24,13 @@ class GoogleLensAIControlFeature(
     private val settings: Settings,
 ) : AIControllableFeature, AIFeatureMetadata by Companion {
     private val _revision = MutableStateFlow(0)
-    override val isEnabled: Flow<Boolean> = _revision.map { settings.googleLensIntegrationUserEnabled }
+    override val featureState: Flow<AIFeatureState>
+        get() = _revision.map {
+            when {
+                settings.googleLensIntegrationUserEnabled -> AIFeatureState.Enabled
+                else -> AIFeatureState.Disabled
+            }
+        }
 
     override suspend fun set(enabled: Boolean) {
         settings.googleLensIntegrationUserEnabled = enabled

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/search/VoiceSearchAIControlFeature.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/search/VoiceSearchAIControlFeature.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import mozilla.components.concept.ai.controls.AIControllableFeature
 import mozilla.components.concept.ai.controls.AIFeatureMetadata
+import mozilla.components.concept.ai.controls.AIFeatureState
 import org.mozilla.fenix.R
 import org.mozilla.fenix.utils.Settings
 import org.mozilla.gecko.search.SearchWidgetProvider
@@ -29,7 +30,13 @@ class VoiceSearchAIControlFeature(
     //      while the object is still alive
     // pushing to the counter here will allow us to get 2 while the map will allow us to get 1
     private val _revision = MutableStateFlow(0)
-    override val isEnabled: Flow<Boolean> = _revision.map { settings.shouldShowVoiceSearch }
+    override val featureState: Flow<AIFeatureState>
+        get() = _revision.map {
+            when (settings.shouldShowVoiceSearch) {
+                true -> AIFeatureState.Enabled
+                else -> AIFeatureState.Disabled
+            }
+        }
 
     override suspend fun set(enabled: Boolean) {
         settings.shouldShowVoiceSearch = enabled

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -74,7 +74,7 @@ class CustomizationFragment : PreferenceFragmentCompat(), SystemInsetsPaddedFrag
                     .distinctUntilChanged()
                     .collect { (isFeatureEnabled, isGestureEnabled) ->
                         setupPreferences(
-                            isSummarizationEnabled = isFeatureEnabled,
+                            isSummarizationEnabled = isFeatureEnabled ?: false,
                             isSummarizationGestureEnabled = isGestureEnabled,
                         )
                     }

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/ai/AIControlsScreen.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/ai/AIControlsScreen.kt
@@ -48,6 +48,7 @@ import mozilla.components.compose.base.PromoCard
 import mozilla.components.compose.base.annotation.FlexibleWindowPreview
 import mozilla.components.compose.base.button.TextButton
 import mozilla.components.concept.ai.controls.AIControllableFeature
+import mozilla.components.concept.ai.controls.isEnabled
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.list.IconListItem
 import org.mozilla.fenix.compose.list.SwitchListItem

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/summarization/FenixSummarizationSettingsBinding.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/summarization/FenixSummarizationSettingsBinding.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import mozilla.components.feature.summarize.settings.SummarizationSettings
 
@@ -29,16 +30,17 @@ interface SummarizationSettingsBinding {
 class FenixSummarizationSettingsBinding(
     private val summarizationSettings: SummarizationSettings,
 ) : DefaultLifecycleObserver, SummarizationSettingsBinding {
-    private val _isFeatureEnabled = MutableStateFlow(true)
+    private val _isFeatureEnabled = MutableStateFlow(false)
     override val isFeatureEnabled: StateFlow<Boolean> = _isFeatureEnabled
-    private val _isGestureEnabled = MutableStateFlow(true)
+    private val _isGestureEnabled = MutableStateFlow(false)
     override val isGestureEnabled: StateFlow<Boolean> = _isGestureEnabled
 
     override fun onCreate(owner: LifecycleOwner) {
         super.onCreate(owner)
         owner.lifecycle.coroutineScope.launch {
             combine(
-                summarizationSettings.getFeatureEnabledUserStatus(),
+                summarizationSettings.getFeatureEnabledUserStatus()
+                    .mapNotNull { it },
                 summarizationSettings.getGestureEnabledUserStatus(),
             ) { a, b ->
                 a to b

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/translations/TranslationsAIControllableFeature.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/translations/TranslationsAIControllableFeature.kt
@@ -5,10 +5,12 @@
 package org.mozilla.fenix.translations
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import mozilla.components.browser.state.action.TranslationsAction
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.ai.controls.AIControllableFeature
 import mozilla.components.concept.ai.controls.AIFeatureMetadata
+import mozilla.components.concept.ai.controls.AIFeatureState
 import org.mozilla.fenix.R
 import mozilla.components.ui.icons.R as iconsR
 
@@ -19,7 +21,11 @@ class TranslationsAIControllableFeature(
     private val settings: TranslationsEnabledSettings,
     private val browserStore: BrowserStore,
 ) : AIControllableFeature, AIFeatureMetadata by Companion {
-    override val isEnabled: Flow<Boolean> = settings.isEnabled
+
+    override val featureState: Flow<AIFeatureState>
+        get() = settings.isEnabled.map { enabled ->
+            if (enabled) AIFeatureState.Enabled else AIFeatureState.Disabled
+        }
 
     override suspend fun set(enabled: Boolean) {
         settings.setEnabled(enabled)

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/components/lens/GoogleLensAIControlFeatureTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/components/lens/GoogleLensAIControlFeatureTest.kt
@@ -9,6 +9,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import mozilla.components.concept.ai.controls.isEnabled
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/search/VoiceSearchAIControlFeatureTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/search/VoiceSearchAIControlFeatureTest.kt
@@ -9,6 +9,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import mozilla.components.concept.ai.controls.isEnabled
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test


### PR DESCRIPTION
… of AI controls

This fixes the issue in bug 2040784 by ensuring that we have an unknown state where we don't know yet if the feature is enabled or not. This becomes important when we need to know if the user turned a feature on explicitly, or it was on by default, or they just never never interacted with the feature.

I commandeered this from Segun. Only downstream changes from me were to swap to the IO dispatcher while collecting the storage flow in the registry and a cosmetic change to remove the text fixtures he introduced in favor of the existing `inMemory` factories.