### PR TITLE
Add ML-DSA-87 (NIST FIPS 204) signature verification support

### DIFF
--- a/netwerk/protocol/http/WebTransportCertificateVerifier.cpp
+++ b/netwerk/protocol/http/WebTransportCertificateVerifier.cpp
@@ -52,6 +52,10 @@ class ServerCertHashesTrustDomain : public mozilla::pkix::TrustDomain {
       mozilla::pkix::Input signature,
       mozilla::pkix::Input subjectPublicKeyInfo) override;
 
+  virtual mozilla::pkix::Result VerifyMLDSASignedData(
+      mozilla::pkix::Input data, mozilla::pkix::Input signature,
+      mozilla::pkix::Input subjectPublicKeyInfo) override;
+
   virtual mozilla::pkix::Result DigestBuf(
       mozilla::pkix::Input item, mozilla::pkix::DigestAlgorithm digestAlg,
       /*out*/ uint8_t* digestBuf, size_t digestBufLen) override;
@@ -140,6 +144,14 @@ mozilla::pkix::Result ServerCertHashesTrustDomain::CheckECDSACurveIsAcceptable(
 mozilla::pkix::Result ServerCertHashesTrustDomain::VerifyECDSASignedData(
     mozilla::pkix::Input data, mozilla::pkix::DigestAlgorithm digestAlgorithm,
     mozilla::pkix::Input signature, mozilla::pkix::Input subjectPublicKeyInfo) {
+  MOZ_ASSERT_UNREACHABLE("not expecting this to be called");
+
+  return mozilla::pkix::Result::FATAL_ERROR_LIBRARY_FAILURE;
+}
+
+mozilla::pkix::Result ServerCertHashesTrustDomain::VerifyMLDSASignedData(
+    mozilla::pkix::Input data, mozilla::pkix::Input signature,
+    mozilla::pkix::Input subjectPublicKeyInfo) {
   MOZ_ASSERT_UNREACHABLE("not expecting this to be called");
 
   return mozilla::pkix::Result::FATAL_ERROR_LIBRARY_FAILURE;

--- a/security/certverifier/CertVerifier.cpp
+++ b/security/certverifier/CertVerifier.cpp
@@ -1091,6 +1091,10 @@ Result VerifySignedDataWithCache(
       result = VerifyRSAPSSSignedDataNSS(data, digestAlgorithm, signature,
                                          subjectPublicKeyInfo, pinArg);
       break;
+    case der::PublicKeyAlgorithm::ML_DSA:
+      result = VerifyMLDSASignedDataNSS(data, signature, subjectPublicKeyInfo,
+                                        pinArg);
+      break;
     default:
       MOZ_ASSERT_UNREACHABLE("unhandled public key algorithm");
       return Result::FATAL_ERROR_LIBRARY_FAILURE;

--- a/security/certverifier/NSSCertDBTrustDomain.cpp
+++ b/security/certverifier/NSSCertDBTrustDomain.cpp
@@ -1473,6 +1473,16 @@ Result NSSCertDBTrustDomain::VerifyECDSASignedData(
       signature, subjectPublicKeyInfo, mSignatureCache, mPinArg);
 }
 
+Result NSSCertDBTrustDomain::VerifyMLDSASignedData(Input data, Input signature,
+    Input subjectPublicKeyInfo) {
+  return VerifySignedDataWithCache(
+      der::PublicKeyAlgorithm::ML_DSA,
+      mozilla::glean::cert_signature_cache::total,
+      mozilla::glean::cert_signature_cache::hits, data,
+      DigestAlgorithm::none, signature, subjectPublicKeyInfo,
+      mSignatureCache, mPinArg);
+}
+
 Result NSSCertDBTrustDomain::CheckValidityIsAcceptable(
     Time notBefore, Time notAfter, EndEntityOrCA endEntityOrCA,
     KeyPurposeId keyPurpose) {

--- a/security/certverifier/NSSCertDBTrustDomain.h
+++ b/security/certverifier/NSSCertDBTrustDomain.h
@@ -175,6 +175,10 @@ class NSSCertDBTrustDomain : public mozilla::pkix::TrustDomain {
       mozilla::pkix::Input signature,
       mozilla::pkix::Input subjectPublicKeyInfo) override;
 
+  virtual Result VerifyMLDSASignedData(
+      mozilla::pkix::Input data, mozilla::pkix::Input signature,
+      mozilla::pkix::Input subjectPublicKeyInfo) override;
+
   virtual Result DigestBuf(mozilla::pkix::Input item,
                            mozilla::pkix::DigestAlgorithm digestAlg,
                            /*out*/ uint8_t* digestBuf,

--- a/security/ct/CTLogVerifier.cpp
+++ b/security/ct/CTLogVerifier.cpp
@@ -74,6 +74,10 @@ class SignatureParamsTrustDomain final : public TrustDomain {
     return pkix::Result::FATAL_ERROR_LIBRARY_FAILURE;
   }
 
+  pkix::Result VerifyMLDSASignedData(Input, Input, Input) override {
+    return pkix::Result::FATAL_ERROR_LIBRARY_FAILURE;
+  }
+
   pkix::Result CheckRSAPublicKeyModulusSizeInBits(
       EndEntityOrCA, unsigned int modulusSizeInBits) override {
     assert(mSignatureAlgorithm ==

--- a/security/ct/tests/gtest/CTTestUtils.cpp
+++ b/security/ct/tests/gtest/CTTestUtils.cpp
@@ -782,6 +782,12 @@ class OCSPExtensionTrustDomain : public TrustDomain {
                                     subjectPublicKeyInfo, nullptr);
   }
 
+  pkix::Result VerifyMLDSASignedData(Input data, Input signature,
+                                     Input subjectPublicKeyInfo) override {
+    return VerifyMLDSASignedDataNSS(data, signature, subjectPublicKeyInfo,
+                                    nullptr);
+  }
+
   pkix::Result CheckRSAPublicKeyModulusSizeInBits(EndEntityOrCA,
                                                   unsigned int) override {
     ADD_FAILURE();

--- a/security/manager/ssl/AppTrustDomain.cpp
+++ b/security/manager/ssl/AppTrustDomain.cpp
@@ -317,6 +317,11 @@ pkix::Result AppTrustDomain::VerifyECDSASignedData(
                                   subjectPublicKeyInfo, nullptr);
 }
 
+pkix::Result AppTrustDomain::VerifyMLDSASignedData(Input data, Input signature,
+                                                    Input subjectPublicKeyInfo) {
+  return VerifyMLDSASignedDataNSS(data, signature, subjectPublicKeyInfo, nullptr);
+}
+
 pkix::Result AppTrustDomain::CheckValidityIsAcceptable(
     Time /*notBefore*/, Time /*notAfter*/, EndEntityOrCA /*endEntityOrCA*/,
     KeyPurposeId /*keyPurpose*/) {

--- a/security/manager/ssl/AppTrustDomain.h
+++ b/security/manager/ssl/AppTrustDomain.h
@@ -63,6 +63,9 @@ class AppTrustDomain final : public mozilla::pkix::TrustDomain {
       mozilla::pkix::Input data, mozilla::pkix::DigestAlgorithm digestAlgorithm,
       mozilla::pkix::Input signature,
       mozilla::pkix::Input subjectPublicKeyInfo) override;
+  virtual Result VerifyMLDSASignedData(
+      mozilla::pkix::Input data, mozilla::pkix::Input signature,
+      mozilla::pkix::Input subjectPublicKeyInfo) override;
   virtual Result CheckValidityIsAcceptable(
       mozilla::pkix::Time notBefore, mozilla::pkix::Time notAfter,
       mozilla::pkix::EndEntityOrCA endEntityOrCA,

--- a/security/manager/ssl/PDFTrustDomain.cpp
+++ b/security/manager/ssl/PDFTrustDomain.cpp
@@ -195,6 +195,11 @@ pkix::Result PDFTrustDomain::VerifyECDSASignedData(
                                   subjectPublicKeyInfo, nullptr);
 }
 
+pkix::Result PDFTrustDomain::VerifyMLDSASignedData(Input data, Input signature,
+                                                    Input subjectPublicKeyInfo) {
+  return VerifyMLDSASignedDataNSS(data, signature, subjectPublicKeyInfo, nullptr);
+}
+
 pkix::Result PDFTrustDomain::CheckValidityIsAcceptable(
     Time /*notBefore*/, Time /*notAfter*/, EndEntityOrCA /*endEntityOrCA*/,
     KeyPurposeId /*keyPurpose*/) {

--- a/security/manager/ssl/PDFTrustDomain.h
+++ b/security/manager/ssl/PDFTrustDomain.h
@@ -59,6 +59,9 @@ class PDFTrustDomain final : public mozilla::pkix::TrustDomain {
       mozilla::pkix::Input data, mozilla::pkix::DigestAlgorithm digestAlgorithm,
       mozilla::pkix::Input signature,
       mozilla::pkix::Input subjectPublicKeyInfo) override;
+  virtual Result VerifyMLDSASignedData(
+      mozilla::pkix::Input data, mozilla::pkix::Input signature,
+      mozilla::pkix::Input subjectPublicKeyInfo) override;
   virtual Result CheckValidityIsAcceptable(
       mozilla::pkix::Time notBefore, mozilla::pkix::Time notAfter,
       mozilla::pkix::EndEntityOrCA endEntityOrCA,

--- a/security/manager/ssl/QWACTrustDomain.cpp
+++ b/security/manager/ssl/QWACTrustDomain.cpp
@@ -147,6 +147,11 @@ pkix::Result QWACTrustDomain::VerifyECDSASignedData(
                                   subjectPublicKeyInfo, nullptr);
 }
 
+pkix::Result QWACTrustDomain::VerifyMLDSASignedData(Input data, Input signature,
+                                                     Input subjectPublicKeyInfo) {
+  return VerifyMLDSASignedDataNSS(data, signature, subjectPublicKeyInfo, nullptr);
+}
+
 pkix::Result QWACTrustDomain::CheckValidityIsAcceptable(
     Time /*notBefore*/, Time /*notAfter*/, EndEntityOrCA /*endEntityOrCA*/,
     KeyPurposeId /*keyPurpose*/) {

--- a/security/manager/ssl/QWACTrustDomain.h
+++ b/security/manager/ssl/QWACTrustDomain.h
@@ -57,6 +57,9 @@ class QWACTrustDomain final : public mozilla::pkix::TrustDomain {
       mozilla::pkix::Input data, mozilla::pkix::DigestAlgorithm digestAlgorithm,
       mozilla::pkix::Input signature,
       mozilla::pkix::Input subjectPublicKeyInfo) override;
+  virtual Result VerifyMLDSASignedData(
+      mozilla::pkix::Input data, mozilla::pkix::Input signature,
+      mozilla::pkix::Input subjectPublicKeyInfo) override;
   virtual Result CheckValidityIsAcceptable(
       mozilla::pkix::Time notBefore, mozilla::pkix::Time notAfter,
       mozilla::pkix::EndEntityOrCA endEntityOrCA,

--- a/security/manager/ssl/TLSClientAuthCertSelection.cpp
+++ b/security/manager/ssl/TLSClientAuthCertSelection.cpp
@@ -225,6 +225,11 @@ class ClientAuthCertNonverifyingTrustDomain final : public TrustDomain {
       pkix::Input subjectPublicKeyInfo) override {
     return pkix::Success;
   }
+  virtual mozilla::pkix::Result VerifyMLDSASignedData(
+      pkix::Input data, pkix::Input signature,
+      pkix::Input subjectPublicKeyInfo) override {
+    return pkix::Success;
+  }
   virtual mozilla::pkix::Result CheckValidityIsAcceptable(
       pkix::Time notBefore, pkix::Time notAfter,
       pkix::EndEntityOrCA endEntityOrCA,

--- a/security/manager/ssl/nsNSSCallbacks.cpp
+++ b/security/manager/ssl/nsNSSCallbacks.cpp
@@ -1183,6 +1183,10 @@ void HandshakeCallback(PRFileDesc* fd, void* client_data) {
           glean::ssl::auth_ecdsa_curve_full.AccumulateSingleSample(
               ECCCurve(channelInfo.authKeyBits));
           break;
+        case ssl_auth_mldsa:
+          // ML-DSA key strength is fixed by the parameter set, so there is no
+          // key-size metric to record.
+          break;
         default:
           MOZ_CRASH("impossible auth algorithm");
           break;

--- a/security/nss/gtests/mozpkix_gtest/pkixgtest.h
+++ b/security/nss/gtests/mozpkix_gtest/pkixgtest.h
@@ -140,6 +140,12 @@ class EverythingFailsByDefaultTrustDomain : public TrustDomain {
                       Result::FATAL_ERROR_LIBRARY_FAILURE);
   }
 
+  Result VerifyMLDSASignedData(Input, Input, Input) override {
+    ADD_FAILURE();
+    return NotReached("VerifyMLDSASignedData should not be called",
+                      Result::FATAL_ERROR_LIBRARY_FAILURE);
+  }
+
   Result CheckRSAPublicKeyModulusSizeInBits(EndEntityOrCA,
                                             unsigned int) override {
     ADD_FAILURE();

--- a/security/nss/lib/freebl/dilithium-pqcrystals-ref.c
+++ b/security/nss/lib/freebl/dilithium-pqcrystals-ref.c
@@ -1,0 +1,3686 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ *
+ * This file was generated from
+ *   https://github.com/pq-crystals/dilithium/commit/6e00625c
+ * (ref/ implementation), amalgamated for ML-DSA-87 (Dilithium mode 5).
+ *
+ * Source files from that repository are listed below surrounded by
+ * "begin: ref/[file]" and "end: ref/[file]" comments.
+ *
+ * The following changes have been made:
+ *  - local #include directives have been removed (sources are concatenated),
+ *  - DILITHIUM_MODE is forced to 5 (ML-DSA-87),
+ *  - ref/randombytes.c is omitted; randombytes() is provided by ml_dsa.c and
+ *    backed by freebl's RNG_GenerateGlobalRandomBytes,
+ *  - crypto_sign_keypair is split into a seed-taking
+ *    pqcrystals_dilithium5_ref_keypair_internal() plus a random wrapper,
+ *  - the AES symmetric variant is not used (SHAKE only, as upstream default).
+ *
+ * Upstream LICENSE: Public Domain (CC0) or Apache 2.0. AUTHORS: Shi Bai,
+ * Leo Ducas, Eike Kiltz, Tancrede Lepoint, Vadim Lyubashevsky, Peter Schwabe,
+ * Gregor Seiler, Damien Stehle.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef FREEBL_NO_DEPEND
+#include "stubs.h"
+#endif
+
+#include "secport.h"
+
+/* Provided by ml_dsa.c, backed by freebl's RNG. */
+void randombytes(uint8_t *out, size_t outlen);
+
+/* ML-DSA-87 */
+#define DILITHIUM_MODE 5
+
+
+/* begin: ref/config.h */
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+//#define DILITHIUM_MODE 2
+#define DILITHIUM_RANDOMIZED_SIGNING
+//#define USE_RDPMC
+//#define DBENCH
+
+#ifndef DILITHIUM_MODE
+#define DILITHIUM_MODE 2
+#endif
+
+#if DILITHIUM_MODE == 2
+#define CRYPTO_ALGNAME "Dilithium2"
+#define DILITHIUM_NAMESPACETOP pqcrystals_dilithium2_ref
+#define DILITHIUM_NAMESPACE(s) pqcrystals_dilithium2_ref_##s
+#elif DILITHIUM_MODE == 3
+#define CRYPTO_ALGNAME "Dilithium3"
+#define DILITHIUM_NAMESPACETOP pqcrystals_dilithium3_ref
+#define DILITHIUM_NAMESPACE(s) pqcrystals_dilithium3_ref_##s
+#elif DILITHIUM_MODE == 5
+#define CRYPTO_ALGNAME "Dilithium5"
+#define DILITHIUM_NAMESPACETOP pqcrystals_dilithium5_ref
+#define DILITHIUM_NAMESPACE(s) pqcrystals_dilithium5_ref_##s
+#endif
+
+#endif
+
+/* end: ref/config.h */
+
+
+/* begin: ref/params.h */
+
+#ifndef PARAMS_H
+#define PARAMS_H
+
+
+#define SEEDBYTES 32
+#define CRHBYTES 64
+#define TRBYTES 64
+#define RNDBYTES 32
+#define N 256
+#define Q 8380417
+#define D 13
+#define ROOT_OF_UNITY 1753
+
+#if DILITHIUM_MODE == 2
+#define K 4
+#define L 4
+#define ETA 2
+#define TAU 39
+#define BETA 78
+#define GAMMA1 (1 << 17)
+#define GAMMA2 ((Q-1)/88)
+#define OMEGA 80
+#define CTILDEBYTES 32
+
+#elif DILITHIUM_MODE == 3
+#define K 6
+#define L 5
+#define ETA 4
+#define TAU 49
+#define BETA 196
+#define GAMMA1 (1 << 19)
+#define GAMMA2 ((Q-1)/32)
+#define OMEGA 55
+#define CTILDEBYTES 48
+
+#elif DILITHIUM_MODE == 5
+#define K 8
+#define L 7
+#define ETA 2
+#define TAU 60
+#define BETA 120
+#define GAMMA1 (1 << 19)
+#define GAMMA2 ((Q-1)/32)
+#define OMEGA 75
+#define CTILDEBYTES 64
+
+#endif
+
+#define POLYT1_PACKEDBYTES  320
+#define POLYT0_PACKEDBYTES  416
+#define POLYVECH_PACKEDBYTES (OMEGA + K)
+
+#if GAMMA1 == (1 << 17)
+#define POLYZ_PACKEDBYTES   576
+#elif GAMMA1 == (1 << 19)
+#define POLYZ_PACKEDBYTES   640
+#endif
+
+#if GAMMA2 == (Q-1)/88
+#define POLYW1_PACKEDBYTES  192
+#elif GAMMA2 == (Q-1)/32
+#define POLYW1_PACKEDBYTES  128
+#endif
+
+#if ETA == 2
+#define POLYETA_PACKEDBYTES  96
+#elif ETA == 4
+#define POLYETA_PACKEDBYTES 128
+#endif
+
+#define CRYPTO_PUBLICKEYBYTES (SEEDBYTES + K*POLYT1_PACKEDBYTES)
+#define CRYPTO_SECRETKEYBYTES (2*SEEDBYTES \
+                               + TRBYTES \
+                               + L*POLYETA_PACKEDBYTES \
+                               + K*POLYETA_PACKEDBYTES \
+                               + K*POLYT0_PACKEDBYTES)
+#define CRYPTO_BYTES (CTILDEBYTES + L*POLYZ_PACKEDBYTES + POLYVECH_PACKEDBYTES)
+
+#endif
+
+/* end: ref/params.h */
+
+
+/* begin: ref/fips202.h */
+
+#ifndef FIPS202_H
+#define FIPS202_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define SHAKE128_RATE 168
+#define SHAKE256_RATE 136
+#define SHA3_256_RATE 136
+#define SHA3_512_RATE 72
+
+#define FIPS202_NAMESPACE(s) pqcrystals_dilithium_fips202_ref_##s
+
+typedef struct {
+  uint64_t s[25];
+  unsigned int pos;
+} keccak_state;
+
+#define KeccakF_RoundConstants FIPS202_NAMESPACE(KeccakF_RoundConstants)
+extern const uint64_t KeccakF_RoundConstants[];
+
+#define shake128_init FIPS202_NAMESPACE(shake128_init)
+void shake128_init(keccak_state *state);
+#define shake128_absorb FIPS202_NAMESPACE(shake128_absorb)
+void shake128_absorb(keccak_state *state, const uint8_t *in, size_t inlen);
+#define shake128_finalize FIPS202_NAMESPACE(shake128_finalize)
+void shake128_finalize(keccak_state *state);
+#define shake128_squeeze FIPS202_NAMESPACE(shake128_squeeze)
+void shake128_squeeze(uint8_t *out, size_t outlen, keccak_state *state);
+#define shake128_absorb_once FIPS202_NAMESPACE(shake128_absorb_once)
+void shake128_absorb_once(keccak_state *state, const uint8_t *in, size_t inlen);
+#define shake128_squeezeblocks FIPS202_NAMESPACE(shake128_squeezeblocks)
+void shake128_squeezeblocks(uint8_t *out, size_t nblocks, keccak_state *state);
+
+#define shake256_init FIPS202_NAMESPACE(shake256_init)
+void shake256_init(keccak_state *state);
+#define shake256_absorb FIPS202_NAMESPACE(shake256_absorb)
+void shake256_absorb(keccak_state *state, const uint8_t *in, size_t inlen);
+#define shake256_finalize FIPS202_NAMESPACE(shake256_finalize)
+void shake256_finalize(keccak_state *state);
+#define shake256_squeeze FIPS202_NAMESPACE(shake256_squeeze)
+void shake256_squeeze(uint8_t *out, size_t outlen, keccak_state *state);
+#define shake256_absorb_once FIPS202_NAMESPACE(shake256_absorb_once)
+void shake256_absorb_once(keccak_state *state, const uint8_t *in, size_t inlen);
+#define shake256_squeezeblocks FIPS202_NAMESPACE(shake256_squeezeblocks)
+void shake256_squeezeblocks(uint8_t *out, size_t nblocks,  keccak_state *state);
+
+#define shake128 FIPS202_NAMESPACE(shake128)
+void shake128(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen);
+#define shake256 FIPS202_NAMESPACE(shake256)
+void shake256(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen);
+#define sha3_256 FIPS202_NAMESPACE(sha3_256)
+void sha3_256(uint8_t h[32], const uint8_t *in, size_t inlen);
+#define sha3_512 FIPS202_NAMESPACE(sha3_512)
+void sha3_512(uint8_t h[64], const uint8_t *in, size_t inlen);
+
+#endif
+
+/* end: ref/fips202.h */
+
+
+/* begin: ref/reduce.h */
+
+#ifndef REDUCE_H
+#define REDUCE_H
+
+#include <stdint.h>
+
+#define MONT -4186625 // 2^32 % Q
+#define QINV 58728449 // q^(-1) mod 2^32
+
+#define montgomery_reduce DILITHIUM_NAMESPACE(montgomery_reduce)
+int32_t montgomery_reduce(int64_t a);
+
+#define reduce32 DILITHIUM_NAMESPACE(reduce32)
+int32_t reduce32(int32_t a);
+
+#define caddq DILITHIUM_NAMESPACE(caddq)
+int32_t caddq(int32_t a);
+
+#define freeze DILITHIUM_NAMESPACE(freeze)
+int32_t freeze(int32_t a);
+
+#endif
+
+/* end: ref/reduce.h */
+
+
+/* begin: ref/rounding.h */
+
+#ifndef ROUNDING_H
+#define ROUNDING_H
+
+#include <stdint.h>
+
+#define power2round DILITHIUM_NAMESPACE(power2round)
+int32_t power2round(int32_t *a0, int32_t a);
+
+#define decompose DILITHIUM_NAMESPACE(decompose)
+int32_t decompose(int32_t *a0, int32_t a);
+
+#define make_hint DILITHIUM_NAMESPACE(make_hint)
+unsigned int make_hint(int32_t a0, int32_t a1);
+
+#define use_hint DILITHIUM_NAMESPACE(use_hint)
+int32_t use_hint(int32_t a, unsigned int hint);
+
+#endif
+
+/* end: ref/rounding.h */
+
+
+/* begin: ref/ntt.h */
+
+#ifndef NTT_H
+#define NTT_H
+
+#include <stdint.h>
+
+#define ntt DILITHIUM_NAMESPACE(ntt)
+void ntt(int32_t a[N]);
+
+#define invntt_tomont DILITHIUM_NAMESPACE(invntt_tomont)
+void invntt_tomont(int32_t a[N]);
+
+#endif
+
+/* end: ref/ntt.h */
+
+
+/* begin: ref/symmetric.h */
+
+#ifndef SYMMETRIC_H
+#define SYMMETRIC_H
+
+#include <stdint.h>
+
+
+typedef keccak_state stream128_state;
+typedef keccak_state stream256_state;
+
+#define dilithium_shake128_stream_init DILITHIUM_NAMESPACE(dilithium_shake128_stream_init)
+void dilithium_shake128_stream_init(keccak_state *state,
+                                    const uint8_t seed[SEEDBYTES],
+                                    uint16_t nonce);
+
+#define dilithium_shake256_stream_init DILITHIUM_NAMESPACE(dilithium_shake256_stream_init)
+void dilithium_shake256_stream_init(keccak_state *state,
+                                    const uint8_t seed[CRHBYTES],
+                                    uint16_t nonce);
+
+#define STREAM128_BLOCKBYTES SHAKE128_RATE
+#define STREAM256_BLOCKBYTES SHAKE256_RATE
+
+#define stream128_init(STATE, SEED, NONCE) \
+        dilithium_shake128_stream_init(STATE, SEED, NONCE)
+#define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) \
+        shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_init(STATE, SEED, NONCE) \
+        dilithium_shake256_stream_init(STATE, SEED, NONCE)
+#define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) \
+        shake256_squeezeblocks(OUT, OUTBLOCKS, STATE)
+
+#endif
+
+/* end: ref/symmetric.h */
+
+
+/* begin: ref/poly.h */
+
+#ifndef POLY_H
+#define POLY_H
+
+#include <stdint.h>
+
+typedef struct {
+  int32_t coeffs[N];
+} poly;
+
+#define poly_reduce DILITHIUM_NAMESPACE(poly_reduce)
+void poly_reduce(poly *a);
+#define poly_caddq DILITHIUM_NAMESPACE(poly_caddq)
+void poly_caddq(poly *a);
+
+#define poly_add DILITHIUM_NAMESPACE(poly_add)
+void poly_add(poly *c, const poly *a, const poly *b);
+#define poly_sub DILITHIUM_NAMESPACE(poly_sub)
+void poly_sub(poly *c, const poly *a, const poly *b);
+#define poly_shiftl DILITHIUM_NAMESPACE(poly_shiftl)
+void poly_shiftl(poly *a);
+
+#define poly_ntt DILITHIUM_NAMESPACE(poly_ntt)
+void poly_ntt(poly *a);
+#define poly_invntt_tomont DILITHIUM_NAMESPACE(poly_invntt_tomont)
+void poly_invntt_tomont(poly *a);
+#define poly_pointwise_montgomery DILITHIUM_NAMESPACE(poly_pointwise_montgomery)
+void poly_pointwise_montgomery(poly *c, const poly *a, const poly *b);
+
+#define poly_power2round DILITHIUM_NAMESPACE(poly_power2round)
+void poly_power2round(poly *a1, poly *a0, const poly *a);
+#define poly_decompose DILITHIUM_NAMESPACE(poly_decompose)
+void poly_decompose(poly *a1, poly *a0, const poly *a);
+#define poly_make_hint DILITHIUM_NAMESPACE(poly_make_hint)
+unsigned int poly_make_hint(poly *h, const poly *a0, const poly *a1);
+#define poly_use_hint DILITHIUM_NAMESPACE(poly_use_hint)
+void poly_use_hint(poly *b, const poly *a, const poly *h);
+
+#define poly_chknorm DILITHIUM_NAMESPACE(poly_chknorm)
+int poly_chknorm(const poly *a, int32_t B);
+#define poly_uniform DILITHIUM_NAMESPACE(poly_uniform)
+void poly_uniform(poly *a,
+                  const uint8_t seed[SEEDBYTES],
+                  uint16_t nonce);
+#define poly_uniform_eta DILITHIUM_NAMESPACE(poly_uniform_eta)
+void poly_uniform_eta(poly *a,
+                      const uint8_t seed[CRHBYTES],
+                      uint16_t nonce);
+#define poly_uniform_gamma1 DILITHIUM_NAMESPACE(poly_uniform_gamma1)
+void poly_uniform_gamma1(poly *a,
+                         const uint8_t seed[CRHBYTES],
+                         uint16_t nonce);
+#define poly_challenge DILITHIUM_NAMESPACE(poly_challenge)
+void poly_challenge(poly *c, const uint8_t seed[CTILDEBYTES]);
+
+#define polyeta_pack DILITHIUM_NAMESPACE(polyeta_pack)
+void polyeta_pack(uint8_t *r, const poly *a);
+#define polyeta_unpack DILITHIUM_NAMESPACE(polyeta_unpack)
+void polyeta_unpack(poly *r, const uint8_t *a);
+
+#define polyt1_pack DILITHIUM_NAMESPACE(polyt1_pack)
+void polyt1_pack(uint8_t *r, const poly *a);
+#define polyt1_unpack DILITHIUM_NAMESPACE(polyt1_unpack)
+void polyt1_unpack(poly *r, const uint8_t *a);
+
+#define polyt0_pack DILITHIUM_NAMESPACE(polyt0_pack)
+void polyt0_pack(uint8_t *r, const poly *a);
+#define polyt0_unpack DILITHIUM_NAMESPACE(polyt0_unpack)
+void polyt0_unpack(poly *r, const uint8_t *a);
+
+#define polyz_pack DILITHIUM_NAMESPACE(polyz_pack)
+void polyz_pack(uint8_t *r, const poly *a);
+#define polyz_unpack DILITHIUM_NAMESPACE(polyz_unpack)
+void polyz_unpack(poly *r, const uint8_t *a);
+
+#define polyw1_pack DILITHIUM_NAMESPACE(polyw1_pack)
+void polyw1_pack(uint8_t *r, const poly *a);
+
+#endif
+
+/* end: ref/poly.h */
+
+
+/* begin: ref/polyvec.h */
+
+#ifndef POLYVEC_H
+#define POLYVEC_H
+
+#include <stdint.h>
+
+/* Vectors of polynomials of length L */
+typedef struct {
+  poly vec[L];
+} polyvecl;
+
+#define polyvecl_uniform_eta DILITHIUM_NAMESPACE(polyvecl_uniform_eta)
+void polyvecl_uniform_eta(polyvecl *v, const uint8_t seed[CRHBYTES], uint16_t nonce);
+
+#define polyvecl_uniform_gamma1 DILITHIUM_NAMESPACE(polyvecl_uniform_gamma1)
+void polyvecl_uniform_gamma1(polyvecl *v, const uint8_t seed[CRHBYTES], uint16_t nonce);
+
+#define polyvecl_reduce DILITHIUM_NAMESPACE(polyvecl_reduce)
+void polyvecl_reduce(polyvecl *v);
+
+#define polyvecl_add DILITHIUM_NAMESPACE(polyvecl_add)
+void polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v);
+
+#define polyvecl_ntt DILITHIUM_NAMESPACE(polyvecl_ntt)
+void polyvecl_ntt(polyvecl *v);
+#define polyvecl_invntt_tomont DILITHIUM_NAMESPACE(polyvecl_invntt_tomont)
+void polyvecl_invntt_tomont(polyvecl *v);
+#define polyvecl_pointwise_poly_montgomery DILITHIUM_NAMESPACE(polyvecl_pointwise_poly_montgomery)
+void polyvecl_pointwise_poly_montgomery(polyvecl *r, const poly *a, const polyvecl *v);
+#define polyvecl_pointwise_acc_montgomery \
+        DILITHIUM_NAMESPACE(polyvecl_pointwise_acc_montgomery)
+void polyvecl_pointwise_acc_montgomery(poly *w,
+                                       const polyvecl *u,
+                                       const polyvecl *v);
+
+
+#define polyvecl_chknorm DILITHIUM_NAMESPACE(polyvecl_chknorm)
+int polyvecl_chknorm(const polyvecl *v, int32_t B);
+
+
+
+/* Vectors of polynomials of length K */
+typedef struct {
+  poly vec[K];
+} polyveck;
+
+#define polyveck_uniform_eta DILITHIUM_NAMESPACE(polyveck_uniform_eta)
+void polyveck_uniform_eta(polyveck *v, const uint8_t seed[CRHBYTES], uint16_t nonce);
+
+#define polyveck_reduce DILITHIUM_NAMESPACE(polyveck_reduce)
+void polyveck_reduce(polyveck *v);
+#define polyveck_caddq DILITHIUM_NAMESPACE(polyveck_caddq)
+void polyveck_caddq(polyveck *v);
+
+#define polyveck_add DILITHIUM_NAMESPACE(polyveck_add)
+void polyveck_add(polyveck *w, const polyveck *u, const polyveck *v);
+#define polyveck_sub DILITHIUM_NAMESPACE(polyveck_sub)
+void polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v);
+#define polyveck_shiftl DILITHIUM_NAMESPACE(polyveck_shiftl)
+void polyveck_shiftl(polyveck *v);
+
+#define polyveck_ntt DILITHIUM_NAMESPACE(polyveck_ntt)
+void polyveck_ntt(polyveck *v);
+#define polyveck_invntt_tomont DILITHIUM_NAMESPACE(polyveck_invntt_tomont)
+void polyveck_invntt_tomont(polyveck *v);
+#define polyveck_pointwise_poly_montgomery DILITHIUM_NAMESPACE(polyveck_pointwise_poly_montgomery)
+void polyveck_pointwise_poly_montgomery(polyveck *r, const poly *a, const polyveck *v);
+
+#define polyveck_chknorm DILITHIUM_NAMESPACE(polyveck_chknorm)
+int polyveck_chknorm(const polyveck *v, int32_t B);
+
+#define polyveck_power2round DILITHIUM_NAMESPACE(polyveck_power2round)
+void polyveck_power2round(polyveck *v1, polyveck *v0, const polyveck *v);
+#define polyveck_decompose DILITHIUM_NAMESPACE(polyveck_decompose)
+void polyveck_decompose(polyveck *v1, polyveck *v0, const polyveck *v);
+#define polyveck_make_hint DILITHIUM_NAMESPACE(polyveck_make_hint)
+unsigned int polyveck_make_hint(polyveck *h,
+                                const polyveck *v0,
+                                const polyveck *v1);
+#define polyveck_use_hint DILITHIUM_NAMESPACE(polyveck_use_hint)
+void polyveck_use_hint(polyveck *w, const polyveck *v, const polyveck *h);
+
+#define polyveck_pack_w1 DILITHIUM_NAMESPACE(polyveck_pack_w1)
+void polyveck_pack_w1(uint8_t r[K*POLYW1_PACKEDBYTES], const polyveck *w1);
+
+#define polyvec_matrix_expand DILITHIUM_NAMESPACE(polyvec_matrix_expand)
+void polyvec_matrix_expand(polyvecl mat[K], const uint8_t rho[SEEDBYTES]);
+
+#define polyvec_matrix_pointwise_montgomery DILITHIUM_NAMESPACE(polyvec_matrix_pointwise_montgomery)
+void polyvec_matrix_pointwise_montgomery(polyveck *t, const polyvecl mat[K], const polyvecl *v);
+
+#endif
+
+/* end: ref/polyvec.h */
+
+
+/* begin: ref/packing.h */
+
+#ifndef PACKING_H
+#define PACKING_H
+
+#include <stdint.h>
+
+#define pack_pk DILITHIUM_NAMESPACE(pack_pk)
+void pack_pk(uint8_t pk[CRYPTO_PUBLICKEYBYTES], const uint8_t rho[SEEDBYTES], const polyveck *t1);
+
+#define pack_sk DILITHIUM_NAMESPACE(pack_sk)
+void pack_sk(uint8_t sk[CRYPTO_SECRETKEYBYTES],
+             const uint8_t rho[SEEDBYTES],
+             const uint8_t tr[TRBYTES],
+             const uint8_t key[SEEDBYTES],
+             const polyveck *t0,
+             const polyvecl *s1,
+             const polyveck *s2);
+
+#define pack_sig DILITHIUM_NAMESPACE(pack_sig)
+void pack_sig(uint8_t sig[CRYPTO_BYTES], const uint8_t c[CTILDEBYTES], const polyvecl *z, const polyveck *h);
+
+#define unpack_pk DILITHIUM_NAMESPACE(unpack_pk)
+void unpack_pk(uint8_t rho[SEEDBYTES], polyveck *t1, const uint8_t pk[CRYPTO_PUBLICKEYBYTES]);
+
+#define unpack_sk DILITHIUM_NAMESPACE(unpack_sk)
+void unpack_sk(uint8_t rho[SEEDBYTES],
+               uint8_t tr[TRBYTES],
+               uint8_t key[SEEDBYTES],
+               polyveck *t0,
+               polyvecl *s1,
+               polyveck *s2,
+               const uint8_t sk[CRYPTO_SECRETKEYBYTES]);
+
+#define unpack_sig DILITHIUM_NAMESPACE(unpack_sig)
+int unpack_sig(uint8_t c[CTILDEBYTES], polyvecl *z, polyveck *h, const uint8_t sig[CRYPTO_BYTES]);
+
+#endif
+
+/* end: ref/packing.h */
+
+
+/* begin: ref/sign.h */
+
+#ifndef SIGN_H
+#define SIGN_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
+int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+
+#define crypto_sign_signature_internal DILITHIUM_NAMESPACE(signature_internal)
+int crypto_sign_signature_internal(uint8_t *sig,
+                                   size_t *siglen,
+                                   const uint8_t *m,
+                                   size_t mlen,
+                                   const uint8_t *pre,
+                                   size_t prelen,
+                                   const uint8_t rnd[RNDBYTES],
+                                   const uint8_t *sk);
+
+#define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
+int crypto_sign_signature(uint8_t *sig, size_t *siglen,
+                          const uint8_t *m, size_t mlen,
+                          const uint8_t *ctx, size_t ctxlen,
+                          const uint8_t *sk);
+
+#define crypto_sign DILITHIUM_NAMESPACETOP
+int crypto_sign(uint8_t *sm, size_t *smlen,
+                const uint8_t *m, size_t mlen,
+                const uint8_t *ctx, size_t ctxlen,
+                const uint8_t *sk);
+
+#define crypto_sign_verify_internal DILITHIUM_NAMESPACE(verify_internal)
+int crypto_sign_verify_internal(const uint8_t *sig,
+                                size_t siglen,
+                                const uint8_t *m,
+                                size_t mlen,
+                                const uint8_t *pre,
+                                size_t prelen,
+                                const uint8_t *pk);
+
+#define crypto_sign_verify DILITHIUM_NAMESPACE(verify)
+int crypto_sign_verify(const uint8_t *sig, size_t siglen,
+                       const uint8_t *m, size_t mlen,
+                       const uint8_t *ctx, size_t ctxlen,
+                       const uint8_t *pk);
+
+#define crypto_sign_open DILITHIUM_NAMESPACE(open)
+int crypto_sign_open(uint8_t *m, size_t *mlen,
+                     const uint8_t *sm, size_t smlen,
+                     const uint8_t *ctx, size_t ctxlen,
+                     const uint8_t *pk);
+
+#endif
+
+/* end: ref/sign.h */
+
+
+/* begin: ref/fips202.c */
+
+/* Based on the public domain implementation in crypto_hash/keccakc512/simple/ from
+ * http://bench.cr.yp.to/supercop.html by Ronny Van Keer and the public domain "TweetFips202"
+ * implementation from https://twitter.com/tweetfips202 by Gilles Van Assche, Daniel J. Bernstein,
+ * and Peter Schwabe */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define NROUNDS 24
+#define ROL(a, offset) ((a << offset) ^ (a >> (64-offset)))
+
+/*************************************************
+* Name:        load64
+*
+* Description: Load 8 bytes into uint64_t in little-endian order
+*
+* Arguments:   - const uint8_t *x: pointer to input byte array
+*
+* Returns the loaded 64-bit unsigned integer
+**************************************************/
+static uint64_t load64(const uint8_t x[8]) {
+  unsigned int i;
+  uint64_t r = 0;
+
+  for(i=0;i<8;i++)
+    r |= (uint64_t)x[i] << 8*i;
+
+  return r;
+}
+
+/*************************************************
+* Name:        store64
+*
+* Description: Store a 64-bit integer to array of 8 bytes in little-endian order
+*
+* Arguments:   - uint8_t *x: pointer to the output byte array (allocated)
+*              - uint64_t u: input 64-bit unsigned integer
+**************************************************/
+static void store64(uint8_t x[8], uint64_t u) {
+  unsigned int i;
+
+  for(i=0;i<8;i++)
+    x[i] = u >> 8*i;
+}
+
+/* Keccak round constants */
+const uint64_t KeccakF_RoundConstants[NROUNDS] = {
+  (uint64_t)0x0000000000000001ULL,
+  (uint64_t)0x0000000000008082ULL,
+  (uint64_t)0x800000000000808aULL,
+  (uint64_t)0x8000000080008000ULL,
+  (uint64_t)0x000000000000808bULL,
+  (uint64_t)0x0000000080000001ULL,
+  (uint64_t)0x8000000080008081ULL,
+  (uint64_t)0x8000000000008009ULL,
+  (uint64_t)0x000000000000008aULL,
+  (uint64_t)0x0000000000000088ULL,
+  (uint64_t)0x0000000080008009ULL,
+  (uint64_t)0x000000008000000aULL,
+  (uint64_t)0x000000008000808bULL,
+  (uint64_t)0x800000000000008bULL,
+  (uint64_t)0x8000000000008089ULL,
+  (uint64_t)0x8000000000008003ULL,
+  (uint64_t)0x8000000000008002ULL,
+  (uint64_t)0x8000000000000080ULL,
+  (uint64_t)0x000000000000800aULL,
+  (uint64_t)0x800000008000000aULL,
+  (uint64_t)0x8000000080008081ULL,
+  (uint64_t)0x8000000000008080ULL,
+  (uint64_t)0x0000000080000001ULL,
+  (uint64_t)0x8000000080008008ULL
+};
+
+/*************************************************
+* Name:        KeccakF1600_StatePermute
+*
+* Description: The Keccak F1600 Permutation
+*
+* Arguments:   - uint64_t *state: pointer to input/output Keccak state
+**************************************************/
+static void KeccakF1600_StatePermute(uint64_t state[25])
+{
+        int round;
+
+        uint64_t Aba, Abe, Abi, Abo, Abu;
+        uint64_t Aga, Age, Agi, Ago, Agu;
+        uint64_t Aka, Ake, Aki, Ako, Aku;
+        uint64_t Ama, Ame, Ami, Amo, Amu;
+        uint64_t Asa, Ase, Asi, Aso, Asu;
+        uint64_t BCa, BCe, BCi, BCo, BCu;
+        uint64_t Da, De, Di, Do, Du;
+        uint64_t Eba, Ebe, Ebi, Ebo, Ebu;
+        uint64_t Ega, Ege, Egi, Ego, Egu;
+        uint64_t Eka, Eke, Eki, Eko, Eku;
+        uint64_t Ema, Eme, Emi, Emo, Emu;
+        uint64_t Esa, Ese, Esi, Eso, Esu;
+
+        //copyFromState(A, state)
+        Aba = state[ 0];
+        Abe = state[ 1];
+        Abi = state[ 2];
+        Abo = state[ 3];
+        Abu = state[ 4];
+        Aga = state[ 5];
+        Age = state[ 6];
+        Agi = state[ 7];
+        Ago = state[ 8];
+        Agu = state[ 9];
+        Aka = state[10];
+        Ake = state[11];
+        Aki = state[12];
+        Ako = state[13];
+        Aku = state[14];
+        Ama = state[15];
+        Ame = state[16];
+        Ami = state[17];
+        Amo = state[18];
+        Amu = state[19];
+        Asa = state[20];
+        Ase = state[21];
+        Asi = state[22];
+        Aso = state[23];
+        Asu = state[24];
+
+        for(round = 0; round < NROUNDS; round += 2) {
+            //    prepareTheta
+            BCa = Aba^Aga^Aka^Ama^Asa;
+            BCe = Abe^Age^Ake^Ame^Ase;
+            BCi = Abi^Agi^Aki^Ami^Asi;
+            BCo = Abo^Ago^Ako^Amo^Aso;
+            BCu = Abu^Agu^Aku^Amu^Asu;
+
+            //thetaRhoPiChiIotaPrepareTheta(round, A, E)
+            Da = BCu^ROL(BCe, 1);
+            De = BCa^ROL(BCi, 1);
+            Di = BCe^ROL(BCo, 1);
+            Do = BCi^ROL(BCu, 1);
+            Du = BCo^ROL(BCa, 1);
+
+            Aba ^= Da;
+            BCa = Aba;
+            Age ^= De;
+            BCe = ROL(Age, 44);
+            Aki ^= Di;
+            BCi = ROL(Aki, 43);
+            Amo ^= Do;
+            BCo = ROL(Amo, 21);
+            Asu ^= Du;
+            BCu = ROL(Asu, 14);
+            Eba =   BCa ^((~BCe)&  BCi );
+            Eba ^= (uint64_t)KeccakF_RoundConstants[round];
+            Ebe =   BCe ^((~BCi)&  BCo );
+            Ebi =   BCi ^((~BCo)&  BCu );
+            Ebo =   BCo ^((~BCu)&  BCa );
+            Ebu =   BCu ^((~BCa)&  BCe );
+
+            Abo ^= Do;
+            BCa = ROL(Abo, 28);
+            Agu ^= Du;
+            BCe = ROL(Agu, 20);
+            Aka ^= Da;
+            BCi = ROL(Aka,  3);
+            Ame ^= De;
+            BCo = ROL(Ame, 45);
+            Asi ^= Di;
+            BCu = ROL(Asi, 61);
+            Ega =   BCa ^((~BCe)&  BCi );
+            Ege =   BCe ^((~BCi)&  BCo );
+            Egi =   BCi ^((~BCo)&  BCu );
+            Ego =   BCo ^((~BCu)&  BCa );
+            Egu =   BCu ^((~BCa)&  BCe );
+
+            Abe ^= De;
+            BCa = ROL(Abe,  1);
+            Agi ^= Di;
+            BCe = ROL(Agi,  6);
+            Ako ^= Do;
+            BCi = ROL(Ako, 25);
+            Amu ^= Du;
+            BCo = ROL(Amu,  8);
+            Asa ^= Da;
+            BCu = ROL(Asa, 18);
+            Eka =   BCa ^((~BCe)&  BCi );
+            Eke =   BCe ^((~BCi)&  BCo );
+            Eki =   BCi ^((~BCo)&  BCu );
+            Eko =   BCo ^((~BCu)&  BCa );
+            Eku =   BCu ^((~BCa)&  BCe );
+
+            Abu ^= Du;
+            BCa = ROL(Abu, 27);
+            Aga ^= Da;
+            BCe = ROL(Aga, 36);
+            Ake ^= De;
+            BCi = ROL(Ake, 10);
+            Ami ^= Di;
+            BCo = ROL(Ami, 15);
+            Aso ^= Do;
+            BCu = ROL(Aso, 56);
+            Ema =   BCa ^((~BCe)&  BCi );
+            Eme =   BCe ^((~BCi)&  BCo );
+            Emi =   BCi ^((~BCo)&  BCu );
+            Emo =   BCo ^((~BCu)&  BCa );
+            Emu =   BCu ^((~BCa)&  BCe );
+
+            Abi ^= Di;
+            BCa = ROL(Abi, 62);
+            Ago ^= Do;
+            BCe = ROL(Ago, 55);
+            Aku ^= Du;
+            BCi = ROL(Aku, 39);
+            Ama ^= Da;
+            BCo = ROL(Ama, 41);
+            Ase ^= De;
+            BCu = ROL(Ase,  2);
+            Esa =   BCa ^((~BCe)&  BCi );
+            Ese =   BCe ^((~BCi)&  BCo );
+            Esi =   BCi ^((~BCo)&  BCu );
+            Eso =   BCo ^((~BCu)&  BCa );
+            Esu =   BCu ^((~BCa)&  BCe );
+
+            //    prepareTheta
+            BCa = Eba^Ega^Eka^Ema^Esa;
+            BCe = Ebe^Ege^Eke^Eme^Ese;
+            BCi = Ebi^Egi^Eki^Emi^Esi;
+            BCo = Ebo^Ego^Eko^Emo^Eso;
+            BCu = Ebu^Egu^Eku^Emu^Esu;
+
+            //thetaRhoPiChiIotaPrepareTheta(round+1, E, A)
+            Da = BCu^ROL(BCe, 1);
+            De = BCa^ROL(BCi, 1);
+            Di = BCe^ROL(BCo, 1);
+            Do = BCi^ROL(BCu, 1);
+            Du = BCo^ROL(BCa, 1);
+
+            Eba ^= Da;
+            BCa = Eba;
+            Ege ^= De;
+            BCe = ROL(Ege, 44);
+            Eki ^= Di;
+            BCi = ROL(Eki, 43);
+            Emo ^= Do;
+            BCo = ROL(Emo, 21);
+            Esu ^= Du;
+            BCu = ROL(Esu, 14);
+            Aba =   BCa ^((~BCe)&  BCi );
+            Aba ^= (uint64_t)KeccakF_RoundConstants[round+1];
+            Abe =   BCe ^((~BCi)&  BCo );
+            Abi =   BCi ^((~BCo)&  BCu );
+            Abo =   BCo ^((~BCu)&  BCa );
+            Abu =   BCu ^((~BCa)&  BCe );
+
+            Ebo ^= Do;
+            BCa = ROL(Ebo, 28);
+            Egu ^= Du;
+            BCe = ROL(Egu, 20);
+            Eka ^= Da;
+            BCi = ROL(Eka, 3);
+            Eme ^= De;
+            BCo = ROL(Eme, 45);
+            Esi ^= Di;
+            BCu = ROL(Esi, 61);
+            Aga =   BCa ^((~BCe)&  BCi );
+            Age =   BCe ^((~BCi)&  BCo );
+            Agi =   BCi ^((~BCo)&  BCu );
+            Ago =   BCo ^((~BCu)&  BCa );
+            Agu =   BCu ^((~BCa)&  BCe );
+
+            Ebe ^= De;
+            BCa = ROL(Ebe, 1);
+            Egi ^= Di;
+            BCe = ROL(Egi, 6);
+            Eko ^= Do;
+            BCi = ROL(Eko, 25);
+            Emu ^= Du;
+            BCo = ROL(Emu, 8);
+            Esa ^= Da;
+            BCu = ROL(Esa, 18);
+            Aka =   BCa ^((~BCe)&  BCi );
+            Ake =   BCe ^((~BCi)&  BCo );
+            Aki =   BCi ^((~BCo)&  BCu );
+            Ako =   BCo ^((~BCu)&  BCa );
+            Aku =   BCu ^((~BCa)&  BCe );
+
+            Ebu ^= Du;
+            BCa = ROL(Ebu, 27);
+            Ega ^= Da;
+            BCe = ROL(Ega, 36);
+            Eke ^= De;
+            BCi = ROL(Eke, 10);
+            Emi ^= Di;
+            BCo = ROL(Emi, 15);
+            Eso ^= Do;
+            BCu = ROL(Eso, 56);
+            Ama =   BCa ^((~BCe)&  BCi );
+            Ame =   BCe ^((~BCi)&  BCo );
+            Ami =   BCi ^((~BCo)&  BCu );
+            Amo =   BCo ^((~BCu)&  BCa );
+            Amu =   BCu ^((~BCa)&  BCe );
+
+            Ebi ^= Di;
+            BCa = ROL(Ebi, 62);
+            Ego ^= Do;
+            BCe = ROL(Ego, 55);
+            Eku ^= Du;
+            BCi = ROL(Eku, 39);
+            Ema ^= Da;
+            BCo = ROL(Ema, 41);
+            Ese ^= De;
+            BCu = ROL(Ese, 2);
+            Asa =   BCa ^((~BCe)&  BCi );
+            Ase =   BCe ^((~BCi)&  BCo );
+            Asi =   BCi ^((~BCo)&  BCu );
+            Aso =   BCo ^((~BCu)&  BCa );
+            Asu =   BCu ^((~BCa)&  BCe );
+        }
+
+        //copyToState(state, A)
+        state[ 0] = Aba;
+        state[ 1] = Abe;
+        state[ 2] = Abi;
+        state[ 3] = Abo;
+        state[ 4] = Abu;
+        state[ 5] = Aga;
+        state[ 6] = Age;
+        state[ 7] = Agi;
+        state[ 8] = Ago;
+        state[ 9] = Agu;
+        state[10] = Aka;
+        state[11] = Ake;
+        state[12] = Aki;
+        state[13] = Ako;
+        state[14] = Aku;
+        state[15] = Ama;
+        state[16] = Ame;
+        state[17] = Ami;
+        state[18] = Amo;
+        state[19] = Amu;
+        state[20] = Asa;
+        state[21] = Ase;
+        state[22] = Asi;
+        state[23] = Aso;
+        state[24] = Asu;
+}
+
+/*************************************************
+* Name:        keccak_init
+*
+* Description: Initializes the Keccak state.
+*
+* Arguments:   - uint64_t *s: pointer to Keccak state
+**************************************************/
+static void keccak_init(uint64_t s[25])
+{
+  unsigned int i;
+  for(i=0;i<25;i++)
+    s[i] = 0;
+}
+
+/*************************************************
+* Name:        keccak_absorb
+*
+* Description: Absorb step of Keccak; incremental.
+*
+* Arguments:   - uint64_t *s: pointer to Keccak state
+*              - unsigned int pos: position in current block to be absorbed
+*              - unsigned int r: rate in bytes (e.g., 168 for SHAKE128)
+*              - const uint8_t *in: pointer to input to be absorbed into s
+*              - size_t inlen: length of input in bytes
+*
+* Returns new position pos in current block
+**************************************************/
+static unsigned int keccak_absorb(uint64_t s[25],
+                                  unsigned int pos,
+                                  unsigned int r,
+                                  const uint8_t *in,
+                                  size_t inlen)
+{
+  unsigned int i;
+
+  while(pos+inlen >= r) {
+    for(i=pos;i<r;i++)
+      s[i/8] ^= (uint64_t)*in++ << 8*(i%8);
+    inlen -= r-pos;
+    KeccakF1600_StatePermute(s);
+    pos = 0;
+  }
+
+  for(i=pos;i<pos+inlen;i++)
+    s[i/8] ^= (uint64_t)*in++ << 8*(i%8);
+
+  return i;
+}
+
+/*************************************************
+* Name:        keccak_finalize
+*
+* Description: Finalize absorb step.
+*
+* Arguments:   - uint64_t *s: pointer to Keccak state
+*              - unsigned int pos: position in current block to be absorbed
+*              - unsigned int r: rate in bytes (e.g., 168 for SHAKE128)
+*              - uint8_t p: domain separation byte
+**************************************************/
+static void keccak_finalize(uint64_t s[25], unsigned int pos, unsigned int r, uint8_t p)
+{
+  s[pos/8] ^= (uint64_t)p << 8*(pos%8);
+  s[r/8-1] ^= 1ULL << 63;
+}
+
+/*************************************************
+* Name:        keccak_squeeze
+*
+* Description: Squeeze step of Keccak. Squeezes arbitratrily many bytes.
+*              Modifies the state. Can be called multiple times to keep
+*              squeezing, i.e., is incremental.
+*
+* Arguments:   - uint8_t *out: pointer to output
+*              - size_t outlen: number of bytes to be squeezed (written to out)
+*              - uint64_t *s: pointer to input/output Keccak state
+*              - unsigned int pos: number of bytes in current block already squeezed
+*              - unsigned int r: rate in bytes (e.g., 168 for SHAKE128)
+*
+* Returns new position pos in current block
+**************************************************/
+static unsigned int keccak_squeeze(uint8_t *out,
+                                   size_t outlen,
+                                   uint64_t s[25],
+                                   unsigned int pos,
+                                   unsigned int r)
+{
+  unsigned int i;
+
+  while(outlen) {
+    if(pos == r) {
+      KeccakF1600_StatePermute(s);
+      pos = 0;
+    }
+    for(i=pos;i < r && i < pos+outlen; i++)
+      *out++ = s[i/8] >> 8*(i%8);
+    outlen -= i-pos;
+    pos = i;
+  }
+
+  return pos;
+}
+
+
+/*************************************************
+* Name:        keccak_absorb_once
+*
+* Description: Absorb step of Keccak;
+*              non-incremental, starts by zeroeing the state.
+*
+* Arguments:   - uint64_t *s: pointer to (uninitialized) output Keccak state
+*              - unsigned int r: rate in bytes (e.g., 168 for SHAKE128)
+*              - const uint8_t *in: pointer to input to be absorbed into s
+*              - size_t inlen: length of input in bytes
+*              - uint8_t p: domain-separation byte for different Keccak-derived functions
+**************************************************/
+static void keccak_absorb_once(uint64_t s[25],
+                               unsigned int r,
+                               const uint8_t *in,
+                               size_t inlen,
+                               uint8_t p)
+{
+  unsigned int i;
+
+  for(i=0;i<25;i++)
+    s[i] = 0;
+
+  while(inlen >= r) {
+    for(i=0;i<r/8;i++)
+      s[i] ^= load64(in+8*i);
+    in += r;
+    inlen -= r;
+    KeccakF1600_StatePermute(s);
+  }
+
+  for(i=0;i<inlen;i++)
+    s[i/8] ^= (uint64_t)in[i] << 8*(i%8);
+
+  s[i/8] ^= (uint64_t)p << 8*(i%8);
+  s[(r-1)/8] ^= 1ULL << 63;
+}
+
+/*************************************************
+* Name:        keccak_squeezeblocks
+*
+* Description: Squeeze step of Keccak. Squeezes full blocks of r bytes each.
+*              Modifies the state. Can be called multiple times to keep
+*              squeezing, i.e., is incremental. Assumes zero bytes of current
+*              block have already been squeezed.
+*
+* Arguments:   - uint8_t *out: pointer to output blocks
+*              - size_t nblocks: number of blocks to be squeezed (written to out)
+*              - uint64_t *s: pointer to input/output Keccak state
+*              - unsigned int r: rate in bytes (e.g., 168 for SHAKE128)
+**************************************************/
+static void keccak_squeezeblocks(uint8_t *out,
+                                 size_t nblocks,
+                                 uint64_t s[25],
+                                 unsigned int r)
+{
+  unsigned int i;
+
+  while(nblocks) {
+    KeccakF1600_StatePermute(s);
+    for(i=0;i<r/8;i++)
+      store64(out+8*i, s[i]);
+    out += r;
+    nblocks -= 1;
+  }
+}
+
+/*************************************************
+* Name:        shake128_init
+*
+* Description: Initilizes Keccak state for use as SHAKE128 XOF
+*
+* Arguments:   - keccak_state *state: pointer to (uninitialized) Keccak state
+**************************************************/
+void shake128_init(keccak_state *state)
+{
+  keccak_init(state->s);
+  state->pos = 0;
+}
+
+/*************************************************
+* Name:        shake128_absorb
+*
+* Description: Absorb step of the SHAKE128 XOF; incremental.
+*
+* Arguments:   - keccak_state *state: pointer to (initialized) output Keccak state
+*              - const uint8_t *in: pointer to input to be absorbed into s
+*              - size_t inlen: length of input in bytes
+**************************************************/
+void shake128_absorb(keccak_state *state, const uint8_t *in, size_t inlen)
+{
+  state->pos = keccak_absorb(state->s, state->pos, SHAKE128_RATE, in, inlen);
+}
+
+/*************************************************
+* Name:        shake128_finalize
+*
+* Description: Finalize absorb step of the SHAKE128 XOF.
+*
+* Arguments:   - keccak_state *state: pointer to Keccak state
+**************************************************/
+void shake128_finalize(keccak_state *state)
+{
+  keccak_finalize(state->s, state->pos, SHAKE128_RATE, 0x1F);
+  state->pos = SHAKE128_RATE;
+}
+
+/*************************************************
+* Name:        shake128_squeeze
+*
+* Description: Squeeze step of SHAKE128 XOF. Squeezes arbitraily many
+*              bytes. Can be called multiple times to keep squeezing.
+*
+* Arguments:   - uint8_t *out: pointer to output blocks
+*              - size_t outlen : number of bytes to be squeezed (written to output)
+*              - keccak_state *s: pointer to input/output Keccak state
+**************************************************/
+void shake128_squeeze(uint8_t *out, size_t outlen, keccak_state *state)
+{
+  state->pos = keccak_squeeze(out, outlen, state->s, state->pos, SHAKE128_RATE);
+}
+
+/*************************************************
+* Name:        shake128_absorb_once
+*
+* Description: Initialize, absorb into and finalize SHAKE128 XOF; non-incremental.
+*
+* Arguments:   - keccak_state *state: pointer to (uninitialized) output Keccak state
+*              - const uint8_t *in: pointer to input to be absorbed into s
+*              - size_t inlen: length of input in bytes
+**************************************************/
+void shake128_absorb_once(keccak_state *state, const uint8_t *in, size_t inlen)
+{
+  keccak_absorb_once(state->s, SHAKE128_RATE, in, inlen, 0x1F);
+  state->pos = SHAKE128_RATE;
+}
+
+/*************************************************
+* Name:        shake128_squeezeblocks
+*
+* Description: Squeeze step of SHAKE128 XOF. Squeezes full blocks of
+*              SHAKE128_RATE bytes each. Can be called multiple times
+*              to keep squeezing. Assumes new block has not yet been
+*              started (state->pos = SHAKE128_RATE).
+*
+* Arguments:   - uint8_t *out: pointer to output blocks
+*              - size_t nblocks: number of blocks to be squeezed (written to output)
+*              - keccak_state *s: pointer to input/output Keccak state
+**************************************************/
+void shake128_squeezeblocks(uint8_t *out, size_t nblocks, keccak_state *state)
+{
+  keccak_squeezeblocks(out, nblocks, state->s, SHAKE128_RATE);
+}
+
+/*************************************************
+* Name:        shake256_init
+*
+* Description: Initilizes Keccak state for use as SHAKE256 XOF
+*
+* Arguments:   - keccak_state *state: pointer to (uninitialized) Keccak state
+**************************************************/
+void shake256_init(keccak_state *state)
+{
+  keccak_init(state->s);
+  state->pos = 0;
+}
+
+/*************************************************
+* Name:        shake256_absorb
+*
+* Description: Absorb step of the SHAKE256 XOF; incremental.
+*
+* Arguments:   - keccak_state *state: pointer to (initialized) output Keccak state
+*              - const uint8_t *in: pointer to input to be absorbed into s
+*              - size_t inlen: length of input in bytes
+**************************************************/
+void shake256_absorb(keccak_state *state, const uint8_t *in, size_t inlen)
+{
+  state->pos = keccak_absorb(state->s, state->pos, SHAKE256_RATE, in, inlen);
+}
+
+/*************************************************
+* Name:        shake256_finalize
+*
+* Description: Finalize absorb step of the SHAKE256 XOF.
+*
+* Arguments:   - keccak_state *state: pointer to Keccak state
+**************************************************/
+void shake256_finalize(keccak_state *state)
+{
+  keccak_finalize(state->s, state->pos, SHAKE256_RATE, 0x1F);
+  state->pos = SHAKE256_RATE;
+}
+
+/*************************************************
+* Name:        shake256_squeeze
+*
+* Description: Squeeze step of SHAKE256 XOF. Squeezes arbitraily many
+*              bytes. Can be called multiple times to keep squeezing.
+*
+* Arguments:   - uint8_t *out: pointer to output blocks
+*              - size_t outlen : number of bytes to be squeezed (written to output)
+*              - keccak_state *s: pointer to input/output Keccak state
+**************************************************/
+void shake256_squeeze(uint8_t *out, size_t outlen, keccak_state *state)
+{
+  state->pos = keccak_squeeze(out, outlen, state->s, state->pos, SHAKE256_RATE);
+}
+
+/*************************************************
+* Name:        shake256_absorb_once
+*
+* Description: Initialize, absorb into and finalize SHAKE256 XOF; non-incremental.
+*
+* Arguments:   - keccak_state *state: pointer to (uninitialized) output Keccak state
+*              - const uint8_t *in: pointer to input to be absorbed into s
+*              - size_t inlen: length of input in bytes
+**************************************************/
+void shake256_absorb_once(keccak_state *state, const uint8_t *in, size_t inlen)
+{
+  keccak_absorb_once(state->s, SHAKE256_RATE, in, inlen, 0x1F);
+  state->pos = SHAKE256_RATE;
+}
+
+/*************************************************
+* Name:        shake256_squeezeblocks
+*
+* Description: Squeeze step of SHAKE256 XOF. Squeezes full blocks of
+*              SHAKE256_RATE bytes each. Can be called multiple times
+*              to keep squeezing. Assumes next block has not yet been
+*              started (state->pos = SHAKE256_RATE).
+*
+* Arguments:   - uint8_t *out: pointer to output blocks
+*              - size_t nblocks: number of blocks to be squeezed (written to output)
+*              - keccak_state *s: pointer to input/output Keccak state
+**************************************************/
+void shake256_squeezeblocks(uint8_t *out, size_t nblocks, keccak_state *state)
+{
+  keccak_squeezeblocks(out, nblocks, state->s, SHAKE256_RATE);
+}
+
+/*************************************************
+* Name:        shake128
+*
+* Description: SHAKE128 XOF with non-incremental API
+*
+* Arguments:   - uint8_t *out: pointer to output
+*              - size_t outlen: requested output length in bytes
+*              - const uint8_t *in: pointer to input
+*              - size_t inlen: length of input in bytes
+**************************************************/
+void shake128(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen)
+{
+  size_t nblocks;
+  keccak_state state;
+
+  shake128_absorb_once(&state, in, inlen);
+  nblocks = outlen/SHAKE128_RATE;
+  shake128_squeezeblocks(out, nblocks, &state);
+  outlen -= nblocks*SHAKE128_RATE;
+  out += nblocks*SHAKE128_RATE;
+  shake128_squeeze(out, outlen, &state);
+}
+
+/*************************************************
+* Name:        shake256
+*
+* Description: SHAKE256 XOF with non-incremental API
+*
+* Arguments:   - uint8_t *out: pointer to output
+*              - size_t outlen: requested output length in bytes
+*              - const uint8_t *in: pointer to input
+*              - size_t inlen: length of input in bytes
+**************************************************/
+void shake256(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen)
+{
+  size_t nblocks;
+  keccak_state state;
+
+  shake256_absorb_once(&state, in, inlen);
+  nblocks = outlen/SHAKE256_RATE;
+  shake256_squeezeblocks(out, nblocks, &state);
+  outlen -= nblocks*SHAKE256_RATE;
+  out += nblocks*SHAKE256_RATE;
+  shake256_squeeze(out, outlen, &state);
+}
+
+/*************************************************
+* Name:        sha3_256
+*
+* Description: SHA3-256 with non-incremental API
+*
+* Arguments:   - uint8_t *h: pointer to output (32 bytes)
+*              - const uint8_t *in: pointer to input
+*              - size_t inlen: length of input in bytes
+**************************************************/
+void sha3_256(uint8_t h[32], const uint8_t *in, size_t inlen)
+{
+  unsigned int i;
+  uint64_t s[25];
+
+  keccak_absorb_once(s, SHA3_256_RATE, in, inlen, 0x06);
+  KeccakF1600_StatePermute(s);
+  for(i=0;i<4;i++)
+    store64(h+8*i,s[i]);
+}
+
+/*************************************************
+* Name:        sha3_512
+*
+* Description: SHA3-512 with non-incremental API
+*
+* Arguments:   - uint8_t *h: pointer to output (64 bytes)
+*              - const uint8_t *in: pointer to input
+*              - size_t inlen: length of input in bytes
+**************************************************/
+void sha3_512(uint8_t h[64], const uint8_t *in, size_t inlen)
+{
+  unsigned int i;
+  uint64_t s[25];
+
+  keccak_absorb_once(s, SHA3_512_RATE, in, inlen, 0x06);
+  KeccakF1600_StatePermute(s);
+  for(i=0;i<8;i++)
+    store64(h+8*i,s[i]);
+}
+
+/* end: ref/fips202.c */
+
+
+/* begin: ref/reduce.c */
+
+#include <stdint.h>
+
+/*************************************************
+* Name:        montgomery_reduce
+*
+* Description: For finite field element a with -2^{31}Q <= a <= Q*2^31,
+*              compute r \equiv a*2^{-32} (mod Q) such that -Q < r < Q.
+*
+* Arguments:   - int64_t: finite field element a
+*
+* Returns r.
+**************************************************/
+int32_t montgomery_reduce(int64_t a) {
+  int32_t t;
+
+  t = (int64_t)(int32_t)a*QINV;
+  t = (a - (int64_t)t*Q) >> 32;
+  return t;
+}
+
+/*************************************************
+* Name:        reduce32
+*
+* Description: For finite field element a with a <= 2^{31} - 2^{22} - 1,
+*              compute r \equiv a (mod Q) such that -6283008 <= r <= 6283008.
+*
+* Arguments:   - int32_t: finite field element a
+*
+* Returns r.
+**************************************************/
+int32_t reduce32(int32_t a) {
+  int32_t t;
+
+  t = (a + (1 << 22)) >> 23;
+  t = a - t*Q;
+  return t;
+}
+
+/*************************************************
+* Name:        caddq
+*
+* Description: Add Q if input coefficient is negative.
+*
+* Arguments:   - int32_t: finite field element a
+*
+* Returns r.
+**************************************************/
+int32_t caddq(int32_t a) {
+  a += (a >> 31) & Q;
+  return a;
+}
+
+/*************************************************
+* Name:        freeze
+*
+* Description: For finite field element a, compute standard
+*              representative r = a mod^+ Q.
+*
+* Arguments:   - int32_t: finite field element a
+*
+* Returns r.
+**************************************************/
+int32_t freeze(int32_t a) {
+  a = reduce32(a);
+  a = caddq(a);
+  return a;
+}
+
+/* end: ref/reduce.c */
+
+
+/* begin: ref/rounding.c */
+
+#include <stdint.h>
+
+/*************************************************
+* Name:        power2round
+*
+* Description: For finite field element a, compute a0, a1 such that
+*              a mod^+ Q = a1*2^D + a0 with -2^{D-1} < a0 <= 2^{D-1}.
+*              Assumes a to be standard representative.
+*
+* Arguments:   - int32_t a: input element
+*              - int32_t *a0: pointer to output element a0
+*
+* Returns a1.
+**************************************************/
+int32_t power2round(int32_t *a0, int32_t a)  {
+  int32_t a1;
+
+  a1 = (a + (1 << (D-1)) - 1) >> D;
+  *a0 = a - (a1 << D);
+  return a1;
+}
+
+/*************************************************
+* Name:        decompose
+*
+* Description: For finite field element a, compute high and low bits a0, a1 such
+*              that a mod^+ Q = a1*ALPHA + a0 with -ALPHA/2 < a0 <= ALPHA/2 except
+*              if a1 = (Q-1)/ALPHA where we set a1 = 0 and
+*              -ALPHA/2 <= a0 = a mod^+ Q - Q < 0. Assumes a to be standard
+*              representative.
+*
+* Arguments:   - int32_t a: input element
+*              - int32_t *a0: pointer to output element a0
+*
+* Returns a1.
+**************************************************/
+int32_t decompose(int32_t *a0, int32_t a) {
+  int32_t a1;
+
+  a1  = (a + 127) >> 7;
+#if GAMMA2 == (Q-1)/32
+  a1  = (a1*1025 + (1 << 21)) >> 22;
+  a1 &= 15;
+#elif GAMMA2 == (Q-1)/88
+  a1  = (a1*11275 + (1 << 23)) >> 24;
+  a1 ^= ((43 - a1) >> 31) & a1;
+#endif
+
+  *a0  = a - a1*2*GAMMA2;
+  *a0 -= (((Q-1)/2 - *a0) >> 31) & Q;
+  return a1;
+}
+
+/*************************************************
+* Name:        make_hint
+*
+* Description: Compute hint bit indicating whether the low bits of the
+*              input element overflow into the high bits.
+*
+* Arguments:   - int32_t a0: low bits of input element
+*              - int32_t a1: high bits of input element
+*
+* Returns 1 if overflow.
+**************************************************/
+unsigned int make_hint(int32_t a0, int32_t a1) {
+  if(a0 > GAMMA2 || a0 < -GAMMA2 || (a0 == -GAMMA2 && a1 != 0))
+    return 1;
+
+  return 0;
+}
+
+/*************************************************
+* Name:        use_hint
+*
+* Description: Correct high bits according to hint.
+*
+* Arguments:   - int32_t a: input element
+*              - unsigned int hint: hint bit
+*
+* Returns corrected high bits.
+**************************************************/
+int32_t use_hint(int32_t a, unsigned int hint) {
+  int32_t a0, a1;
+
+  a1 = decompose(&a0, a);
+  if(hint == 0)
+    return a1;
+
+#if GAMMA2 == (Q-1)/32
+  if(a0 > 0)
+    return (a1 + 1) & 15;
+  else
+    return (a1 - 1) & 15;
+#elif GAMMA2 == (Q-1)/88
+  if(a0 > 0)
+    return (a1 == 43) ?  0 : a1 + 1;
+  else
+    return (a1 ==  0) ? 43 : a1 - 1;
+#endif
+}
+
+/* end: ref/rounding.c */
+
+
+/* begin: ref/ntt.c */
+
+#include <stdint.h>
+
+static const int32_t zetas[N] = {
+         0,    25847, -2608894,  -518909,   237124,  -777960,  -876248,   466468,
+   1826347,  2353451,  -359251, -2091905,  3119733, -2884855,  3111497,  2680103,
+   2725464,  1024112, -1079900,  3585928,  -549488, -1119584,  2619752, -2108549,
+  -2118186, -3859737, -1399561, -3277672,  1757237,   -19422,  4010497,   280005,
+   2706023,    95776,  3077325,  3530437, -1661693, -3592148, -2537516,  3915439,
+  -3861115, -3043716,  3574422, -2867647,  3539968,  -300467,  2348700,  -539299,
+  -1699267, -1643818,  3505694, -3821735,  3507263, -2140649, -1600420,  3699596,
+    811944,   531354,   954230,  3881043,  3900724, -2556880,  2071892, -2797779,
+  -3930395, -1528703, -3677745, -3041255, -1452451,  3475950,  2176455, -1585221,
+  -1257611,  1939314, -4083598, -1000202, -3190144, -3157330, -3632928,   126922,
+   3412210,  -983419,  2147896,  2715295, -2967645, -3693493,  -411027, -2477047,
+   -671102, -1228525,   -22981, -1308169,  -381987,  1349076,  1852771, -1430430,
+  -3343383,   264944,   508951,  3097992,    44288, -1100098,   904516,  3958618,
+  -3724342,    -8578,  1653064, -3249728,  2389356,  -210977,   759969, -1316856,
+    189548, -3553272,  3159746, -1851402, -2409325,  -177440,  1315589,  1341330,
+   1285669, -1584928,  -812732, -1439742, -3019102, -3881060, -3628969,  3839961,
+   2091667,  3407706,  2316500,  3817976, -3342478,  2244091, -2446433, -3562462,
+    266997,  2434439, -1235728,  3513181, -3520352, -3759364, -1197226, -3193378,
+    900702,  1859098,   909542,   819034,   495491, -1613174,   -43260,  -522500,
+   -655327, -3122442,  2031748,  3207046, -3556995,  -525098,  -768622, -3595838,
+    342297,   286988, -2437823,  4108315,  3437287, -3342277,  1735879,   203044,
+   2842341,  2691481, -2590150,  1265009,  4055324,  1247620,  2486353,  1595974,
+  -3767016,  1250494,  2635921, -3548272, -2994039,  1869119,  1903435, -1050970,
+  -1333058,  1237275, -3318210, -1430225,  -451100,  1312455,  3306115, -1962642,
+  -1279661,  1917081, -2546312, -1374803,  1500165,   777191,  2235880,  3406031,
+   -542412, -2831860, -1671176, -1846953, -2584293, -3724270,   594136, -3776993,
+  -2013608,  2432395,  2454455,  -164721,  1957272,  3369112,   185531, -1207385,
+  -3183426,   162844,  1616392,  3014001,   810149,  1652634, -3694233, -1799107,
+  -3038916,  3523897,  3866901,   269760,  2213111,  -975884,  1717735,   472078,
+   -426683,  1723600, -1803090,  1910376, -1667432, -1104333,  -260646, -3833893,
+  -2939036, -2235985,  -420899, -2286327,   183443,  -976891,  1612842, -3545687,
+   -554416,  3919660,   -48306, -1362209,  3937738,  1400424,  -846154,  1976782
+};
+
+/*************************************************
+* Name:        ntt
+*
+* Description: Forward NTT, in-place. No modular reduction is performed after
+*              additions or subtractions. Output vector is in bitreversed order.
+*
+* Arguments:   - uint32_t p[N]: input/output coefficient array
+**************************************************/
+void ntt(int32_t a[N]) {
+  unsigned int len, start, j, k;
+  int32_t zeta, t;
+
+  k = 0;
+  for(len = 128; len > 0; len >>= 1) {
+    for(start = 0; start < N; start = j + len) {
+      zeta = zetas[++k];
+      for(j = start; j < start + len; ++j) {
+        t = montgomery_reduce((int64_t)zeta * a[j + len]);
+        a[j + len] = a[j] - t;
+        a[j] = a[j] + t;
+      }
+    }
+  }
+}
+
+/*************************************************
+* Name:        invntt_tomont
+*
+* Description: Inverse NTT and multiplication by Montgomery factor 2^32.
+*              In-place. No modular reductions after additions or
+*              subtractions; input coefficients need to be smaller than
+*              Q in absolute value. Output coefficient are smaller than Q in
+*              absolute value.
+*
+* Arguments:   - uint32_t p[N]: input/output coefficient array
+**************************************************/
+void invntt_tomont(int32_t a[N]) {
+  unsigned int start, len, j, k;
+  int32_t t, zeta;
+  const int32_t f = 41978; // mont^2/256
+
+  k = 256;
+  for(len = 1; len < N; len <<= 1) {
+    for(start = 0; start < N; start = j + len) {
+      zeta = -zetas[--k];
+      for(j = start; j < start + len; ++j) {
+        t = a[j];
+        a[j] = t + a[j + len];
+        a[j + len] = t - a[j + len];
+        a[j + len] = montgomery_reduce((int64_t)zeta * a[j + len]);
+      }
+    }
+  }
+
+  for(j = 0; j < N; ++j) {
+    a[j] = montgomery_reduce((int64_t)f * a[j]);
+  }
+}
+
+/* end: ref/ntt.c */
+
+
+/* begin: ref/poly.c */
+
+#include <stdint.h>
+
+#ifdef DBENCH
+extern const uint64_t timing_overhead;
+extern uint64_t *tred, *tadd, *tmul, *tround, *tsample, *tpack;
+#define DBENCH_START() uint64_t time = cpucycles()
+#define DBENCH_STOP(t) t += cpucycles() - time - timing_overhead
+#else
+#define DBENCH_START()
+#define DBENCH_STOP(t)
+#endif
+
+/*************************************************
+* Name:        poly_reduce
+*
+* Description: Inplace reduction of all coefficients of polynomial to
+*              representative in [-6283008,6283008].
+*
+* Arguments:   - poly *a: pointer to input/output polynomial
+**************************************************/
+void poly_reduce(poly *a) {
+  unsigned int i;
+  DBENCH_START();
+
+  for(i = 0; i < N; ++i)
+    a->coeffs[i] = reduce32(a->coeffs[i]);
+
+  DBENCH_STOP(*tred);
+}
+
+/*************************************************
+* Name:        poly_caddq
+*
+* Description: For all coefficients of in/out polynomial add Q if
+*              coefficient is negative.
+*
+* Arguments:   - poly *a: pointer to input/output polynomial
+**************************************************/
+void poly_caddq(poly *a) {
+  unsigned int i;
+  DBENCH_START();
+
+  for(i = 0; i < N; ++i)
+    a->coeffs[i] = caddq(a->coeffs[i]);
+
+  DBENCH_STOP(*tred);
+}
+
+/*************************************************
+* Name:        poly_add
+*
+* Description: Add polynomials. No modular reduction is performed.
+*
+* Arguments:   - poly *c: pointer to output polynomial
+*              - const poly *a: pointer to first summand
+*              - const poly *b: pointer to second summand
+**************************************************/
+void poly_add(poly *c, const poly *a, const poly *b)  {
+  unsigned int i;
+  DBENCH_START();
+
+  for(i = 0; i < N; ++i)
+    c->coeffs[i] = a->coeffs[i] + b->coeffs[i];
+
+  DBENCH_STOP(*tadd);
+}
+
+/*************************************************
+* Name:        poly_sub
+*
+* Description: Subtract polynomials. No modular reduction is
+*              performed.
+*
+* Arguments:   - poly *c: pointer to output polynomial
+*              - const poly *a: pointer to first input polynomial
+*              - const poly *b: pointer to second input polynomial to be
+*                               subtraced from first input polynomial
+**************************************************/
+void poly_sub(poly *c, const poly *a, const poly *b) {
+  unsigned int i;
+  DBENCH_START();
+
+  for(i = 0; i < N; ++i)
+    c->coeffs[i] = a->coeffs[i] - b->coeffs[i];
+
+  DBENCH_STOP(*tadd);
+}
+
+/*************************************************
+* Name:        poly_shiftl
+*
+* Description: Multiply polynomial by 2^D without modular reduction. Assumes
+*              input coefficients to be less than 2^{31-D} in absolute value.
+*
+* Arguments:   - poly *a: pointer to input/output polynomial
+**************************************************/
+void poly_shiftl(poly *a) {
+  unsigned int i;
+  DBENCH_START();
+
+  for(i = 0; i < N; ++i)
+    a->coeffs[i] <<= D;
+
+  DBENCH_STOP(*tmul);
+}
+
+/*************************************************
+* Name:        poly_ntt
+*
+* Description: Inplace forward NTT. Coefficients can grow by
+*              8*Q in absolute value.
+*
+* Arguments:   - poly *a: pointer to input/output polynomial
+**************************************************/
+void poly_ntt(poly *a) {
+  DBENCH_START();
+
+  ntt(a->coeffs);
+
+  DBENCH_STOP(*tmul);
+}
+
+/*************************************************
+* Name:        poly_invntt_tomont
+*
+* Description: Inplace inverse NTT and multiplication by 2^{32}.
+*              Input coefficients need to be less than Q in absolute
+*              value and output coefficients are again bounded by Q.
+*
+* Arguments:   - poly *a: pointer to input/output polynomial
+**************************************************/
+void poly_invntt_tomont(poly *a) {
+  DBENCH_START();
+
+  invntt_tomont(a->coeffs);
+
+  DBENCH_STOP(*tmul);
+}
+
+/*************************************************
+* Name:        poly_pointwise_montgomery
+*
+* Description: Pointwise multiplication of polynomials in NTT domain
+*              representation and multiplication of resulting polynomial
+*              by 2^{-32}.
+*
+* Arguments:   - poly *c: pointer to output polynomial
+*              - const poly *a: pointer to first input polynomial
+*              - const poly *b: pointer to second input polynomial
+**************************************************/
+void poly_pointwise_montgomery(poly *c, const poly *a, const poly *b) {
+  unsigned int i;
+  DBENCH_START();
+
+  for(i = 0; i < N; ++i)
+    c->coeffs[i] = montgomery_reduce((int64_t)a->coeffs[i] * b->coeffs[i]);
+
+  DBENCH_STOP(*tmul);
+}
+
+/*************************************************
+* Name:        poly_power2round
+*
+* Description: For all coefficients c of the input polynomial,
+*              compute c0, c1 such that c mod Q = c1*2^D + c0
+*              with -2^{D-1} < c0 <= 2^{D-1}. Assumes coefficients to be
+*              standard representatives.
+*
+* Arguments:   - poly *a1: pointer to output polynomial with coefficients c1
+*              - poly *a0: pointer to output polynomial with coefficients c0
+*              - const poly *a: pointer to input polynomial
+**************************************************/
+void poly_power2round(poly *a1, poly *a0, const poly *a) {
+  unsigned int i;
+  DBENCH_START();
+
+  for(i = 0; i < N; ++i)
+    a1->coeffs[i] = power2round(&a0->coeffs[i], a->coeffs[i]);
+
+  DBENCH_STOP(*tround);
+}
+
+/*************************************************
+* Name:        poly_decompose
+*
+* Description: For all coefficients c of the input polynomial,
+*              compute high and low bits c0, c1 such c mod Q = c1*ALPHA + c0
+*              with -ALPHA/2 < c0 <= ALPHA/2 except c1 = (Q-1)/ALPHA where we
+*              set c1 = 0 and -ALPHA/2 <= c0 = c mod Q - Q < 0.
+*              Assumes coefficients to be standard representatives.
+*
+* Arguments:   - poly *a1: pointer to output polynomial with coefficients c1
+*              - poly *a0: pointer to output polynomial with coefficients c0
+*              - const poly *a: pointer to input polynomial
+**************************************************/
+void poly_decompose(poly *a1, poly *a0, const poly *a) {
+  unsigned int i;
+  DBENCH_START();
+
+  for(i = 0; i < N; ++i)
+    a1->coeffs[i] = decompose(&a0->coeffs[i], a->coeffs[i]);
+
+  DBENCH_STOP(*tround);
+}
+
+/*************************************************
+* Name:        poly_make_hint
+*
+* Description: Compute hint polynomial. The coefficients of which indicate
+*              whether the low bits of the corresponding coefficient of
+*              the input polynomial overflow into the high bits.
+*
+* Arguments:   - poly *h: pointer to output hint polynomial
+*              - const poly *a0: pointer to low part of input polynomial
+*              - const poly *a1: pointer to high part of input polynomial
+*
+* Returns number of 1 bits.
+**************************************************/
+unsigned int poly_make_hint(poly *h, const poly *a0, const poly *a1) {
+  unsigned int i, s = 0;
+  DBENCH_START();
+
+  for(i = 0; i < N; ++i) {
+    h->coeffs[i] = make_hint(a0->coeffs[i], a1->coeffs[i]);
+    s += h->coeffs[i];
+  }
+
+  DBENCH_STOP(*tround);
+  return s;
+}
+
+/*************************************************
+* Name:        poly_use_hint
+*
+* Description: Use hint polynomial to correct the high bits of a polynomial.
+*
+* Arguments:   - poly *b: pointer to output polynomial with corrected high bits
+*              - const poly *a: pointer to input polynomial
+*              - const poly *h: pointer to input hint polynomial
+**************************************************/
+void poly_use_hint(poly *b, const poly *a, const poly *h) {
+  unsigned int i;
+  DBENCH_START();
+
+  for(i = 0; i < N; ++i)
+    b->coeffs[i] = use_hint(a->coeffs[i], h->coeffs[i]);
+
+  DBENCH_STOP(*tround);
+}
+
+/*************************************************
+* Name:        poly_chknorm
+*
+* Description: Check infinity norm of polynomial against given bound.
+*              Assumes input coefficients were reduced by reduce32().
+*
+* Arguments:   - const poly *a: pointer to polynomial
+*              - int32_t B: norm bound
+*
+* Returns 0 if norm is strictly smaller than B <= (Q-1)/8 and 1 otherwise.
+**************************************************/
+int poly_chknorm(const poly *a, int32_t B) {
+  unsigned int i;
+  int32_t t;
+  DBENCH_START();
+
+  if(B > (Q-1)/8)
+    return 1;
+
+  /* It is ok to leak which coefficient violates the bound since
+     the probability for each coefficient is independent of secret
+     data but we must not leak the sign of the centralized representative. */
+  for(i = 0; i < N; ++i) {
+    /* Absolute value */
+    t = a->coeffs[i] >> 31;
+    t = a->coeffs[i] - (t & 2*a->coeffs[i]);
+
+    if(t >= B) {
+      DBENCH_STOP(*tsample);
+      return 1;
+    }
+  }
+
+  DBENCH_STOP(*tsample);
+  return 0;
+}
+
+/*************************************************
+* Name:        rej_uniform
+*
+* Description: Sample uniformly random coefficients in [0, Q-1] by
+*              performing rejection sampling on array of random bytes.
+*
+* Arguments:   - int32_t *a: pointer to output array (allocated)
+*              - unsigned int len: number of coefficients to be sampled
+*              - const uint8_t *buf: array of random bytes
+*              - unsigned int buflen: length of array of random bytes
+*
+* Returns number of sampled coefficients. Can be smaller than len if not enough
+* random bytes were given.
+**************************************************/
+static unsigned int rej_uniform(int32_t *a,
+                                unsigned int len,
+                                const uint8_t *buf,
+                                unsigned int buflen)
+{
+  unsigned int ctr, pos;
+  uint32_t t;
+  DBENCH_START();
+
+  ctr = pos = 0;
+  while(ctr < len && pos + 3 <= buflen) {
+    t  = buf[pos++];
+    t |= (uint32_t)buf[pos++] << 8;
+    t |= (uint32_t)buf[pos++] << 16;
+    t &= 0x7FFFFF;
+
+    if(t < Q)
+      a[ctr++] = t;
+  }
+
+  DBENCH_STOP(*tsample);
+  return ctr;
+}
+
+/*************************************************
+* Name:        poly_uniform
+*
+* Description: Sample polynomial with uniformly random coefficients
+*              in [0,Q-1] by performing rejection sampling on the
+*              output stream of SHAKE128(seed|nonce)
+*
+* Arguments:   - poly *a: pointer to output polynomial
+*              - const uint8_t seed[]: byte array with seed of length SEEDBYTES
+*              - uint16_t nonce: 2-byte nonce
+**************************************************/
+#define POLY_UNIFORM_NBLOCKS ((768 + STREAM128_BLOCKBYTES - 1)/STREAM128_BLOCKBYTES)
+void poly_uniform(poly *a,
+                  const uint8_t seed[SEEDBYTES],
+                  uint16_t nonce)
+{
+  unsigned int i, ctr, off;
+  unsigned int buflen = POLY_UNIFORM_NBLOCKS*STREAM128_BLOCKBYTES;
+  uint8_t buf[POLY_UNIFORM_NBLOCKS*STREAM128_BLOCKBYTES + 2];
+  stream128_state state;
+
+  stream128_init(&state, seed, nonce);
+  stream128_squeezeblocks(buf, POLY_UNIFORM_NBLOCKS, &state);
+
+  ctr = rej_uniform(a->coeffs, N, buf, buflen);
+
+  while(ctr < N) {
+    off = buflen % 3;
+    for(i = 0; i < off; ++i)
+      buf[i] = buf[buflen - off + i];
+
+    stream128_squeezeblocks(buf + off, 1, &state);
+    buflen = STREAM128_BLOCKBYTES + off;
+    ctr += rej_uniform(a->coeffs + ctr, N - ctr, buf, buflen);
+  }
+}
+
+/*************************************************
+* Name:        rej_eta
+*
+* Description: Sample uniformly random coefficients in [-ETA, ETA] by
+*              performing rejection sampling on array of random bytes.
+*
+* Arguments:   - int32_t *a: pointer to output array (allocated)
+*              - unsigned int len: number of coefficients to be sampled
+*              - const uint8_t *buf: array of random bytes
+*              - unsigned int buflen: length of array of random bytes
+*
+* Returns number of sampled coefficients. Can be smaller than len if not enough
+* random bytes were given.
+**************************************************/
+static unsigned int rej_eta(int32_t *a,
+                            unsigned int len,
+                            const uint8_t *buf,
+                            unsigned int buflen)
+{
+  unsigned int ctr, pos;
+  uint32_t t0, t1;
+  DBENCH_START();
+
+  ctr = pos = 0;
+  while(ctr < len && pos < buflen) {
+    t0 = buf[pos] & 0x0F;
+    t1 = buf[pos++] >> 4;
+
+#if ETA == 2
+    if(t0 < 15) {
+      t0 = t0 - (205*t0 >> 10)*5;
+      a[ctr++] = 2 - t0;
+    }
+    if(t1 < 15 && ctr < len) {
+      t1 = t1 - (205*t1 >> 10)*5;
+      a[ctr++] = 2 - t1;
+    }
+#elif ETA == 4
+    if(t0 < 9)
+      a[ctr++] = 4 - t0;
+    if(t1 < 9 && ctr < len)
+      a[ctr++] = 4 - t1;
+#endif
+  }
+
+  DBENCH_STOP(*tsample);
+  return ctr;
+}
+
+/*************************************************
+* Name:        poly_uniform_eta
+*
+* Description: Sample polynomial with uniformly random coefficients
+*              in [-ETA,ETA] by performing rejection sampling on the
+*              output stream from SHAKE256(seed|nonce)
+*
+* Arguments:   - poly *a: pointer to output polynomial
+*              - const uint8_t seed[]: byte array with seed of length CRHBYTES
+*              - uint16_t nonce: 2-byte nonce
+**************************************************/
+#if ETA == 2
+#define POLY_UNIFORM_ETA_NBLOCKS ((136 + STREAM256_BLOCKBYTES - 1)/STREAM256_BLOCKBYTES)
+#elif ETA == 4
+#define POLY_UNIFORM_ETA_NBLOCKS ((227 + STREAM256_BLOCKBYTES - 1)/STREAM256_BLOCKBYTES)
+#endif
+void poly_uniform_eta(poly *a,
+                      const uint8_t seed[CRHBYTES],
+                      uint16_t nonce)
+{
+  unsigned int ctr;
+  unsigned int buflen = POLY_UNIFORM_ETA_NBLOCKS*STREAM256_BLOCKBYTES;
+  uint8_t buf[POLY_UNIFORM_ETA_NBLOCKS*STREAM256_BLOCKBYTES];
+  stream256_state state;
+
+  stream256_init(&state, seed, nonce);
+  stream256_squeezeblocks(buf, POLY_UNIFORM_ETA_NBLOCKS, &state);
+
+  ctr = rej_eta(a->coeffs, N, buf, buflen);
+
+  while(ctr < N) {
+    stream256_squeezeblocks(buf, 1, &state);
+    ctr += rej_eta(a->coeffs + ctr, N - ctr, buf, STREAM256_BLOCKBYTES);
+  }
+}
+
+/*************************************************
+* Name:        poly_uniform_gamma1m1
+*
+* Description: Sample polynomial with uniformly random coefficients
+*              in [-(GAMMA1 - 1), GAMMA1] by unpacking output stream
+*              of SHAKE256(seed|nonce)
+*
+* Arguments:   - poly *a: pointer to output polynomial
+*              - const uint8_t seed[]: byte array with seed of length CRHBYTES
+*              - uint16_t nonce: 16-bit nonce
+**************************************************/
+#define POLY_UNIFORM_GAMMA1_NBLOCKS ((POLYZ_PACKEDBYTES + STREAM256_BLOCKBYTES - 1)/STREAM256_BLOCKBYTES)
+void poly_uniform_gamma1(poly *a,
+                         const uint8_t seed[CRHBYTES],
+                         uint16_t nonce)
+{
+  uint8_t buf[POLY_UNIFORM_GAMMA1_NBLOCKS*STREAM256_BLOCKBYTES];
+  stream256_state state;
+
+  stream256_init(&state, seed, nonce);
+  stream256_squeezeblocks(buf, POLY_UNIFORM_GAMMA1_NBLOCKS, &state);
+  polyz_unpack(a, buf);
+}
+
+/*************************************************
+* Name:        challenge
+*
+* Description: Implementation of H. Samples polynomial with TAU nonzero
+*              coefficients in {-1,1} using the output stream of
+*              SHAKE256(seed).
+*
+* Arguments:   - poly *c: pointer to output polynomial
+*              - const uint8_t mu[]: byte array containing seed of length CTILDEBYTES
+**************************************************/
+void poly_challenge(poly *c, const uint8_t seed[CTILDEBYTES]) {
+  unsigned int i, b, pos;
+  uint64_t signs;
+  uint8_t buf[SHAKE256_RATE];
+  keccak_state state;
+
+  shake256_init(&state);
+  shake256_absorb(&state, seed, CTILDEBYTES);
+  shake256_finalize(&state);
+  shake256_squeezeblocks(buf, 1, &state);
+
+  signs = 0;
+  for(i = 0; i < 8; ++i)
+    signs |= (uint64_t)buf[i] << 8*i;
+  pos = 8;
+
+  for(i = 0; i < N; ++i)
+    c->coeffs[i] = 0;
+  for(i = N-TAU; i < N; ++i) {
+    do {
+      if(pos >= SHAKE256_RATE) {
+        shake256_squeezeblocks(buf, 1, &state);
+        pos = 0;
+      }
+
+      b = buf[pos++];
+    } while(b > i);
+
+    c->coeffs[i] = c->coeffs[b];
+    c->coeffs[b] = 1 - 2*(signs & 1);
+    signs >>= 1;
+  }
+}
+
+/*************************************************
+* Name:        polyeta_pack
+*
+* Description: Bit-pack polynomial with coefficients in [-ETA,ETA].
+*
+* Arguments:   - uint8_t *r: pointer to output byte array with at least
+*                            POLYETA_PACKEDBYTES bytes
+*              - const poly *a: pointer to input polynomial
+**************************************************/
+void polyeta_pack(uint8_t *r, const poly *a) {
+  unsigned int i;
+  uint8_t t[8];
+  DBENCH_START();
+
+#if ETA == 2
+  for(i = 0; i < N/8; ++i) {
+    t[0] = ETA - a->coeffs[8*i+0];
+    t[1] = ETA - a->coeffs[8*i+1];
+    t[2] = ETA - a->coeffs[8*i+2];
+    t[3] = ETA - a->coeffs[8*i+3];
+    t[4] = ETA - a->coeffs[8*i+4];
+    t[5] = ETA - a->coeffs[8*i+5];
+    t[6] = ETA - a->coeffs[8*i+6];
+    t[7] = ETA - a->coeffs[8*i+7];
+
+    r[3*i+0]  = (t[0] >> 0) | (t[1] << 3) | (t[2] << 6);
+    r[3*i+1]  = (t[2] >> 2) | (t[3] << 1) | (t[4] << 4) | (t[5] << 7);
+    r[3*i+2]  = (t[5] >> 1) | (t[6] << 2) | (t[7] << 5);
+  }
+#elif ETA == 4
+  for(i = 0; i < N/2; ++i) {
+    t[0] = ETA - a->coeffs[2*i+0];
+    t[1] = ETA - a->coeffs[2*i+1];
+    r[i] = t[0] | (t[1] << 4);
+  }
+#endif
+
+  DBENCH_STOP(*tpack);
+}
+
+/*************************************************
+* Name:        polyeta_unpack
+*
+* Description: Unpack polynomial with coefficients in [-ETA,ETA].
+*
+* Arguments:   - poly *r: pointer to output polynomial
+*              - const uint8_t *a: byte array with bit-packed polynomial
+**************************************************/
+void polyeta_unpack(poly *r, const uint8_t *a) {
+  unsigned int i;
+  DBENCH_START();
+
+#if ETA == 2
+  for(i = 0; i < N/8; ++i) {
+    r->coeffs[8*i+0] =  (a[3*i+0] >> 0) & 7;
+    r->coeffs[8*i+1] =  (a[3*i+0] >> 3) & 7;
+    r->coeffs[8*i+2] = ((a[3*i+0] >> 6) | (a[3*i+1] << 2)) & 7;
+    r->coeffs[8*i+3] =  (a[3*i+1] >> 1) & 7;
+    r->coeffs[8*i+4] =  (a[3*i+1] >> 4) & 7;
+    r->coeffs[8*i+5] = ((a[3*i+1] >> 7) | (a[3*i+2] << 1)) & 7;
+    r->coeffs[8*i+6] =  (a[3*i+2] >> 2) & 7;
+    r->coeffs[8*i+7] =  (a[3*i+2] >> 5) & 7;
+
+    r->coeffs[8*i+0] = ETA - r->coeffs[8*i+0];
+    r->coeffs[8*i+1] = ETA - r->coeffs[8*i+1];
+    r->coeffs[8*i+2] = ETA - r->coeffs[8*i+2];
+    r->coeffs[8*i+3] = ETA - r->coeffs[8*i+3];
+    r->coeffs[8*i+4] = ETA - r->coeffs[8*i+4];
+    r->coeffs[8*i+5] = ETA - r->coeffs[8*i+5];
+    r->coeffs[8*i+6] = ETA - r->coeffs[8*i+6];
+    r->coeffs[8*i+7] = ETA - r->coeffs[8*i+7];
+  }
+#elif ETA == 4
+  for(i = 0; i < N/2; ++i) {
+    r->coeffs[2*i+0] = a[i] & 0x0F;
+    r->coeffs[2*i+1] = a[i] >> 4;
+    r->coeffs[2*i+0] = ETA - r->coeffs[2*i+0];
+    r->coeffs[2*i+1] = ETA - r->coeffs[2*i+1];
+  }
+#endif
+
+  DBENCH_STOP(*tpack);
+}
+
+/*************************************************
+* Name:        polyt1_pack
+*
+* Description: Bit-pack polynomial t1 with coefficients fitting in 10 bits.
+*              Input coefficients are assumed to be standard representatives.
+*
+* Arguments:   - uint8_t *r: pointer to output byte array with at least
+*                            POLYT1_PACKEDBYTES bytes
+*              - const poly *a: pointer to input polynomial
+**************************************************/
+void polyt1_pack(uint8_t *r, const poly *a) {
+  unsigned int i;
+  DBENCH_START();
+
+  for(i = 0; i < N/4; ++i) {
+    r[5*i+0] = (a->coeffs[4*i+0] >> 0);
+    r[5*i+1] = (a->coeffs[4*i+0] >> 8) | (a->coeffs[4*i+1] << 2);
+    r[5*i+2] = (a->coeffs[4*i+1] >> 6) | (a->coeffs[4*i+2] << 4);
+    r[5*i+3] = (a->coeffs[4*i+2] >> 4) | (a->coeffs[4*i+3] << 6);
+    r[5*i+4] = (a->coeffs[4*i+3] >> 2);
+  }
+
+  DBENCH_STOP(*tpack);
+}
+
+/*************************************************
+* Name:        polyt1_unpack
+*
+* Description: Unpack polynomial t1 with 10-bit coefficients.
+*              Output coefficients are standard representatives.
+*
+* Arguments:   - poly *r: pointer to output polynomial
+*              - const uint8_t *a: byte array with bit-packed polynomial
+**************************************************/
+void polyt1_unpack(poly *r, const uint8_t *a) {
+  unsigned int i;
+  DBENCH_START();
+
+  for(i = 0; i < N/4; ++i) {
+    r->coeffs[4*i+0] = ((a[5*i+0] >> 0) | ((uint32_t)a[5*i+1] << 8)) & 0x3FF;
+    r->coeffs[4*i+1] = ((a[5*i+1] >> 2) | ((uint32_t)a[5*i+2] << 6)) & 0x3FF;
+    r->coeffs[4*i+2] = ((a[5*i+2] >> 4) | ((uint32_t)a[5*i+3] << 4)) & 0x3FF;
+    r->coeffs[4*i+3] = ((a[5*i+3] >> 6) | ((uint32_t)a[5*i+4] << 2)) & 0x3FF;
+  }
+
+  DBENCH_STOP(*tpack);
+}
+
+/*************************************************
+* Name:        polyt0_pack
+*
+* Description: Bit-pack polynomial t0 with coefficients in ]-2^{D-1}, 2^{D-1}].
+*
+* Arguments:   - uint8_t *r: pointer to output byte array with at least
+*                            POLYT0_PACKEDBYTES bytes
+*              - const poly *a: pointer to input polynomial
+**************************************************/
+void polyt0_pack(uint8_t *r, const poly *a) {
+  unsigned int i;
+  uint32_t t[8];
+  DBENCH_START();
+
+  for(i = 0; i < N/8; ++i) {
+    t[0] = (1 << (D-1)) - a->coeffs[8*i+0];
+    t[1] = (1 << (D-1)) - a->coeffs[8*i+1];
+    t[2] = (1 << (D-1)) - a->coeffs[8*i+2];
+    t[3] = (1 << (D-1)) - a->coeffs[8*i+3];
+    t[4] = (1 << (D-1)) - a->coeffs[8*i+4];
+    t[5] = (1 << (D-1)) - a->coeffs[8*i+5];
+    t[6] = (1 << (D-1)) - a->coeffs[8*i+6];
+    t[7] = (1 << (D-1)) - a->coeffs[8*i+7];
+
+    r[13*i+ 0]  =  t[0];
+    r[13*i+ 1]  =  t[0] >>  8;
+    r[13*i+ 1] |=  t[1] <<  5;
+    r[13*i+ 2]  =  t[1] >>  3;
+    r[13*i+ 3]  =  t[1] >> 11;
+    r[13*i+ 3] |=  t[2] <<  2;
+    r[13*i+ 4]  =  t[2] >>  6;
+    r[13*i+ 4] |=  t[3] <<  7;
+    r[13*i+ 5]  =  t[3] >>  1;
+    r[13*i+ 6]  =  t[3] >>  9;
+    r[13*i+ 6] |=  t[4] <<  4;
+    r[13*i+ 7]  =  t[4] >>  4;
+    r[13*i+ 8]  =  t[4] >> 12;
+    r[13*i+ 8] |=  t[5] <<  1;
+    r[13*i+ 9]  =  t[5] >>  7;
+    r[13*i+ 9] |=  t[6] <<  6;
+    r[13*i+10]  =  t[6] >>  2;
+    r[13*i+11]  =  t[6] >> 10;
+    r[13*i+11] |=  t[7] <<  3;
+    r[13*i+12]  =  t[7] >>  5;
+  }
+
+  DBENCH_STOP(*tpack);
+}
+
+/*************************************************
+* Name:        polyt0_unpack
+*
+* Description: Unpack polynomial t0 with coefficients in ]-2^{D-1}, 2^{D-1}].
+*
+* Arguments:   - poly *r: pointer to output polynomial
+*              - const uint8_t *a: byte array with bit-packed polynomial
+**************************************************/
+void polyt0_unpack(poly *r, const uint8_t *a) {
+  unsigned int i;
+  DBENCH_START();
+
+  for(i = 0; i < N/8; ++i) {
+    r->coeffs[8*i+0]  = a[13*i+0];
+    r->coeffs[8*i+0] |= (uint32_t)a[13*i+1] << 8;
+    r->coeffs[8*i+0] &= 0x1FFF;
+
+    r->coeffs[8*i+1]  = a[13*i+1] >> 5;
+    r->coeffs[8*i+1] |= (uint32_t)a[13*i+2] << 3;
+    r->coeffs[8*i+1] |= (uint32_t)a[13*i+3] << 11;
+    r->coeffs[8*i+1] &= 0x1FFF;
+
+    r->coeffs[8*i+2]  = a[13*i+3] >> 2;
+    r->coeffs[8*i+2] |= (uint32_t)a[13*i+4] << 6;
+    r->coeffs[8*i+2] &= 0x1FFF;
+
+    r->coeffs[8*i+3]  = a[13*i+4] >> 7;
+    r->coeffs[8*i+3] |= (uint32_t)a[13*i+5] << 1;
+    r->coeffs[8*i+3] |= (uint32_t)a[13*i+6] << 9;
+    r->coeffs[8*i+3] &= 0x1FFF;
+
+    r->coeffs[8*i+4]  = a[13*i+6] >> 4;
+    r->coeffs[8*i+4] |= (uint32_t)a[13*i+7] << 4;
+    r->coeffs[8*i+4] |= (uint32_t)a[13*i+8] << 12;
+    r->coeffs[8*i+4] &= 0x1FFF;
+
+    r->coeffs[8*i+5]  = a[13*i+8] >> 1;
+    r->coeffs[8*i+5] |= (uint32_t)a[13*i+9] << 7;
+    r->coeffs[8*i+5] &= 0x1FFF;
+
+    r->coeffs[8*i+6]  = a[13*i+9] >> 6;
+    r->coeffs[8*i+6] |= (uint32_t)a[13*i+10] << 2;
+    r->coeffs[8*i+6] |= (uint32_t)a[13*i+11] << 10;
+    r->coeffs[8*i+6] &= 0x1FFF;
+
+    r->coeffs[8*i+7]  = a[13*i+11] >> 3;
+    r->coeffs[8*i+7] |= (uint32_t)a[13*i+12] << 5;
+    r->coeffs[8*i+7] &= 0x1FFF;
+
+    r->coeffs[8*i+0] = (1 << (D-1)) - r->coeffs[8*i+0];
+    r->coeffs[8*i+1] = (1 << (D-1)) - r->coeffs[8*i+1];
+    r->coeffs[8*i+2] = (1 << (D-1)) - r->coeffs[8*i+2];
+    r->coeffs[8*i+3] = (1 << (D-1)) - r->coeffs[8*i+3];
+    r->coeffs[8*i+4] = (1 << (D-1)) - r->coeffs[8*i+4];
+    r->coeffs[8*i+5] = (1 << (D-1)) - r->coeffs[8*i+5];
+    r->coeffs[8*i+6] = (1 << (D-1)) - r->coeffs[8*i+6];
+    r->coeffs[8*i+7] = (1 << (D-1)) - r->coeffs[8*i+7];
+  }
+
+  DBENCH_STOP(*tpack);
+}
+
+/*************************************************
+* Name:        polyz_pack
+*
+* Description: Bit-pack polynomial with coefficients
+*              in [-(GAMMA1 - 1), GAMMA1].
+*
+* Arguments:   - uint8_t *r: pointer to output byte array with at least
+*                            POLYZ_PACKEDBYTES bytes
+*              - const poly *a: pointer to input polynomial
+**************************************************/
+void polyz_pack(uint8_t *r, const poly *a) {
+  unsigned int i;
+  uint32_t t[4];
+  DBENCH_START();
+
+#if GAMMA1 == (1 << 17)
+  for(i = 0; i < N/4; ++i) {
+    t[0] = GAMMA1 - a->coeffs[4*i+0];
+    t[1] = GAMMA1 - a->coeffs[4*i+1];
+    t[2] = GAMMA1 - a->coeffs[4*i+2];
+    t[3] = GAMMA1 - a->coeffs[4*i+3];
+
+    r[9*i+0]  = t[0];
+    r[9*i+1]  = t[0] >> 8;
+    r[9*i+2]  = t[0] >> 16;
+    r[9*i+2] |= t[1] << 2;
+    r[9*i+3]  = t[1] >> 6;
+    r[9*i+4]  = t[1] >> 14;
+    r[9*i+4] |= t[2] << 4;
+    r[9*i+5]  = t[2] >> 4;
+    r[9*i+6]  = t[2] >> 12;
+    r[9*i+6] |= t[3] << 6;
+    r[9*i+7]  = t[3] >> 2;
+    r[9*i+8]  = t[3] >> 10;
+  }
+#elif GAMMA1 == (1 << 19)
+  for(i = 0; i < N/2; ++i) {
+    t[0] = GAMMA1 - a->coeffs[2*i+0];
+    t[1] = GAMMA1 - a->coeffs[2*i+1];
+
+    r[5*i+0]  = t[0];
+    r[5*i+1]  = t[0] >> 8;
+    r[5*i+2]  = t[0] >> 16;
+    r[5*i+2] |= t[1] << 4;
+    r[5*i+3]  = t[1] >> 4;
+    r[5*i+4]  = t[1] >> 12;
+  }
+#endif
+
+  DBENCH_STOP(*tpack);
+}
+
+/*************************************************
+* Name:        polyz_unpack
+*
+* Description: Unpack polynomial z with coefficients
+*              in [-(GAMMA1 - 1), GAMMA1].
+*
+* Arguments:   - poly *r: pointer to output polynomial
+*              - const uint8_t *a: byte array with bit-packed polynomial
+**************************************************/
+void polyz_unpack(poly *r, const uint8_t *a) {
+  unsigned int i;
+  DBENCH_START();
+
+#if GAMMA1 == (1 << 17)
+  for(i = 0; i < N/4; ++i) {
+    r->coeffs[4*i+0]  = a[9*i+0];
+    r->coeffs[4*i+0] |= (uint32_t)a[9*i+1] << 8;
+    r->coeffs[4*i+0] |= (uint32_t)a[9*i+2] << 16;
+    r->coeffs[4*i+0] &= 0x3FFFF;
+
+    r->coeffs[4*i+1]  = a[9*i+2] >> 2;
+    r->coeffs[4*i+1] |= (uint32_t)a[9*i+3] << 6;
+    r->coeffs[4*i+1] |= (uint32_t)a[9*i+4] << 14;
+    r->coeffs[4*i+1] &= 0x3FFFF;
+
+    r->coeffs[4*i+2]  = a[9*i+4] >> 4;
+    r->coeffs[4*i+2] |= (uint32_t)a[9*i+5] << 4;
+    r->coeffs[4*i+2] |= (uint32_t)a[9*i+6] << 12;
+    r->coeffs[4*i+2] &= 0x3FFFF;
+
+    r->coeffs[4*i+3]  = a[9*i+6] >> 6;
+    r->coeffs[4*i+3] |= (uint32_t)a[9*i+7] << 2;
+    r->coeffs[4*i+3] |= (uint32_t)a[9*i+8] << 10;
+    r->coeffs[4*i+3] &= 0x3FFFF;
+
+    r->coeffs[4*i+0] = GAMMA1 - r->coeffs[4*i+0];
+    r->coeffs[4*i+1] = GAMMA1 - r->coeffs[4*i+1];
+    r->coeffs[4*i+2] = GAMMA1 - r->coeffs[4*i+2];
+    r->coeffs[4*i+3] = GAMMA1 - r->coeffs[4*i+3];
+  }
+#elif GAMMA1 == (1 << 19)
+  for(i = 0; i < N/2; ++i) {
+    r->coeffs[2*i+0]  = a[5*i+0];
+    r->coeffs[2*i+0] |= (uint32_t)a[5*i+1] << 8;
+    r->coeffs[2*i+0] |= (uint32_t)a[5*i+2] << 16;
+    r->coeffs[2*i+0] &= 0xFFFFF;
+
+    r->coeffs[2*i+1]  = a[5*i+2] >> 4;
+    r->coeffs[2*i+1] |= (uint32_t)a[5*i+3] << 4;
+    r->coeffs[2*i+1] |= (uint32_t)a[5*i+4] << 12;
+    /* r->coeffs[2*i+1] &= 0xFFFFF; */ /* No effect, since we're anyway at 20 bits */
+
+    r->coeffs[2*i+0] = GAMMA1 - r->coeffs[2*i+0];
+    r->coeffs[2*i+1] = GAMMA1 - r->coeffs[2*i+1];
+  }
+#endif
+
+  DBENCH_STOP(*tpack);
+}
+
+/*************************************************
+* Name:        polyw1_pack
+*
+* Description: Bit-pack polynomial w1 with coefficients in [0,15] or [0,43].
+*              Input coefficients are assumed to be standard representatives.
+*
+* Arguments:   - uint8_t *r: pointer to output byte array with at least
+*                            POLYW1_PACKEDBYTES bytes
+*              - const poly *a: pointer to input polynomial
+**************************************************/
+void polyw1_pack(uint8_t *r, const poly *a) {
+  unsigned int i;
+  DBENCH_START();
+
+#if GAMMA2 == (Q-1)/88
+  for(i = 0; i < N/4; ++i) {
+    r[3*i+0]  = a->coeffs[4*i+0];
+    r[3*i+0] |= a->coeffs[4*i+1] << 6;
+    r[3*i+1]  = a->coeffs[4*i+1] >> 2;
+    r[3*i+1] |= a->coeffs[4*i+2] << 4;
+    r[3*i+2]  = a->coeffs[4*i+2] >> 4;
+    r[3*i+2] |= a->coeffs[4*i+3] << 2;
+  }
+#elif GAMMA2 == (Q-1)/32
+  for(i = 0; i < N/2; ++i)
+    r[i] = a->coeffs[2*i+0] | (a->coeffs[2*i+1] << 4);
+#endif
+
+  DBENCH_STOP(*tpack);
+}
+
+/* end: ref/poly.c */
+
+
+/* begin: ref/polyvec.c */
+
+#include <stdint.h>
+
+/*************************************************
+* Name:        expand_mat
+*
+* Description: Implementation of ExpandA. Generates matrix A with uniformly
+*              random coefficients a_{i,j} by performing rejection
+*              sampling on the output stream of SHAKE128(rho|j|i)
+*
+* Arguments:   - polyvecl mat[K]: output matrix
+*              - const uint8_t rho[]: byte array containing seed rho
+**************************************************/
+void polyvec_matrix_expand(polyvecl mat[K], const uint8_t rho[SEEDBYTES]) {
+  unsigned int i, j;
+
+  for(i = 0; i < K; ++i)
+    for(j = 0; j < L; ++j)
+      poly_uniform(&mat[i].vec[j], rho, (i << 8) + j);
+}
+
+void polyvec_matrix_pointwise_montgomery(polyveck *t, const polyvecl mat[K], const polyvecl *v) {
+  unsigned int i;
+
+  for(i = 0; i < K; ++i)
+    polyvecl_pointwise_acc_montgomery(&t->vec[i], &mat[i], v);
+}
+
+/**************************************************************/
+/************ Vectors of polynomials of length L **************/
+/**************************************************************/
+
+void polyvecl_uniform_eta(polyvecl *v, const uint8_t seed[CRHBYTES], uint16_t nonce) {
+  unsigned int i;
+
+  for(i = 0; i < L; ++i)
+    poly_uniform_eta(&v->vec[i], seed, nonce++);
+}
+
+void polyvecl_uniform_gamma1(polyvecl *v, const uint8_t seed[CRHBYTES], uint16_t nonce) {
+  unsigned int i;
+
+  for(i = 0; i < L; ++i)
+    poly_uniform_gamma1(&v->vec[i], seed, L*nonce + i);
+}
+
+void polyvecl_reduce(polyvecl *v) {
+  unsigned int i;
+
+  for(i = 0; i < L; ++i)
+    poly_reduce(&v->vec[i]);
+}
+
+/*************************************************
+* Name:        polyvecl_add
+*
+* Description: Add vectors of polynomials of length L.
+*              No modular reduction is performed.
+*
+* Arguments:   - polyvecl *w: pointer to output vector
+*              - const polyvecl *u: pointer to first summand
+*              - const polyvecl *v: pointer to second summand
+**************************************************/
+void polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v) {
+  unsigned int i;
+
+  for(i = 0; i < L; ++i)
+    poly_add(&w->vec[i], &u->vec[i], &v->vec[i]);
+}
+
+/*************************************************
+* Name:        polyvecl_ntt
+*
+* Description: Forward NTT of all polynomials in vector of length L. Output
+*              coefficients can be up to 16*Q larger than input coefficients.
+*
+* Arguments:   - polyvecl *v: pointer to input/output vector
+**************************************************/
+void polyvecl_ntt(polyvecl *v) {
+  unsigned int i;
+
+  for(i = 0; i < L; ++i)
+    poly_ntt(&v->vec[i]);
+}
+
+void polyvecl_invntt_tomont(polyvecl *v) {
+  unsigned int i;
+
+  for(i = 0; i < L; ++i)
+    poly_invntt_tomont(&v->vec[i]);
+}
+
+void polyvecl_pointwise_poly_montgomery(polyvecl *r, const poly *a, const polyvecl *v) {
+  unsigned int i;
+
+  for(i = 0; i < L; ++i)
+    poly_pointwise_montgomery(&r->vec[i], a, &v->vec[i]);
+}
+
+/*************************************************
+* Name:        polyvecl_pointwise_acc_montgomery
+*
+* Description: Pointwise multiply vectors of polynomials of length L, multiply
+*              resulting vector by 2^{-32} and add (accumulate) polynomials
+*              in it. Input/output vectors are in NTT domain representation.
+*
+* Arguments:   - poly *w: output polynomial
+*              - const polyvecl *u: pointer to first input vector
+*              - const polyvecl *v: pointer to second input vector
+**************************************************/
+void polyvecl_pointwise_acc_montgomery(poly *w,
+                                       const polyvecl *u,
+                                       const polyvecl *v)
+{
+  unsigned int i;
+  poly t;
+
+  poly_pointwise_montgomery(w, &u->vec[0], &v->vec[0]);
+  for(i = 1; i < L; ++i) {
+    poly_pointwise_montgomery(&t, &u->vec[i], &v->vec[i]);
+    poly_add(w, w, &t);
+  }
+}
+
+/*************************************************
+* Name:        polyvecl_chknorm
+*
+* Description: Check infinity norm of polynomials in vector of length L.
+*              Assumes input polyvecl to be reduced by polyvecl_reduce().
+*
+* Arguments:   - const polyvecl *v: pointer to vector
+*              - int32_t B: norm bound
+*
+* Returns 0 if norm of all polynomials is strictly smaller than B <= (Q-1)/8
+* and 1 otherwise.
+**************************************************/
+int polyvecl_chknorm(const polyvecl *v, int32_t bound)  {
+  unsigned int i;
+
+  for(i = 0; i < L; ++i)
+    if(poly_chknorm(&v->vec[i], bound))
+      return 1;
+
+  return 0;
+}
+
+/**************************************************************/
+/************ Vectors of polynomials of length K **************/
+/**************************************************************/
+
+void polyveck_uniform_eta(polyveck *v, const uint8_t seed[CRHBYTES], uint16_t nonce) {
+  unsigned int i;
+
+  for(i = 0; i < K; ++i)
+    poly_uniform_eta(&v->vec[i], seed, nonce++);
+}
+
+/*************************************************
+* Name:        polyveck_reduce
+*
+* Description: Reduce coefficients of polynomials in vector of length K
+*              to representatives in [-6283008,6283008].
+*
+* Arguments:   - polyveck *v: pointer to input/output vector
+**************************************************/
+void polyveck_reduce(polyveck *v) {
+  unsigned int i;
+
+  for(i = 0; i < K; ++i)
+    poly_reduce(&v->vec[i]);
+}
+
+/*************************************************
+* Name:        polyveck_caddq
+*
+* Description: For all coefficients of polynomials in vector of length K
+*              add Q if coefficient is negative.
+*
+* Arguments:   - polyveck *v: pointer to input/output vector
+**************************************************/
+void polyveck_caddq(polyveck *v) {
+  unsigned int i;
+
+  for(i = 0; i < K; ++i)
+    poly_caddq(&v->vec[i]);
+}
+
+/*************************************************
+* Name:        polyveck_add
+*
+* Description: Add vectors of polynomials of length K.
+*              No modular reduction is performed.
+*
+* Arguments:   - polyveck *w: pointer to output vector
+*              - const polyveck *u: pointer to first summand
+*              - const polyveck *v: pointer to second summand
+**************************************************/
+void polyveck_add(polyveck *w, const polyveck *u, const polyveck *v) {
+  unsigned int i;
+
+  for(i = 0; i < K; ++i)
+    poly_add(&w->vec[i], &u->vec[i], &v->vec[i]);
+}
+
+/*************************************************
+* Name:        polyveck_sub
+*
+* Description: Subtract vectors of polynomials of length K.
+*              No modular reduction is performed.
+*
+* Arguments:   - polyveck *w: pointer to output vector
+*              - const polyveck *u: pointer to first input vector
+*              - const polyveck *v: pointer to second input vector to be
+*                                   subtracted from first input vector
+**************************************************/
+void polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v) {
+  unsigned int i;
+
+  for(i = 0; i < K; ++i)
+    poly_sub(&w->vec[i], &u->vec[i], &v->vec[i]);
+}
+
+/*************************************************
+* Name:        polyveck_shiftl
+*
+* Description: Multiply vector of polynomials of Length K by 2^D without modular
+*              reduction. Assumes input coefficients to be less than 2^{31-D}.
+*
+* Arguments:   - polyveck *v: pointer to input/output vector
+**************************************************/
+void polyveck_shiftl(polyveck *v) {
+  unsigned int i;
+
+  for(i = 0; i < K; ++i)
+    poly_shiftl(&v->vec[i]);
+}
+
+/*************************************************
+* Name:        polyveck_ntt
+*
+* Description: Forward NTT of all polynomials in vector of length K. Output
+*              coefficients can be up to 16*Q larger than input coefficients.
+*
+* Arguments:   - polyveck *v: pointer to input/output vector
+**************************************************/
+void polyveck_ntt(polyveck *v) {
+  unsigned int i;
+
+  for(i = 0; i < K; ++i)
+    poly_ntt(&v->vec[i]);
+}
+
+/*************************************************
+* Name:        polyveck_invntt_tomont
+*
+* Description: Inverse NTT and multiplication by 2^{32} of polynomials
+*              in vector of length K. Input coefficients need to be less
+*              than 2*Q.
+*
+* Arguments:   - polyveck *v: pointer to input/output vector
+**************************************************/
+void polyveck_invntt_tomont(polyveck *v) {
+  unsigned int i;
+
+  for(i = 0; i < K; ++i)
+    poly_invntt_tomont(&v->vec[i]);
+}
+
+void polyveck_pointwise_poly_montgomery(polyveck *r, const poly *a, const polyveck *v) {
+  unsigned int i;
+
+  for(i = 0; i < K; ++i)
+    poly_pointwise_montgomery(&r->vec[i], a, &v->vec[i]);
+}
+
+
+/*************************************************
+* Name:        polyveck_chknorm
+*
+* Description: Check infinity norm of polynomials in vector of length K.
+*              Assumes input polyveck to be reduced by polyveck_reduce().
+*
+* Arguments:   - const polyveck *v: pointer to vector
+*              - int32_t B: norm bound
+*
+* Returns 0 if norm of all polynomials are strictly smaller than B <= (Q-1)/8
+* and 1 otherwise.
+**************************************************/
+int polyveck_chknorm(const polyveck *v, int32_t bound) {
+  unsigned int i;
+
+  for(i = 0; i < K; ++i)
+    if(poly_chknorm(&v->vec[i], bound))
+      return 1;
+
+  return 0;
+}
+
+/*************************************************
+* Name:        polyveck_power2round
+*
+* Description: For all coefficients a of polynomials in vector of length K,
+*              compute a0, a1 such that a mod^+ Q = a1*2^D + a0
+*              with -2^{D-1} < a0 <= 2^{D-1}. Assumes coefficients to be
+*              standard representatives.
+*
+* Arguments:   - polyveck *v1: pointer to output vector of polynomials with
+*                              coefficients a1
+*              - polyveck *v0: pointer to output vector of polynomials with
+*                              coefficients a0
+*              - const polyveck *v: pointer to input vector
+**************************************************/
+void polyveck_power2round(polyveck *v1, polyveck *v0, const polyveck *v) {
+  unsigned int i;
+
+  for(i = 0; i < K; ++i)
+    poly_power2round(&v1->vec[i], &v0->vec[i], &v->vec[i]);
+}
+
+/*************************************************
+* Name:        polyveck_decompose
+*
+* Description: For all coefficients a of polynomials in vector of length K,
+*              compute high and low bits a0, a1 such a mod^+ Q = a1*ALPHA + a0
+*              with -ALPHA/2 < a0 <= ALPHA/2 except a1 = (Q-1)/ALPHA where we
+*              set a1 = 0 and -ALPHA/2 <= a0 = a mod Q - Q < 0.
+*              Assumes coefficients to be standard representatives.
+*
+* Arguments:   - polyveck *v1: pointer to output vector of polynomials with
+*                              coefficients a1
+*              - polyveck *v0: pointer to output vector of polynomials with
+*                              coefficients a0
+*              - const polyveck *v: pointer to input vector
+**************************************************/
+void polyveck_decompose(polyveck *v1, polyveck *v0, const polyveck *v) {
+  unsigned int i;
+
+  for(i = 0; i < K; ++i)
+    poly_decompose(&v1->vec[i], &v0->vec[i], &v->vec[i]);
+}
+
+/*************************************************
+* Name:        polyveck_make_hint
+*
+* Description: Compute hint vector.
+*
+* Arguments:   - polyveck *h: pointer to output vector
+*              - const polyveck *v0: pointer to low part of input vector
+*              - const polyveck *v1: pointer to high part of input vector
+*
+* Returns number of 1 bits.
+**************************************************/
+unsigned int polyveck_make_hint(polyveck *h,
+                                const polyveck *v0,
+                                const polyveck *v1)
+{
+  unsigned int i, s = 0;
+
+  for(i = 0; i < K; ++i)
+    s += poly_make_hint(&h->vec[i], &v0->vec[i], &v1->vec[i]);
+
+  return s;
+}
+
+/*************************************************
+* Name:        polyveck_use_hint
+*
+* Description: Use hint vector to correct the high bits of input vector.
+*
+* Arguments:   - polyveck *w: pointer to output vector of polynomials with
+*                             corrected high bits
+*              - const polyveck *u: pointer to input vector
+*              - const polyveck *h: pointer to input hint vector
+**************************************************/
+void polyveck_use_hint(polyveck *w, const polyveck *u, const polyveck *h) {
+  unsigned int i;
+
+  for(i = 0; i < K; ++i)
+    poly_use_hint(&w->vec[i], &u->vec[i], &h->vec[i]);
+}
+
+void polyveck_pack_w1(uint8_t r[K*POLYW1_PACKEDBYTES], const polyveck *w1) {
+  unsigned int i;
+
+  for(i = 0; i < K; ++i)
+    polyw1_pack(&r[i*POLYW1_PACKEDBYTES], &w1->vec[i]);
+}
+
+/* end: ref/polyvec.c */
+
+
+/* begin: ref/packing.c */
+
+
+/*************************************************
+* Name:        pack_pk
+*
+* Description: Bit-pack public key pk = (rho, t1).
+*
+* Arguments:   - uint8_t pk[]: output byte array
+*              - const uint8_t rho[]: byte array containing rho
+*              - const polyveck *t1: pointer to vector t1
+**************************************************/
+void pack_pk(uint8_t pk[CRYPTO_PUBLICKEYBYTES],
+             const uint8_t rho[SEEDBYTES],
+             const polyveck *t1)
+{
+  unsigned int i;
+
+  for(i = 0; i < SEEDBYTES; ++i)
+    pk[i] = rho[i];
+  pk += SEEDBYTES;
+
+  for(i = 0; i < K; ++i)
+    polyt1_pack(pk + i*POLYT1_PACKEDBYTES, &t1->vec[i]);
+}
+
+/*************************************************
+* Name:        unpack_pk
+*
+* Description: Unpack public key pk = (rho, t1).
+*
+* Arguments:   - const uint8_t rho[]: output byte array for rho
+*              - const polyveck *t1: pointer to output vector t1
+*              - uint8_t pk[]: byte array containing bit-packed pk
+**************************************************/
+void unpack_pk(uint8_t rho[SEEDBYTES],
+               polyveck *t1,
+               const uint8_t pk[CRYPTO_PUBLICKEYBYTES])
+{
+  unsigned int i;
+
+  for(i = 0; i < SEEDBYTES; ++i)
+    rho[i] = pk[i];
+  pk += SEEDBYTES;
+
+  for(i = 0; i < K; ++i)
+    polyt1_unpack(&t1->vec[i], pk + i*POLYT1_PACKEDBYTES);
+}
+
+/*************************************************
+* Name:        pack_sk
+*
+* Description: Bit-pack secret key sk = (rho, tr, key, t0, s1, s2).
+*
+* Arguments:   - uint8_t sk[]: output byte array
+*              - const uint8_t rho[]: byte array containing rho
+*              - const uint8_t tr[]: byte array containing tr
+*              - const uint8_t key[]: byte array containing key
+*              - const polyveck *t0: pointer to vector t0
+*              - const polyvecl *s1: pointer to vector s1
+*              - const polyveck *s2: pointer to vector s2
+**************************************************/
+void pack_sk(uint8_t sk[CRYPTO_SECRETKEYBYTES],
+             const uint8_t rho[SEEDBYTES],
+             const uint8_t tr[TRBYTES],
+             const uint8_t key[SEEDBYTES],
+             const polyveck *t0,
+             const polyvecl *s1,
+             const polyveck *s2)
+{
+  unsigned int i;
+
+  for(i = 0; i < SEEDBYTES; ++i)
+    sk[i] = rho[i];
+  sk += SEEDBYTES;
+
+  for(i = 0; i < SEEDBYTES; ++i)
+    sk[i] = key[i];
+  sk += SEEDBYTES;
+
+  for(i = 0; i < TRBYTES; ++i)
+    sk[i] = tr[i];
+  sk += TRBYTES;
+
+  for(i = 0; i < L; ++i)
+    polyeta_pack(sk + i*POLYETA_PACKEDBYTES, &s1->vec[i]);
+  sk += L*POLYETA_PACKEDBYTES;
+
+  for(i = 0; i < K; ++i)
+    polyeta_pack(sk + i*POLYETA_PACKEDBYTES, &s2->vec[i]);
+  sk += K*POLYETA_PACKEDBYTES;
+
+  for(i = 0; i < K; ++i)
+    polyt0_pack(sk + i*POLYT0_PACKEDBYTES, &t0->vec[i]);
+}
+
+/*************************************************
+* Name:        unpack_sk
+*
+* Description: Unpack secret key sk = (rho, tr, key, t0, s1, s2).
+*
+* Arguments:   - const uint8_t rho[]: output byte array for rho
+*              - const uint8_t tr[]: output byte array for tr
+*              - const uint8_t key[]: output byte array for key
+*              - const polyveck *t0: pointer to output vector t0
+*              - const polyvecl *s1: pointer to output vector s1
+*              - const polyveck *s2: pointer to output vector s2
+*              - uint8_t sk[]: byte array containing bit-packed sk
+**************************************************/
+void unpack_sk(uint8_t rho[SEEDBYTES],
+               uint8_t tr[TRBYTES],
+               uint8_t key[SEEDBYTES],
+               polyveck *t0,
+               polyvecl *s1,
+               polyveck *s2,
+               const uint8_t sk[CRYPTO_SECRETKEYBYTES])
+{
+  unsigned int i;
+
+  for(i = 0; i < SEEDBYTES; ++i)
+    rho[i] = sk[i];
+  sk += SEEDBYTES;
+
+  for(i = 0; i < SEEDBYTES; ++i)
+    key[i] = sk[i];
+  sk += SEEDBYTES;
+
+  for(i = 0; i < TRBYTES; ++i)
+    tr[i] = sk[i];
+  sk += TRBYTES;
+
+  for(i=0; i < L; ++i)
+    polyeta_unpack(&s1->vec[i], sk + i*POLYETA_PACKEDBYTES);
+  sk += L*POLYETA_PACKEDBYTES;
+
+  for(i=0; i < K; ++i)
+    polyeta_unpack(&s2->vec[i], sk + i*POLYETA_PACKEDBYTES);
+  sk += K*POLYETA_PACKEDBYTES;
+
+  for(i=0; i < K; ++i)
+    polyt0_unpack(&t0->vec[i], sk + i*POLYT0_PACKEDBYTES);
+}
+
+/*************************************************
+* Name:        pack_sig
+*
+* Description: Bit-pack signature sig = (c, z, h).
+*
+* Arguments:   - uint8_t sig[]: output byte array
+*              - const uint8_t *c: pointer to challenge hash length SEEDBYTES
+*              - const polyvecl *z: pointer to vector z
+*              - const polyveck *h: pointer to hint vector h
+**************************************************/
+void pack_sig(uint8_t sig[CRYPTO_BYTES],
+              const uint8_t c[CTILDEBYTES],
+              const polyvecl *z,
+              const polyveck *h)
+{
+  unsigned int i, j, k;
+
+  for(i=0; i < CTILDEBYTES; ++i)
+    sig[i] = c[i];
+  sig += CTILDEBYTES;
+
+  for(i = 0; i < L; ++i)
+    polyz_pack(sig + i*POLYZ_PACKEDBYTES, &z->vec[i]);
+  sig += L*POLYZ_PACKEDBYTES;
+
+  /* Encode h */
+  for(i = 0; i < OMEGA + K; ++i)
+    sig[i] = 0;
+
+  k = 0;
+  for(i = 0; i < K; ++i) {
+    for(j = 0; j < N; ++j)
+      if(h->vec[i].coeffs[j] != 0)
+        sig[k++] = j;
+
+    sig[OMEGA + i] = k;
+  }
+}
+
+/*************************************************
+* Name:        unpack_sig
+*
+* Description: Unpack signature sig = (c, z, h).
+*
+* Arguments:   - uint8_t *c: pointer to output challenge hash
+*              - polyvecl *z: pointer to output vector z
+*              - polyveck *h: pointer to output hint vector h
+*              - const uint8_t sig[]: byte array containing
+*                bit-packed signature
+*
+* Returns 1 in case of malformed signature; otherwise 0.
+**************************************************/
+int unpack_sig(uint8_t c[CTILDEBYTES],
+               polyvecl *z,
+               polyveck *h,
+               const uint8_t sig[CRYPTO_BYTES])
+{
+  unsigned int i, j, k;
+
+  for(i = 0; i < CTILDEBYTES; ++i)
+    c[i] = sig[i];
+  sig += CTILDEBYTES;
+
+  for(i = 0; i < L; ++i)
+    polyz_unpack(&z->vec[i], sig + i*POLYZ_PACKEDBYTES);
+  sig += L*POLYZ_PACKEDBYTES;
+
+  /* Decode h */
+  k = 0;
+  for(i = 0; i < K; ++i) {
+    for(j = 0; j < N; ++j)
+      h->vec[i].coeffs[j] = 0;
+
+    if(sig[OMEGA + i] < k || sig[OMEGA + i] > OMEGA)
+      return 1;
+
+    for(j = k; j < sig[OMEGA + i]; ++j) {
+      /* Coefficients are ordered for strong unforgeability */
+      if(j > k && sig[j] <= sig[j-1]) return 1;
+      h->vec[i].coeffs[sig[j]] = 1;
+    }
+
+    k = sig[OMEGA + i];
+  }
+
+  /* Extra indices are zero for strong unforgeability */
+  for(j = k; j < OMEGA; ++j)
+    if(sig[j])
+      return 1;
+
+  return 0;
+}
+
+/* end: ref/packing.c */
+
+
+/* begin: ref/symmetric-shake.c */
+
+#include <stdint.h>
+
+void dilithium_shake128_stream_init(keccak_state *state, const uint8_t seed[SEEDBYTES], uint16_t nonce)
+{
+  uint8_t t[2];
+  t[0] = nonce;
+  t[1] = nonce >> 8;
+
+  shake128_init(state);
+  shake128_absorb(state, seed, SEEDBYTES);
+  shake128_absorb(state, t, 2);
+  shake128_finalize(state);
+}
+
+void dilithium_shake256_stream_init(keccak_state *state, const uint8_t seed[CRHBYTES], uint16_t nonce)
+{
+  uint8_t t[2];
+  t[0] = nonce;
+  t[1] = nonce >> 8;
+
+  shake256_init(state);
+  shake256_absorb(state, seed, CRHBYTES);
+  shake256_absorb(state, t, 2);
+  shake256_finalize(state);
+}
+
+/* end: ref/symmetric-shake.c */
+
+
+/* begin: ref/sign.c */
+
+#include <stdint.h>
+
+/*************************************************
+* Name:        crypto_sign_keypair
+*
+* Description: Generates public and private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int pqcrystals_dilithium5_ref_keypair_internal(uint8_t *pk, uint8_t *sk,
+                                               const uint8_t coins[SEEDBYTES]) {
+  uint8_t seedbuf[2*SEEDBYTES + CRHBYTES];
+  uint8_t tr[TRBYTES];
+  const uint8_t *rho, *rhoprime, *key;
+  polyvecl mat[K];
+  polyvecl s1, s1hat;
+  polyveck s2, t1, t0;
+
+  /* Get randomness for rho, rhoprime and key */
+  memcpy(seedbuf, coins, SEEDBYTES);
+  seedbuf[SEEDBYTES+0] = K;
+  seedbuf[SEEDBYTES+1] = L;
+  shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seedbuf, SEEDBYTES+2);
+  rho = seedbuf;
+  rhoprime = rho + SEEDBYTES;
+  key = rhoprime + CRHBYTES;
+
+  /* Expand matrix */
+  polyvec_matrix_expand(mat, rho);
+
+  /* Sample short vectors s1 and s2 */
+  polyvecl_uniform_eta(&s1, rhoprime, 0);
+  polyveck_uniform_eta(&s2, rhoprime, L);
+
+  /* Matrix-vector multiplication */
+  s1hat = s1;
+  polyvecl_ntt(&s1hat);
+  polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+  polyveck_reduce(&t1);
+  polyveck_invntt_tomont(&t1);
+
+  /* Add error vector s2 */
+  polyveck_add(&t1, &t1, &s2);
+
+  /* Extract t1 and write public key */
+  polyveck_caddq(&t1);
+  polyveck_power2round(&t1, &t0, &t1);
+  pack_pk(pk, rho, &t1);
+
+  /* Compute H(rho, t1) and write secret key */
+  shake256(tr, TRBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+  pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
+
+  return 0;
+}
+
+/*************************************************
+* Name:        crypto_sign_signature_internal
+*
+* Description: Computes signature. Internal API.
+*
+* Arguments:   - uint8_t *sig:   pointer to output signature (of length CRYPTO_BYTES)
+*              - size_t *siglen: pointer to output length of signature
+*              - uint8_t *m:     pointer to message to be signed
+*              - size_t mlen:    length of message
+*              - uint8_t *pre:   pointer to prefix string
+*              - size_t prelen:  length of prefix string
+*              - uint8_t *rnd:   pointer to random seed
+*              - uint8_t *sk:    pointer to bit-packed secret key
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_signature_internal(uint8_t *sig,
+                                   size_t *siglen,
+                                   const uint8_t *m,
+                                   size_t mlen,
+                                   const uint8_t *pre,
+                                   size_t prelen,
+                                   const uint8_t rnd[RNDBYTES],
+                                   const uint8_t *sk)
+{
+  unsigned int n;
+  uint8_t seedbuf[2*SEEDBYTES + TRBYTES + 2*CRHBYTES];
+  uint8_t *rho, *tr, *key, *mu, *rhoprime;
+  uint16_t nonce = 0;
+  polyvecl mat[K], s1, y, z;
+  polyveck t0, s2, w1, w0, h;
+  poly cp;
+  keccak_state state;
+
+  rho = seedbuf;
+  tr = rho + SEEDBYTES;
+  key = tr + TRBYTES;
+  mu = key + SEEDBYTES;
+  rhoprime = mu + CRHBYTES;
+  unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
+
+  /* Compute mu = CRH(tr, pre, msg) */
+  shake256_init(&state);
+  shake256_absorb(&state, tr, TRBYTES);
+  shake256_absorb(&state, pre, prelen);
+  shake256_absorb(&state, m, mlen);
+  shake256_finalize(&state);
+  shake256_squeeze(mu, CRHBYTES, &state);
+
+  /* Compute rhoprime = CRH(key, rnd, mu) */
+  shake256_init(&state);
+  shake256_absorb(&state, key, SEEDBYTES);
+  shake256_absorb(&state, rnd, RNDBYTES);
+  shake256_absorb(&state, mu, CRHBYTES);
+  shake256_finalize(&state);
+  shake256_squeeze(rhoprime, CRHBYTES, &state);
+
+  /* Expand matrix and transform vectors */
+  polyvec_matrix_expand(mat, rho);
+  polyvecl_ntt(&s1);
+  polyveck_ntt(&s2);
+  polyveck_ntt(&t0);
+
+rej:
+  /* Sample intermediate vector y */
+  polyvecl_uniform_gamma1(&y, rhoprime, nonce++);
+
+  /* Matrix-vector multiplication */
+  z = y;
+  polyvecl_ntt(&z);
+  polyvec_matrix_pointwise_montgomery(&w1, mat, &z);
+  polyveck_reduce(&w1);
+  polyveck_invntt_tomont(&w1);
+
+  /* Decompose w and call the random oracle */
+  polyveck_caddq(&w1);
+  polyveck_decompose(&w1, &w0, &w1);
+  polyveck_pack_w1(sig, &w1);
+
+  shake256_init(&state);
+  shake256_absorb(&state, mu, CRHBYTES);
+  shake256_absorb(&state, sig, K*POLYW1_PACKEDBYTES);
+  shake256_finalize(&state);
+  shake256_squeeze(sig, CTILDEBYTES, &state);
+  poly_challenge(&cp, sig);
+  poly_ntt(&cp);
+
+  /* Compute z, reject if it reveals secret */
+  polyvecl_pointwise_poly_montgomery(&z, &cp, &s1);
+  polyvecl_invntt_tomont(&z);
+  polyvecl_add(&z, &z, &y);
+  polyvecl_reduce(&z);
+  if(polyvecl_chknorm(&z, GAMMA1 - BETA))
+    goto rej;
+
+  /* Check that subtracting cs2 does not change high bits of w and low bits
+   * do not reveal secret information */
+  polyveck_pointwise_poly_montgomery(&h, &cp, &s2);
+  polyveck_invntt_tomont(&h);
+  polyveck_sub(&w0, &w0, &h);
+  polyveck_reduce(&w0);
+  if(polyveck_chknorm(&w0, GAMMA2 - BETA))
+    goto rej;
+
+  /* Compute hints for w1 */
+  polyveck_pointwise_poly_montgomery(&h, &cp, &t0);
+  polyveck_invntt_tomont(&h);
+  polyveck_reduce(&h);
+  if(polyveck_chknorm(&h, GAMMA2))
+    goto rej;
+
+  polyveck_add(&w0, &w0, &h);
+  n = polyveck_make_hint(&h, &w0, &w1);
+  if(n > OMEGA)
+    goto rej;
+
+  /* Write signature */
+  pack_sig(sig, sig, &z, &h);
+  *siglen = CRYPTO_BYTES;
+  return 0;
+}
+
+/*************************************************
+* Name:        crypto_sign_signature
+*
+* Description: Computes signature.
+*
+* Arguments:   - uint8_t *sig:   pointer to output signature (of length CRYPTO_BYTES)
+*              - size_t *siglen: pointer to output length of signature
+*              - uint8_t *m:     pointer to message to be signed
+*              - size_t mlen:    length of message
+*              - uint8_t *ctx:   pointer to contex string
+*              - size_t ctxlen:  length of contex string
+*              - uint8_t *sk:    pointer to bit-packed secret key
+*
+* Returns 0 (success) or -1 (context string too long)
+**************************************************/
+int crypto_sign_signature(uint8_t *sig,
+                          size_t *siglen,
+                          const uint8_t *m,
+                          size_t mlen,
+                          const uint8_t *ctx,
+                          size_t ctxlen,
+                          const uint8_t *sk)
+{
+  size_t i;
+  uint8_t pre[257];
+  uint8_t rnd[RNDBYTES];
+
+  if(ctxlen > 255)
+    return -1;
+
+  /* Prepare pre = (0, ctxlen, ctx) */
+  pre[0] = 0;
+  pre[1] = ctxlen;
+  for(i = 0; i < ctxlen; i++)
+    pre[2 + i] = ctx[i];
+
+#ifdef DILITHIUM_RANDOMIZED_SIGNING
+  randombytes(rnd, RNDBYTES);
+#else
+  for(i=0;i<RNDBYTES;i++)
+    rnd[i] = 0;
+#endif
+
+  crypto_sign_signature_internal(sig,siglen,m,mlen,pre,2+ctxlen,rnd,sk);
+  return 0;
+}
+
+/*************************************************
+* Name:        crypto_sign
+*
+* Description: Compute signed message.
+*
+* Arguments:   - uint8_t *sm: pointer to output signed message (allocated
+*                             array with CRYPTO_BYTES + mlen bytes),
+*                             can be equal to m
+*              - size_t *smlen: pointer to output length of signed
+*                               message
+*              - const uint8_t *m: pointer to message to be signed
+*              - size_t mlen: length of message
+*              - const uint8_t *ctx: pointer to context string
+*              - size_t ctxlen: length of context string
+*              - const uint8_t *sk: pointer to bit-packed secret key
+*
+* Returns 0 (success) or -1 (context string too long)
+**************************************************/
+int crypto_sign(uint8_t *sm,
+                size_t *smlen,
+                const uint8_t *m,
+                size_t mlen,
+                const uint8_t *ctx,
+                size_t ctxlen,
+                const uint8_t *sk)
+{
+  int ret;
+  size_t i;
+
+  for(i = 0; i < mlen; ++i)
+    sm[CRYPTO_BYTES + mlen - 1 - i] = m[mlen - 1 - i];
+  ret = crypto_sign_signature(sm, smlen, sm + CRYPTO_BYTES, mlen, ctx, ctxlen, sk);
+  *smlen += mlen;
+  return ret;
+}
+
+/*************************************************
+* Name:        crypto_sign_verify_internal
+*
+* Description: Verifies signature. Internal API.
+*
+* Arguments:   - uint8_t *m: pointer to input signature
+*              - size_t siglen: length of signature
+*              - const uint8_t *m: pointer to message
+*              - size_t mlen: length of message
+*              - const uint8_t *pre: pointer to prefix string
+*              - size_t prelen: length of prefix string
+*              - const uint8_t *pk: pointer to bit-packed public key
+*
+* Returns 0 if signature could be verified correctly and -1 otherwise
+**************************************************/
+int crypto_sign_verify_internal(const uint8_t *sig,
+                                size_t siglen,
+                                const uint8_t *m,
+                                size_t mlen,
+                                const uint8_t *pre,
+                                size_t prelen,
+                                const uint8_t *pk)
+{
+  unsigned int i;
+  uint8_t buf[K*POLYW1_PACKEDBYTES];
+  uint8_t rho[SEEDBYTES];
+  uint8_t mu[CRHBYTES];
+  uint8_t c[CTILDEBYTES];
+  uint8_t c2[CTILDEBYTES];
+  poly cp;
+  polyvecl mat[K], z;
+  polyveck t1, w1, h;
+  keccak_state state;
+
+  if(siglen != CRYPTO_BYTES)
+    return -1;
+
+  unpack_pk(rho, &t1, pk);
+  if(unpack_sig(c, &z, &h, sig))
+    return -1;
+  if(polyvecl_chknorm(&z, GAMMA1 - BETA))
+    return -1;
+
+  /* Compute CRH(H(rho, t1), pre, msg) */
+  shake256(mu, TRBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+  shake256_init(&state);
+  shake256_absorb(&state, mu, TRBYTES);
+  shake256_absorb(&state, pre, prelen);
+  shake256_absorb(&state, m, mlen);
+  shake256_finalize(&state);
+  shake256_squeeze(mu, CRHBYTES, &state);
+
+  /* Matrix-vector multiplication; compute Az - c2^dt1 */
+  poly_challenge(&cp, c);
+  polyvec_matrix_expand(mat, rho);
+
+  polyvecl_ntt(&z);
+  polyvec_matrix_pointwise_montgomery(&w1, mat, &z);
+
+  poly_ntt(&cp);
+  polyveck_shiftl(&t1);
+  polyveck_ntt(&t1);
+  polyveck_pointwise_poly_montgomery(&t1, &cp, &t1);
+
+  polyveck_sub(&w1, &w1, &t1);
+  polyveck_reduce(&w1);
+  polyveck_invntt_tomont(&w1);
+
+  /* Reconstruct w1 */
+  polyveck_caddq(&w1);
+  polyveck_use_hint(&w1, &w1, &h);
+  polyveck_pack_w1(buf, &w1);
+
+  /* Call random oracle and verify challenge */
+  shake256_init(&state);
+  shake256_absorb(&state, mu, CRHBYTES);
+  shake256_absorb(&state, buf, K*POLYW1_PACKEDBYTES);
+  shake256_finalize(&state);
+  shake256_squeeze(c2, CTILDEBYTES, &state);
+  for(i = 0; i < CTILDEBYTES; ++i)
+    if(c[i] != c2[i])
+      return -1;
+
+  return 0;
+}
+
+/*************************************************
+* Name:        crypto_sign_verify
+*
+* Description: Verifies signature.
+*
+* Arguments:   - uint8_t *m: pointer to input signature
+*              - size_t siglen: length of signature
+*              - const uint8_t *m: pointer to message
+*              - size_t mlen: length of message
+*              - const uint8_t *ctx: pointer to context string
+*              - size_t ctxlen: length of context string
+*              - const uint8_t *pk: pointer to bit-packed public key
+*
+* Returns 0 if signature could be verified correctly and -1 otherwise
+**************************************************/
+int crypto_sign_verify(const uint8_t *sig,
+                       size_t siglen,
+                       const uint8_t *m,
+                       size_t mlen,
+                       const uint8_t *ctx,
+                       size_t ctxlen,
+                       const uint8_t *pk)
+{
+  size_t i;
+  uint8_t pre[257];
+
+  if(ctxlen > 255)
+    return -1;
+
+  pre[0] = 0;
+  pre[1] = ctxlen;
+  for(i = 0; i < ctxlen; i++)
+    pre[2 + i] = ctx[i];
+
+  return crypto_sign_verify_internal(sig,siglen,m,mlen,pre,2+ctxlen,pk);
+}
+
+/*************************************************
+* Name:        crypto_sign_open
+*
+* Description: Verify signed message.
+*
+* Arguments:   - uint8_t *m: pointer to output message (allocated
+*                            array with smlen bytes), can be equal to sm
+*              - size_t *mlen: pointer to output length of message
+*              - const uint8_t *sm: pointer to signed message
+*              - size_t smlen: length of signed message
+*              - const uint8_t *ctx: pointer to context tring
+*              - size_t ctxlen: length of context string
+*              - const uint8_t *pk: pointer to bit-packed public key
+*
+* Returns 0 if signed message could be verified correctly and -1 otherwise
+**************************************************/
+int crypto_sign_open(uint8_t *m,
+                     size_t *mlen,
+                     const uint8_t *sm,
+                     size_t smlen,
+                     const uint8_t *ctx,
+                     size_t ctxlen,
+                     const uint8_t *pk)
+{
+  size_t i;
+
+  if(smlen < CRYPTO_BYTES)
+    goto badsig;
+
+  *mlen = smlen - CRYPTO_BYTES;
+  if(crypto_sign_verify(sm, CRYPTO_BYTES, sm + CRYPTO_BYTES, *mlen, ctx, ctxlen, pk))
+    goto badsig;
+  else {
+    /* All good, copy msg, return 0 */
+    for(i = 0; i < *mlen; ++i)
+      m[i] = sm[CRYPTO_BYTES + i];
+    return 0;
+  }
+
+badsig:
+  /* Signature verification failed */
+  *mlen = 0;
+  for(i = 0; i < smlen; ++i)
+    m[i] = 0;
+
+  return -1;
+}
+
+int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
+  uint8_t coins[SEEDBYTES];
+  randombytes(coins, SEEDBYTES);
+  return pqcrystals_dilithium5_ref_keypair_internal(pk, sk, coins);
+}
+
+
+/* end: ref/sign.c */
+

--- a/security/nss/lib/freebl/dilithium-pqcrystals-ref.h
+++ b/security/nss/lib/freebl/dilithium-pqcrystals-ref.h
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* Declarations for the amalgamated pq-crystals Dilithium reference
+ * implementation in dilithium-pqcrystals-ref.c, monomorphized to ML-DSA-87
+ * (Dilithium mode 5). Only the entry points freebl needs are exposed here. */
+
+#ifndef DILITHIUM_PQCRYSTALS_REF_H
+#define DILITHIUM_PQCRYSTALS_REF_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define DILITHIUM5_PUBLICKEYBYTES 2592
+#define DILITHIUM5_SECRETKEYBYTES 4896
+#define DILITHIUM5_SIGNATUREBYTES 4627
+#define DILITHIUM_SEEDBYTES 32
+#define DILITHIUM_RNDBYTES 32
+
+/* Deterministic key generation from a SEEDBYTES-byte seed. */
+int pqcrystals_dilithium5_ref_keypair_internal(uint8_t *pk, uint8_t *sk,
+                                               const uint8_t coins[DILITHIUM_SEEDBYTES]);
+
+/* Random key generation (draws the seed from randombytes()). */
+int pqcrystals_dilithium5_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+/* Signs m with the prefix pre = (0x00, ctxlen, ctx). rnd is the per-signature
+ * randomizer (zeros for deterministic, random bytes for hedged). */
+int pqcrystals_dilithium5_ref_signature_internal(uint8_t *sig, size_t *siglen,
+                                                 const uint8_t *m, size_t mlen,
+                                                 const uint8_t *pre, size_t prelen,
+                                                 const uint8_t rnd[DILITHIUM_RNDBYTES],
+                                                 const uint8_t *sk);
+
+/* Verifies sig over m with the prefix pre = (0x00, ctxlen, ctx). Returns 0 on
+ * success, nonzero on failure. */
+int pqcrystals_dilithium5_ref_verify_internal(const uint8_t *sig, size_t siglen,
+                                              const uint8_t *m, size_t mlen,
+                                              const uint8_t *pre, size_t prelen,
+                                              const uint8_t *pk);
+
+#endif /* DILITHIUM_PQCRYSTALS_REF_H */

--- a/security/nss/lib/freebl/freebl_base.gypi
+++ b/security/nss/lib/freebl/freebl_base.gypi
@@ -35,6 +35,7 @@
     'md2.c',
     'md5.c',
     'ml_dsa.c',
+    'dilithium-pqcrystals-ref.c',
     'mpi/mp_gf2m.c',
     'mpi/mpcpucache.c',
     'mpi/mpi.c',

--- a/security/nss/lib/freebl/manifest.mn
+++ b/security/nss/lib/freebl/manifest.mn
@@ -157,6 +157,7 @@ CSRCS = \
 	secmpi.c \
 	kyber.c \
 	ml_dsa.c \
+	dilithium-pqcrystals-ref.c \
 	$(KYBER_PQCRYSTALS) \
 	$(MPI_SRCS) \
 	$(MPCPU_SRCS) \

--- a/security/nss/lib/freebl/ml_dsa.c
+++ b/security/nss/lib/freebl/ml_dsa.c
@@ -12,7 +12,6 @@
 #include "secerr.h"
 
 #include "prtypes.h"
-#include "prinit.h"
 #include "blapi.h"
 #include "secitem.h"
 #include "blapit.h"
@@ -20,89 +19,330 @@
 #include "secrng.h"
 #include "ml_dsat.h"
 
-/* include other ml-dsa library specific includes here */
+#include <string.h>
 
-/* this is private to this function and can be changed at will */
-struct MLDSAContextStr {
-    PLArenaPool *arena;
-    MLDSAPrivateKey *privKey;
-    MLDSAPublicKey *pubKey;
-    CK_HEDGE_TYPE hedgeType;
-    CK_ML_DSA_PARAMETER_SET_TYPE paramSet;
-    /* other ml-dsa lowelevel library require values and contexts */
-};
+#include "dilithium-pqcrystals-ref.h"
 
 /*
-** Generate and return a new DSA public and private key pair,
-**  both of which are encoded into a single DSAPrivateKey struct.
-**  "params" is a pointer to the PQG parameters for the domain
-**  Uses a random seed.
-*/
+ * freebl currently ships only the ML-DSA-87 (Dilithium mode 5) parameter set,
+ * provided by the amalgamated pq-crystals reference in
+ * dilithium-pqcrystals-ref.c. The reference signs and verifies a complete
+ * message in one call, so the streaming MLDSAContext below buffers the message
+ * across Update calls and runs sign/verify in Final.
+ */
+
+/* Entropy source for the vendored reference (key generation and hedged
+ * signatures). Backed by freebl's RNG. */
+void
+randombytes(uint8_t *out, size_t outlen)
+{
+    if (RNG_GenerateGlobalRandomBytes(out, outlen) != SECSuccess) {
+        /* The reference API cannot report this; zero the buffer so we never
+         * operate on uninitialized memory. The resulting key/signature will be
+         * unusable, which is the safe failure mode. */
+        PORT_Memset(out, 0, outlen);
+    }
+}
+
+struct MLDSAContextStr {
+    CK_ML_DSA_PARAMETER_SET_TYPE paramSet;
+    PRBool isSign;
+    CK_HEDGE_TYPE hedgeType; /* sign only */
+    unsigned char *key;      /* packed secret key (sign) or public key (verify) */
+    unsigned int keyLen;
+    unsigned char *sgnCtx; /* signature context string (may be NULL) */
+    unsigned int sgnCtxLen;
+    unsigned char *msg; /* buffered message */
+    unsigned int msgLen;
+    unsigned int msgCap;
+};
+
+static PRBool
+mldsa_supported(CK_ML_DSA_PARAMETER_SET_TYPE paramSet)
+{
+    return paramSet == CKP_ML_DSA_87;
+}
+
+/* Build the FIPS 204 pure-signature prefix pre = (0x00, ctxlen, ctx). */
+static SECStatus
+mldsa_build_pre(const unsigned char *ctx, unsigned int ctxLen,
+                unsigned char pre[257], size_t *preLen)
+{
+    if (ctxLen > 255) {
+        PORT_SetError(SEC_ERROR_INVALID_ARGS);
+        return SECFailure;
+    }
+    pre[0] = 0;
+    pre[1] = (unsigned char)ctxLen;
+    if (ctxLen) {
+        memcpy(pre + 2, ctx, ctxLen);
+    }
+    *preLen = 2 + ctxLen;
+    return SECSuccess;
+}
+
+static MLDSAContext *
+mldsa_context_new(CK_ML_DSA_PARAMETER_SET_TYPE paramSet, PRBool isSign,
+                  const unsigned char *key, unsigned int keyLen,
+                  const SECItem *sgnCtx)
+{
+    MLDSAContext *c = PORT_ZNew(MLDSAContext);
+    if (!c) {
+        PORT_SetError(SEC_ERROR_NO_MEMORY);
+        return NULL;
+    }
+    c->paramSet = paramSet;
+    c->isSign = isSign;
+    c->key = (unsigned char *)PORT_Alloc(keyLen);
+    if (!c->key) {
+        PORT_ZFree(c, sizeof(*c));
+        PORT_SetError(SEC_ERROR_NO_MEMORY);
+        return NULL;
+    }
+    memcpy(c->key, key, keyLen);
+    c->keyLen = keyLen;
+    if (sgnCtx && sgnCtx->data && sgnCtx->len) {
+        c->sgnCtx = (unsigned char *)PORT_Alloc(sgnCtx->len);
+        if (!c->sgnCtx) {
+            PORT_ZFree(c->key, keyLen);
+            PORT_ZFree(c, sizeof(*c));
+            PORT_SetError(SEC_ERROR_NO_MEMORY);
+            return NULL;
+        }
+        memcpy(c->sgnCtx, sgnCtx->data, sgnCtx->len);
+        c->sgnCtxLen = sgnCtx->len;
+    }
+    return c;
+}
+
+static void
+mldsa_context_free(MLDSAContext *ctx)
+{
+    if (!ctx) {
+        return;
+    }
+    if (ctx->key) {
+        PORT_ZFree(ctx->key, ctx->keyLen);
+    }
+    if (ctx->sgnCtx) {
+        PORT_ZFree(ctx->sgnCtx, ctx->sgnCtxLen);
+    }
+    if (ctx->msg) {
+        PORT_ZFree(ctx->msg, ctx->msgCap);
+    }
+    PORT_ZFree(ctx, sizeof(*ctx));
+}
+
+static SECStatus
+mldsa_buffer_append(MLDSAContext *ctx, const SECItem *data)
+{
+    if (!ctx || !data) {
+        PORT_SetError(SEC_ERROR_INVALID_ARGS);
+        return SECFailure;
+    }
+    if (data->len == 0) {
+        return SECSuccess;
+    }
+    /* Guard against unsigned overflow of the running length. */
+    if (ctx->msgLen + data->len < ctx->msgLen) {
+        PORT_SetError(SEC_ERROR_INVALID_ARGS);
+        return SECFailure;
+    }
+    if (ctx->msgLen + data->len > ctx->msgCap) {
+        unsigned int newCap = ctx->msgCap ? ctx->msgCap : 1024;
+        unsigned char *newMsg;
+        while (newCap < ctx->msgLen + data->len) {
+            newCap *= 2;
+        }
+        newMsg = (unsigned char *)PORT_Alloc(newCap);
+        if (!newMsg) {
+            PORT_SetError(SEC_ERROR_NO_MEMORY);
+            return SECFailure;
+        }
+        if (ctx->msgLen) {
+            memcpy(newMsg, ctx->msg, ctx->msgLen);
+        }
+        if (ctx->msg) {
+            PORT_ZFree(ctx->msg, ctx->msgCap);
+        }
+        ctx->msg = newMsg;
+        ctx->msgCap = newCap;
+    }
+    memcpy(ctx->msg + ctx->msgLen, data->data, data->len);
+    ctx->msgLen += data->len;
+    return SECSuccess;
+}
+
 SECStatus
 MLDSA_NewKey(CK_ML_DSA_PARAMETER_SET_TYPE paramSet, SECItem *seed,
              MLDSAPrivateKey *privKey, MLDSAPublicKey *pubKey)
 {
-    /* needs to support returning the seed in the private key
-     * (if seed is not supplied) or generating the key using the seed
-     * (if it is supplied) if seed is supplied, it must be the correct
-     * length */
-    PORT_SetError(SEC_ERROR_INVALID_ARGS);
-    return SECFailure;
+    uint8_t coins[DILITHIUM_SEEDBYTES];
+
+    if (!privKey || !pubKey || !mldsa_supported(paramSet)) {
+        PORT_SetError(SEC_ERROR_INVALID_ARGS);
+        return SECFailure;
+    }
+
+    if (seed && seed->data) {
+        if (seed->len != DILITHIUM_SEEDBYTES) {
+            PORT_SetError(SEC_ERROR_INVALID_ARGS);
+            return SECFailure;
+        }
+        memcpy(coins, seed->data, DILITHIUM_SEEDBYTES);
+    } else {
+        randombytes(coins, DILITHIUM_SEEDBYTES);
+    }
+
+    if (pqcrystals_dilithium5_ref_keypair_internal(pubKey->keyVal,
+                                                   privKey->keyVal,
+                                                   coins) != 0) {
+        PORT_Memset(coins, 0, sizeof(coins));
+        PORT_SetError(SEC_ERROR_LIBRARY_FAILURE);
+        return SECFailure;
+    }
+    pubKey->paramSet = paramSet;
+    pubKey->keyValLen = DILITHIUM5_PUBLICKEYBYTES;
+    privKey->paramSet = paramSet;
+    privKey->keyValLen = DILITHIUM5_SECRETKEYBYTES;
+    /* Retain the seed so it can be returned in the private key. */
+    memcpy(privKey->seed, coins, DILITHIUM_SEEDBYTES);
+    privKey->seedLen = DILITHIUM_SEEDBYTES;
+    PORT_Memset(coins, 0, sizeof(coins));
+    return SECSuccess;
 }
 
-/*
- * we don't have a streaming interace, so use our own local context
- * to keep track of things */
 SECStatus
 MLDSA_SignInit(MLDSAPrivateKey *key, CK_HEDGE_TYPE hedgeType,
                const SECItem *sgnCtx, MLDSAContext **ctx)
 {
-    /* if hedgeType is CKH_DETERMINISTIC_REQUIRED, otherwise it
-     * should generate a HEDGE signature, can stash this value
-     * if the library takes the hedge parameter in a later call */
-    PORT_SetError(SEC_ERROR_INVALID_ARGS);
-    return SECFailure;
+    MLDSAContext *c;
+
+    if (!key || !ctx || !mldsa_supported(key->paramSet)) {
+        PORT_SetError(SEC_ERROR_INVALID_ARGS);
+        return SECFailure;
+    }
+    c = mldsa_context_new(key->paramSet, PR_TRUE, key->keyVal, key->keyValLen,
+                          sgnCtx);
+    if (!c) {
+        return SECFailure;
+    }
+    c->hedgeType = hedgeType;
+    *ctx = c;
+    return SECSuccess;
 }
 
 SECStatus
 MLDSA_SignUpdate(MLDSAContext *ctx, const SECItem *data)
 {
-    /* streaming interface. should not return a signature yet.
-     * if the library can't do streaming, we need to buffer */
-    PORT_SetError(SEC_ERROR_INVALID_ARGS);
-    return SECFailure;
+    if (!ctx || !ctx->isSign) {
+        PORT_SetError(SEC_ERROR_INVALID_ARGS);
+        return SECFailure;
+    }
+    return mldsa_buffer_append(ctx, data);
 }
 
 SECStatus
 MLDSA_SignFinal(MLDSAContext *ctx, SECItem *signature)
 {
-    /* produce the actual signature, may need the key, so it needs to be
-     * stashed in ML_DSA_SignInit */
-    PORT_SetError(SEC_ERROR_INVALID_ARGS);
-    return SECFailure;
+    unsigned char pre[257];
+    size_t preLen;
+    uint8_t rnd[DILITHIUM_RNDBYTES];
+    size_t sigLen = 0;
+    int rv;
+
+    if (!ctx || !ctx->isSign || !signature || !signature->data) {
+        PORT_SetError(SEC_ERROR_INVALID_ARGS);
+        if (ctx) {
+            mldsa_context_free(ctx);
+        }
+        return SECFailure;
+    }
+    if (signature->len < DILITHIUM5_SIGNATUREBYTES) {
+        PORT_SetError(SEC_ERROR_OUTPUT_LEN);
+        mldsa_context_free(ctx);
+        return SECFailure;
+    }
+    if (mldsa_build_pre(ctx->sgnCtx, ctx->sgnCtxLen, pre, &preLen) !=
+        SECSuccess) {
+        mldsa_context_free(ctx);
+        return SECFailure;
+    }
+
+    if (ctx->hedgeType == CKH_DETERMINISTIC_REQUIRED) {
+        PORT_Memset(rnd, 0, sizeof(rnd));
+    } else {
+        randombytes(rnd, sizeof(rnd));
+    }
+
+    rv = pqcrystals_dilithium5_ref_signature_internal(
+        signature->data, &sigLen, ctx->msg, ctx->msgLen, pre, preLen, rnd,
+        ctx->key);
+    PORT_Memset(rnd, 0, sizeof(rnd));
+    mldsa_context_free(ctx);
+    if (rv != 0) {
+        PORT_SetError(SEC_ERROR_LIBRARY_FAILURE);
+        return SECFailure;
+    }
+    signature->len = (unsigned int)sigLen;
+    return SECSuccess;
 }
 
-/*
- * we don't have a streaming interace, so use our own local context
- * to keep track of things */
 SECStatus
 MLDSA_VerifyInit(MLDSAPublicKey *key, const SECItem *sgnCtx, MLDSAContext **ctx)
 {
-    PORT_SetError(SEC_ERROR_INVALID_ARGS);
-    return SECFailure;
+    MLDSAContext *c;
+
+    if (!key || !ctx || !mldsa_supported(key->paramSet)) {
+        PORT_SetError(SEC_ERROR_INVALID_ARGS);
+        return SECFailure;
+    }
+    c = mldsa_context_new(key->paramSet, PR_FALSE, key->keyVal, key->keyValLen,
+                          sgnCtx);
+    if (!c) {
+        return SECFailure;
+    }
+    *ctx = c;
+    return SECSuccess;
 }
 
 SECStatus
 MLDSA_VerifyUpdate(MLDSAContext *ctx, const SECItem *data)
 {
-    /* like Sign, a streaming interface some rules about buffering */
-    PORT_SetError(SEC_ERROR_INVALID_ARGS);
-    return SECFailure;
+    if (!ctx || ctx->isSign) {
+        PORT_SetError(SEC_ERROR_INVALID_ARGS);
+        return SECFailure;
+    }
+    return mldsa_buffer_append(ctx, data);
 }
 
 SECStatus
 MLDSA_VerifyFinal(MLDSAContext *ctx, const SECItem *signature)
 {
-    PORT_SetError(SEC_ERROR_INVALID_ARGS);
-    return SECFailure;
+    unsigned char pre[257];
+    size_t preLen;
+    int rv;
+
+    if (!ctx || ctx->isSign || !signature || !signature->data) {
+        PORT_SetError(SEC_ERROR_INVALID_ARGS);
+        if (ctx) {
+            mldsa_context_free(ctx);
+        }
+        return SECFailure;
+    }
+    if (mldsa_build_pre(ctx->sgnCtx, ctx->sgnCtxLen, pre, &preLen) !=
+        SECSuccess) {
+        mldsa_context_free(ctx);
+        return SECFailure;
+    }
+
+    rv = pqcrystals_dilithium5_ref_verify_internal(
+        signature->data, signature->len, ctx->msg, ctx->msgLen, pre, preLen,
+        ctx->key);
+    mldsa_context_free(ctx);
+    if (rv != 0) {
+        PORT_SetError(SEC_ERROR_BAD_SIGNATURE);
+        return SECFailure;
+    }
+    return SECSuccess;
 }

--- a/security/nss/lib/mozpkix/include/pkix/pkixder.h
+++ b/security/nss/lib/mozpkix/include/pkix/pkixder.h
@@ -488,7 +488,7 @@ inline Result OptionalExtensions(Reader& input, uint8_t tag,
 Result DigestAlgorithmIdentifier(Reader& input,
                                  /*out*/ DigestAlgorithm& algorithm);
 
-enum class PublicKeyAlgorithm { RSA_PKCS1, RSA_PSS, ECDSA };
+enum class PublicKeyAlgorithm { RSA_PKCS1, RSA_PSS, ECDSA, ML_DSA };
 
 Result SignatureAlgorithmIdentifierValue(
     Reader& input,

--- a/security/nss/lib/mozpkix/include/pkix/pkixnss.h
+++ b/security/nss/lib/mozpkix/include/pkix/pkixnss.h
@@ -50,6 +50,11 @@ Result VerifyECDSASignedDataNSS(Input data, DigestAlgorithm digestAlgorithm,
                                 Input signature, Input subjectPublicKeyInfo,
                                 void* pkcs11PinArg);
 
+// Verifies an ML-DSA-87 signature (NIST FIPS 204, pure-signature, no hash).
+Result VerifyMLDSASignedDataNSS(Input data, Input signature,
+                                Input subjectPublicKeyInfo,
+                                void* pkcs11PinArg);
+
 // Computes the digest of the given data using the given digest algorithm.
 //
 // item contains the data to hash.

--- a/security/nss/lib/mozpkix/include/pkix/pkixtypes.h
+++ b/security/nss/lib/mozpkix/include/pkix/pkixtypes.h
@@ -39,6 +39,8 @@ enum class DigestAlgorithm {
   sha384 = 2,
   sha256 = 3,
   sha1 = 4,
+  /* Used for pure-signature algorithms (ML-DSA) that have no separate hash. */
+  none = 5,
 };
 
 enum class NamedCurve {
@@ -336,6 +338,12 @@ class TrustDomain {
   // verification of the public key validity as specified in NIST SP 800-56A.
   virtual Result VerifyECDSASignedData(Input data,
                                        DigestAlgorithm digestAlgorithm,
+                                       Input signature,
+                                       Input subjectPublicKeyInfo) = 0;
+
+  // Verify the given ML-DSA-87 signature (NIST FIPS 204, pure-signature).
+  // No digest algorithm — the full tbsCertificate bytes are passed directly.
+  virtual Result VerifyMLDSASignedData(Input data,
                                        Input signature,
                                        Input subjectPublicKeyInfo) = 0;
 

--- a/security/nss/lib/mozpkix/include/pkix/pkixutil.h
+++ b/security/nss/lib/mozpkix/include/pkix/pkixutil.h
@@ -260,6 +260,9 @@ inline size_t DigestAlgorithmToSizeInBytes(DigestAlgorithm digestAlgorithm) {
       return 384 / 8;
     case DigestAlgorithm::sha512:
       return 512 / 8;
+    case DigestAlgorithm::none:
+      /* Pure-signature algorithms (ML-DSA) have no pre-hash output size. */
+      return 0;
       MOZILLA_PKIX_UNREACHABLE_DEFAULT_ENUM
   }
 }

--- a/security/nss/lib/mozpkix/lib/pkixc.cpp
+++ b/security/nss/lib/mozpkix/lib/pkixc.cpp
@@ -142,6 +142,12 @@ class CodeSigningTrustDomain final : public TrustDomain {
         subjectPublicKeyInfo, nullptr);
   }
 
+  virtual Result VerifyMLDSASignedData(Input data, Input signature,
+                                       Input subjectPublicKeyInfo) override {
+    return VerifyMLDSASignedDataNSS(data, signature, subjectPublicKeyInfo,
+                                    nullptr);
+  }
+
   virtual Result CheckValidityIsAcceptable(Time notBefore, Time notAfter,
                                            EndEntityOrCA endEntityOrCA,
                                            KeyPurposeId keyPurpose) override {

--- a/security/nss/lib/mozpkix/lib/pkixcheck.cpp
+++ b/security/nss/lib/mozpkix/lib/pkixcheck.cpp
@@ -257,6 +257,12 @@ CheckSubjectPublicKeyInfoContents(Reader& input, TrustDomain& trustDomain,
     0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01
   };
 
+  // NIST FIPS 204, draft-ietf-lamps-dilithium-certificates
+  // python DottedOIDToCode.py id-ML-DSA-87 2.16.840.1.101.3.4.3.19
+  static const uint8_t id_ML_DSA_87[] = {
+    0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x13
+  };
+
   if (algorithmOID.MatchRest(id_ecPublicKey)) {
     // An id-ecPublicKey AlgorithmIdentifier has a parameter that identifes
     // the curve being used. Although RFC 5480 specifies multiple forms, we
@@ -367,6 +373,15 @@ CheckSubjectPublicKeyInfoContents(Reader& input, TrustDomain& trustDomain,
       Input exponent;
       return der::PositiveInteger(r, exponent);
     });
+    if (rv != Success) {
+      return rv;
+    }
+  } else if (algorithmOID.MatchRest(id_ML_DSA_87)) {
+    // NIST FIPS 204, draft-ietf-lamps-dilithium-certificates.
+    // AlgorithmIdentifier parameters MUST be absent for ML-DSA-87.
+    // The subjectPublicKey is a raw 2592-byte ML-DSA-87 public key.
+    Input rawKey;
+    rv = subjectPublicKeyReader.SkipToEnd(rawKey);
     if (rv != Success) {
       return rv;
     }

--- a/security/nss/lib/mozpkix/lib/pkixcheck.cpp
+++ b/security/nss/lib/mozpkix/lib/pkixcheck.cpp
@@ -92,10 +92,14 @@ CheckSignatureAlgorithm(TrustDomain& trustDomain,
   // more generally it short-circuits any path building with them (which, of
   // course, is even slower).
 
-  rv = trustDomain.CheckSignatureDigestAlgorithm(digestAlg, endEntityOrCA,
-                                                 notBefore);
-  if (rv != Success) {
-    return rv;
+  /* ML-DSA is a pure signature with no separate hash algorithm; skip the
+   * digest-algorithm policy check entirely for this key type. */
+  if (publicKeyAlg != der::PublicKeyAlgorithm::ML_DSA) {
+    rv = trustDomain.CheckSignatureDigestAlgorithm(digestAlg, endEntityOrCA,
+                                                   notBefore);
+    if (rv != Success) {
+      return rv;
+    }
   }
 
   switch (publicKeyAlg) {
@@ -118,6 +122,11 @@ CheckSignatureAlgorithm(TrustDomain& trustDomain,
       // for any curve that we support, the chances of us encountering a curve
       // during path building is too low to be worth bothering with.
       break;
+
+    case der::PublicKeyAlgorithm::ML_DSA:
+      /* Key size is fixed by the parameter set (ML-DSA-87); no modulus check. */
+      break;
+
     MOZILLA_PKIX_UNREACHABLE_DEFAULT_ENUM
   }
 

--- a/security/nss/lib/mozpkix/lib/pkixder.cpp
+++ b/security/nss/lib/mozpkix/lib/pkixder.cpp
@@ -182,6 +182,12 @@ SignatureAlgorithmIdentifierValue(Reader& input,
     0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0a
   };
 
+  // NIST FIPS 204, draft-ietf-lamps-dilithium-certificates
+  // python DottedOIDToCode.py id-ML-DSA-87 2.16.840.1.101.3.4.3.19
+  static const uint8_t id_ML_DSA_87[] = {
+    0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x13
+  };
+
   // CA/B Forum BR 1.8.1 Section 7.1.3.2.1
   // Params for RSA-PSS with SHA-256, MGF-1 with SHA-256, and a salt length
   // of 32 bytes:
@@ -252,12 +258,18 @@ SignatureAlgorithmIdentifierValue(Reader& input,
     } else {
       return Result::ERROR_CERT_SIGNATURE_ALGORITHM_DISABLED;
     }
+  } else if (algorithmID.MatchRest(id_ML_DSA_87)) {
+    /* ML-DSA-87 is a pure signature — no pre-hash and no AlgorithmIdentifier
+     * parameters (RFC: params MUST be absent). */
+    publicKeyAlgorithm = PublicKeyAlgorithm::ML_DSA;
+    digestAlgorithm = DigestAlgorithm::none;
   } else {
     return Result::ERROR_CERT_SIGNATURE_ALGORITHM_DISABLED;
   }
 
-  // Ensure that for non-RSA-PSS algorithms, the params are NULL or omitted.
-  if (publicKeyAlgorithm != PublicKeyAlgorithm::RSA_PSS) {
+  // Ensure that for non-RSA-PSS, non-ML-DSA algorithms, the params are NULL or omitted.
+  if (publicKeyAlgorithm != PublicKeyAlgorithm::RSA_PSS &&
+      publicKeyAlgorithm != PublicKeyAlgorithm::ML_DSA) {
     if (algorithmParams.Peek(NULLTag)) {
       rv = Null(algorithmParams);
       if (rv != Success) {

--- a/security/nss/lib/mozpkix/lib/pkixnss.cpp
+++ b/security/nss/lib/mozpkix/lib/pkixnss.cpp
@@ -270,6 +270,25 @@ VerifyECDSASignedDataNSS(Input data, DigestAlgorithm digestAlgorithm,
 }
 
 Result
+VerifyMLDSASignedDataNSS(Input data, Input signature,
+    Input subjectPublicKeyInfo, void* pkcs11PinArg)
+{
+  ScopedSECKEYPublicKey publicKey;
+  Result rv = SubjectPublicKeyInfoToSECKEYPublicKey(subjectPublicKeyInfo,
+      publicKey);
+  if (rv != Success) {
+    return rv;
+  }
+  SECItem signatureItem(UnsafeMapInputToSECItem(signature));
+  SECItem dataItem(UnsafeMapInputToSECItem(data));
+  /* ML-DSA is a pure signature — pass raw message bytes, no pre-hash.
+   * CKM_ML_DSA uses the paramset embedded in the key object. */
+  SECOidTag policyTags[1] = { SEC_OID_ML_DSA_87 };
+  return VerifySignedData(publicKey.get(), CKM_ML_DSA, nullptr,
+      &signatureItem, &dataItem, policyTags, pkcs11PinArg);
+}
+
+Result
 DigestBufNSS(Input item,
              DigestAlgorithm digestAlg,
              /*out*/ uint8_t* digestBuf,

--- a/security/nss/lib/mozpkix/lib/pkixverify.cpp
+++ b/security/nss/lib/mozpkix/lib/pkixverify.cpp
@@ -53,6 +53,10 @@ VerifySignedData(TrustDomain& trustDomain,
     case der::PublicKeyAlgorithm::RSA_PSS:
       return trustDomain.VerifyRSAPSSSignedData(signedData.data,
           digestAlgorithm, signedData.signature, signerSubjectPublicKeyInfo);
+    case der::PublicKeyAlgorithm::ML_DSA:
+      /* Pure signature — no digest; pass raw tbsCertificate bytes directly. */
+      return trustDomain.VerifyMLDSASignedData(signedData.data,
+          signedData.signature, signerSubjectPublicKeyInfo);
     MOZILLA_PKIX_UNREACHABLE_DEFAULT_ENUM
   }
 }

--- a/security/nss/lib/pk11wrap/pk11pars.c
+++ b/security/nss/lib/pk11wrap/pk11pars.c
@@ -479,7 +479,7 @@ static const oidValDef signOptList[] = {
     { CIPHER_NAME("ML-DSA-65"), SEC_OID_ML_DSA_65,
       NSS_USE_ALG_IN_SIGNATURE },
     { CIPHER_NAME("ML-DSA-87"), SEC_OID_ML_DSA_87,
-      NSS_USE_ALG_IN_SIGNATURE },
+      NSS_USE_ALG_IN_SIGNATURE | NSS_USE_ALG_IN_SSL_KX },
 };
 
 typedef struct {

--- a/security/nss/lib/softoken/pkcs11.c
+++ b/security/nss/lib/softoken/pkcs11.c
@@ -688,11 +688,8 @@ static const struct mechanismList mechanisms[] = {
     { CKM_NSS_ML_KEM, { 0, 0, CKF_KEM }, PR_TRUE },
     { CKM_ML_KEM_KEY_PAIR_GEN, { 0, 0, CKF_GENERATE_KEY_PAIR }, PR_TRUE },
     { CKM_ML_KEM, { 0, 0, CKF_KEM }, PR_TRUE },
-/* don't advertize ML_DSA support until we have it working in freebl */
-#ifdef NSS_ENABLE_ML_DSA
     { CKM_ML_DSA_KEY_PAIR_GEN, { ML_DSA_44_PUBLICKEY_LEN, ML_DSA_87_PUBLICKEY_LEN, CKF_GENERATE }, PR_TRUE },
     { CKM_ML_DSA, { ML_DSA_44_PUBLICKEY_LEN, ML_DSA_87_PUBLICKEY_LEN, CKF_SN_VR }, PR_TRUE },
-#endif
 };
 static const CK_ULONG mechanismCount = sizeof(mechanisms) / sizeof(mechanisms[0]);
 

--- a/security/nss/lib/ssl/ssl3con.c
+++ b/security/nss/lib/ssl/ssl3con.c
@@ -191,6 +191,7 @@ static ssl3CipherSuiteCfg cipherSuites[ssl_V3_SUITES_IMPLEMENTED] = {
  * cipher suites just for consistency.
  */
 static const SSLSignatureScheme defaultSignatureSchemes[] = {
+    ssl_sig_mldsa_87,
     ssl_sig_ecdsa_secp256r1_sha256,
     ssl_sig_ecdsa_secp384r1_sha384,
     ssl_sig_ecdsa_secp521r1_sha512,
@@ -363,7 +364,8 @@ static const CK_MECHANISM_TYPE auth_alg_defs[] = {
     CKM_RSA_PKCS,          /* ssl_auth_rsa_sign */
     CKM_RSA_PKCS_PSS,      /* ssl_auth_rsa_pss */
     CKM_HKDF_DATA,         /* ssl_auth_psk (just check for HKDF) */
-    CKM_INVALID_MECHANISM  /* ssl_auth_tls13_any */
+    CKM_INVALID_MECHANISM, /* ssl_auth_tls13_any */
+    CKM_ML_DSA             /* ssl_auth_mldsa */
 };
 PR_STATIC_ASSERT(PR_ARRAY_SIZE(auth_alg_defs) == ssl_auth_size);
 
@@ -4531,6 +4533,8 @@ ssl3_AuthTypeToOID(SSLAuthType authType)
             return SEC_OID_ANSIX962_EC_PUBLIC_KEY;
         case ssl_auth_dsa:
             return SEC_OID_ANSIX9_DSA_SIGNATURE;
+        case ssl_auth_mldsa:
+            return SEC_OID_ML_DSA_87;
         default:
             break;
     }
@@ -4567,6 +4571,8 @@ ssl_SignatureSchemeToHashType(SSLSignatureScheme scheme)
             return ssl_hash_sha512;
         case ssl_sig_rsa_pkcs1_sha1md5:
             return ssl_hash_none; /* Special for TLS 1.0/1.1. */
+        case ssl_sig_mldsa_87:
+            return ssl_hash_none; /* ML-DSA is a pure signature; no pre-hash. */
         case ssl_sig_none:
         case ssl_sig_ed25519:
         case ssl_sig_ed448:
@@ -4837,6 +4843,7 @@ ssl_IsSupportedSignatureScheme(SSLSignatureScheme scheme)
         case ssl_sig_dsa_sha384:
         case ssl_sig_dsa_sha512:
         case ssl_sig_ecdsa_sha1:
+        case ssl_sig_mldsa_87:
             return ssl_SchemePolicyOK(scheme, kSSLSigSchemePolicy);
             break;
 
@@ -4942,6 +4949,8 @@ ssl_SignatureSchemeToAuthType(SSLSignatureScheme scheme)
         case ssl_sig_dsa_sha384:
         case ssl_sig_dsa_sha512:
             return ssl_auth_dsa;
+        case ssl_sig_mldsa_87:
+            return ssl_auth_mldsa;
 
         default:
             PORT_Assert(0);
@@ -11881,6 +11890,12 @@ ssl_SetAuthKeyBits(sslSocket *ss, const SECKEYPublicKey *pubKey)
             }
             break;
 
+        case mldsaKey:
+            /* ML-DSA key sizes are fixed by the parameter set; if we accepted
+             * the scheme (ssl_sig_mldsa_87), the strength is implicitly valid. */
+            minKey = ss->sec.authKeyBits;
+            break;
+
         default:
             FATAL_ERROR(ss, SEC_ERROR_LIBRARY_FAILURE, internal_error);
             return SECFailure;
@@ -14248,6 +14263,26 @@ SSL_SignatureSchemePrefSet(PRFileDesc *fd, const SSLSignatureScheme *schemes,
         }
 
         ss->ssl3.signatureSchemes[ss->ssl3.signatureSchemeCount++] = schemes[i];
+    }
+
+    /* Inject ML-DSA-87 (draft-ietf-tls-mldsa, 0x0906) at the front of the list
+     * so it is preferred. libxul does not yet include this scheme when calling
+     * SSL_SignatureSchemePrefSet, so we add it here unconditionally. */
+    {
+        PRBool hasMldsa = PR_FALSE;
+        for (i = 0; i < ss->ssl3.signatureSchemeCount; ++i) {
+            if (ss->ssl3.signatureSchemes[i] == ssl_sig_mldsa_87) {
+                hasMldsa = PR_TRUE;
+                break;
+            }
+        }
+        if (!hasMldsa && ss->ssl3.signatureSchemeCount < MAX_SIGNATURE_SCHEMES) {
+            PORT_Memmove(&ss->ssl3.signatureSchemes[1],
+                         &ss->ssl3.signatureSchemes[0],
+                         ss->ssl3.signatureSchemeCount * sizeof(SSLSignatureScheme));
+            ss->ssl3.signatureSchemes[0] = ssl_sig_mldsa_87;
+            ss->ssl3.signatureSchemeCount++;
+        }
     }
 
     if (ss->ssl3.signatureSchemeCount == 0) {

--- a/security/nss/lib/ssl/sslt.h
+++ b/security/nss/lib/ssl/sslt.h
@@ -150,6 +150,9 @@ typedef enum {
     ssl_sig_rsa_pss_pss_sha384 = 0x080a,
     ssl_sig_rsa_pss_pss_sha512 = 0x080b,
 
+    /* ML-DSA-87 (NIST FIPS 204) — draft-ietf-tls-mldsa codepoint 0x0906 */
+    ssl_sig_mldsa_87 = 0x0906,
+
     ssl_sig_dsa_sha1 = 0x0202,
     ssl_sig_dsa_sha256 = 0x0402,
     ssl_sig_dsa_sha384 = 0x0502,
@@ -185,6 +188,7 @@ typedef enum {
     ssl_auth_rsa_pss = 8,    /* RSA signing with a PSS key. */
     ssl_auth_psk = 9,
     ssl_auth_tls13_any = 10,
+    ssl_auth_mldsa = 11,      /* ML-DSA (NIST FIPS 204) */
     ssl_auth_size /* number of authentication types */
 } SSLAuthType;
 

--- a/security/nss/lib/ssl/tls13signature.c
+++ b/security/nss/lib/ssl/tls13signature.c
@@ -58,6 +58,14 @@ tls_GetSignatureAlgorithmId(PLArenaPool *arena, SSLSignatureScheme scheme,
             hashAlgTag = SEC_OID_SHA512;
             break;
 
+        /* ML-DSA-87 (NIST FIPS 204, draft-ietf-tls-mldsa 0x0906).
+         * Pure signature — no pre-hash. hashAlgTag must be the paramset OID,
+         * not SEC_OID_UNKNOWN, because secsign.c rejects UNKNOWN for mldsaKey. */
+        case ssl_sig_mldsa_87:
+            algTag = SEC_OID_ML_DSA_87;
+            hashAlgTag = SEC_OID_ML_DSA_87;
+            break;
+
         /* the following is unsupported in tls 1.3 and greater, just break.
          * We include them here explicitly so we get the compiler warning about
          * missing enums in the switch statement. default would be a break anyway.

--- a/toolkit/components/certviewer/content/certDecoder.mjs
+++ b/toolkit/components/certviewer/content/certDecoder.mjs
@@ -48,6 +48,25 @@ const getPublicKeyInfo = x509 => {
       xy: `04:${x}:${y}`, // 04 (uncompressed) public key
     };
   }
+  // pkijs only parses RSA and EC keys; resolve other algorithms by OID.
+  let algorithmId = getObjPath(
+    x509,
+    "subjectPublicKeyInfo.algorithm.algorithmId"
+  );
+  if (algorithmId === "2.16.840.1.101.3.4.3.19") {
+    let keyView = getObjPath(
+      x509,
+      "subjectPublicKeyInfo.subjectPublicKey.valueBlock.valueHexView"
+    );
+    let keyHex = keyView
+      ? Array.from(keyView, b => b.toString(16).padStart(2, "0")).join("")
+      : undefined;
+    return {
+      kty: "ML-DSA-87",
+      keysize: keyView ? keyView.length * 8 : undefined,
+      xy: keyHex ? hashify(keyHex) : undefined,
+    };
+  }
   return { kty: "Unknown" };
 };
 
@@ -1124,6 +1143,7 @@ const strings = {
     "1.2.840.10045.4.3.2": "ECDSA with SHA-256",
     "1.2.840.10045.4.3.3": "ECDSA with SHA-384",
     "1.2.840.10045.4.3.4": "ECDSA with SHA-512",
+    "2.16.840.1.101.3.4.3.19": "ML-DSA-87",
   },
 
   aia: {


### PR DESCRIPTION
## Summary

Adds end-to-end support for **ML-DSA-87** (NIST FIPS 204, parameter set 5) post-quantum signature verification to NSS and Firefox, backed by an in-tree pq-crystals Dilithium reference so the freebl/FIPS module boundary has no external crypto dependency.

## Changes

**freebl (crypto core)**
- Vendor `dilithium-pqcrystals-ref.c`: the pq-crystals Dilithium reference (commit `6e00625c`), amalgamated and monomorphized to mode 5 (ML-DSA-87), mirroring how freebl vendors `kyber-pqcrystals-ref.c` for ML-KEM. Its bundled Keccak is namespaced `pqcrystals_dilithium_fips202_ref_*` to avoid colliding with the Kyber reference. `crypto_sign_keypair` is split into a seed-taking `keypair_internal` for deterministic and random key generation.
- Rewrite `ml_dsa.c` as a wrapper implementing the full `MLDSA_*` API: `NewKey` (seed or random), `Sign`/`Verify` `Init`/`Update`/`Final`. The reference is one-shot, so the streaming context buffers the message and runs sign/verify in `Final` with the FIPS 204 `pre = (0x00, ctxlen, ctx)` prefix. `randombytes()` is backed by `RNG_GenerateGlobalRandomBytes`.
- Wired into `freebl_base.gypi` and `manifest.mn`.
- Only ML-DSA-87 is monomorphized in; the 44/65 parameter sets return `SEC_ERROR_INVALID_ARGS`.

**softoken**
- Advertise `CKM_ML_DSA` / `CKM_ML_DSA_KEY_PAIR_GEN` now that freebl backs them.

**mozpkix**
- Parse the ML-DSA-87 SubjectPublicKeyInfo OID (`2.16.840.1.101.3.4.3.19`) so ML-DSA leaf/CA keys are accepted.

**PSM**
- Handle `ssl_auth_mldsa` in the post-handshake auth-algorithm telemetry switch (previously hit `MOZ_CRASH("impossible auth algorithm")`).

**certviewer**
- Resolve the ML-DSA-87 OID for both the public-key-info and signature algorithms so `about:certificate` no longer shows "Unknown".

## Testing

The reference is byte-compatible with OpenSSL's ML-DSA-87, cross-checked by verifying signatures in both directions.