### PR TITLE
Bug 2039564: Add nimbus flag to enable longfox.

### DIFF
--- a/mobile/android/fenix/app/nimbus.fml.yaml
+++ b/mobile/android/fenix/app/nimbus.fml.yaml
@@ -1274,6 +1274,21 @@ features:
         value:
           enabled: true
 
+  longfox:
+    description: Flag to enable Longfox for users on Firefox Android.
+    variables:
+      enabled:
+        description: If true, users will see a CTA for launching Longfox on the home screen.
+        type: Boolean
+        default: false
+    defaults:
+      - channel: nightly
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: true
+
 types:
   objects:
     GleanServerKnobsConfiguration:

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -3219,7 +3219,7 @@ class Settings(
      */
     var longfoxEnabled by booleanPreference(
         key = appContext.getPreferenceKey(R.string.pref_key_enable_longfox),
-        default = false,
+        default = { FxNimbus.features.longfox.value().enabled },
     )
 
     /**


### PR DESCRIPTION
Defaulted to false for nightly but true for developers because i think we all need a bit more joy in our lives quite honestly.

[Here is a try](https://treeherder.mozilla.org/jobs?repo=try&revision=64629a31ba5a52bbaee269410003d70774fa26b3)