### PR TITLE
Display default active browser profile

### DIFF
--- a/toolkit/content/aboutProfiles.js
+++ b/toolkit/content/aboutProfiles.js
@@ -394,6 +394,24 @@ function restart(safeMode) {
   }
 }
 
+function displayCurrentProfile(){
+
+  let currentProfile = ProfileService.currentProfile;
+  let profileInfo = document.getElementById("currentProfileInfo");
+
+  if(!currentProfile){
+    return;
+  }
+
+  profileInfo.removeAttribute("hidden");
+
+  let name = document.getElementById("currentProfileName");
+  let path = document.getElementById("currentProfilePath");
+
+  document.l10n.setAttributes(name, "default-profile", { name: currentProfile.name });
+  document.l10n.setAttributes(path, "default-profile-path", { path: currentProfile.rootDir.path });
+}
+
 window.addEventListener(
   "DOMContentLoaded",
   function () {
@@ -415,6 +433,8 @@ window.addEventListener(
     restartNormalModeButton.addEventListener("click", () => {
       restart(false);
     });
+
+    displayCurrentProfile();
 
     if (ProfileService.isListOutdated) {
       document.getElementById("owned").hidden = true;

--- a/toolkit/content/aboutProfiles.xhtml
+++ b/toolkit/content/aboutProfiles.xhtml
@@ -24,6 +24,9 @@
       href="chrome://mozapps/skin/aboutProfiles.css"
       type="text/css"
     />
+    <link rel="stylesheet" href="chrome://global/skin/in-content/common-shared.css" />
+    <link rel="stylesheet" href="chrome://global/content/elements/moz-message-bar.css" />
+
     <script src="chrome://global/content/aboutProfiles.js" />
     <link rel="localization" href="branding/brand.ftl" />
     <link rel="localization" href="toolkit/about/aboutProfiles.ftl" />
@@ -53,6 +56,17 @@
         ></button>
       </div>
     </div>
+
+    <moz-message-bar
+      id="currentProfileInfo"
+      type="info"
+      hidden="true">
+      <span slot="message">
+        <span id="currentProfileName"></span>
+        <br />
+        <span id="currentProfilePath"></span>
+      </span>
+    </moz-message-bar>
 
     <div id="owned">
       <div>

--- a/toolkit/locales/en-US/toolkit/about/aboutProfiles.ftl
+++ b/toolkit/locales/en-US/toolkit/about/aboutProfiles.ftl
@@ -21,6 +21,9 @@ profiles-name = Profile: { $name }
 profiles-is-default = Default Profile
 profiles-rootdir = Root Directory
 
+default-profile = Current Profile: <b>{ $name }</b>
+default-profile-path = Path: <i>{ $path }</i>
+
 # localDir is used to show the directory corresponding to
 # the main profile directory that exists for the purpose of storing data on the
 # local filesystem, including cache files or other data files that may not

--- a/toolkit/themes/shared/aboutProfiles.css
+++ b/toolkit/themes/shared/aboutProfiles.css
@@ -8,6 +8,11 @@
   clear: both;
 }
 
+#currentProfileInfo {
+  padding: 4px 8px;
+  margin-bottom: 1em;
+}
+
 button {
   margin-inline: 0 8px;
 }


### PR DESCRIPTION
I’ve been a default user of Firefox for two decades, and I love this browser. In my day-to-day use, I create and switch between browser profiles. Sometimes I put my laptop to hibernate. Next day, when I log back in, I notice that an instance of Firefox is running. However, I want to instantly know what the current profile is of this session, and sure: `about:profiles` and then scrolling to the one that says yes. But I figure out, there has to be a better way here. 

<img width="834" height="545" alt="profiles" src="https://github.com/user-attachments/assets/7c0cbc27-c642-49d6-a221-13c1b94a80ca" />

**Modified the following files**: 

_toolkit/content/_
- aboutProfiles.xhtml
- aboutProfiles.js

_toolkit/locales/en-US/toolkit/about_
- aboutProfiles.ftl

_toolkit/themes_
- aboutProfiles.css

I built everything and ran this `./mach build faster && ./mach` run, and it works. 

Signed-off-by: Fisnik Hasani <opensource@fisnikhasani.com>