### PR TITLE
Change purgecaches argument to use double dash

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -80,7 +80,7 @@
       },
       {
         "label": "run",
-        "args": ["run", "-purgecaches"],
+        "args": ["run", "--purgecaches"],
         "problemMatcher": []
       },
       {


### PR DESCRIPTION
The run task in .vscode/tasks.json was using -purgecaches 
(single dash) instead of --purgecaches (double dash).

This caused Firefox to run without clearing caches properly.