### PR TITLE
Bug 2043181: Switch between longfox and privacy dashboard cta

### DIFF
--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -797,7 +797,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity, Crash
 
         ProfilerMarkers.homeActivityOnStart(binding.rootContainer, components.core.engine.profiler)
 
-        if (components.settings.longfoxEntryPointShownCount < Settings.LONGFOX_ENTRY_POINT_MAX_SHOWS) {
+        if (components.settings.longfoxPeekAnimationShownCount < Settings.LONGFOX_PEEK_ANIMATION_MAX_SHOWS) {
             components.settings.appLaunchCount++
             components.appStore.dispatch(
                 AppAction.UpdateShowFoxPeekAnimation(components.settings.shouldShowLongfoxPeekAnimationThisTime()),

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/fake/FakeHomepagePreview.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/fake/FakeHomepagePreview.kt
@@ -101,6 +101,8 @@ internal object FakeHomepagePreview {
             override fun onPrivacyReportTapped() { /* no op */ }
 
             override fun onLongfoxEntryPointClicked() { /* no op */ }
+
+            override fun onLongfoxEntryPointShown() { /* no op */ }
         }
 
     internal val sportsInteractor

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/logo/LogoController.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/logo/LogoController.kt
@@ -22,4 +22,11 @@ class LogoController(
     fun handleLongfoxEntryPointClicked() {
         if (container != null && longFoxEnabled) longFoxFeature.start(container = container)
     }
+
+    /**
+     * When the longfox entry point is shown, record the telemetry event.
+     */
+    fun handleLongfoxEntryPointShown() {
+        longFoxFeature.onEntryPointShown()
+    }
 }

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -180,6 +180,11 @@ interface TrackingProtectionInteractor {
      * Invoked when the longfox entry point text is clicked.
      */
     fun onLongfoxEntryPointClicked()
+
+    /**
+     * Invoked when the longfox entry point is shown.
+     */
+    fun onLongfoxEntryPointShown()
 }
 
 /**
@@ -454,6 +459,10 @@ class SessionControlInteractor(
 
     override fun onLongfoxEntryPointClicked() {
         logoController.handleLongfoxEntryPointClicked()
+    }
+
+    override fun onLongfoxEntryPointShown() {
+        logoController.handleLongfoxEntryPointShown()
     }
 
     override fun onGetCustomWallpaperClicked() {

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/store/HomepageState.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/store/HomepageState.kt
@@ -86,7 +86,8 @@ internal sealed class HomepageState {
      * @property showPocketStoriesCarousel Whether to show the pocket stories section.
      * @property showCollections Whether to show the collections section.
      * @property showPrivacyReport Whether to show the privacy report section.
-     * @property showLongfoxEntryPoint Whether to show the longfox entry point section.
+     * @property longfoxEnabled Whether the longfox game is enabled
+     * @property showLongfoxAnimation Whether to play the fox peek animation on the privacy report card.
      * @property trackersBlockedCount The number of trackers blocked for the privacy report.
      * @property sportsWidgetState State of the sports widget on the homepage.
      * @property headerState State related to the header of the homepage.
@@ -120,7 +121,8 @@ internal sealed class HomepageState {
         val showPocketStoriesCarousel: Boolean,
         val showCollections: Boolean,
         val showPrivacyReport: Boolean,
-        val showLongfoxEntryPoint: Boolean,
+        val longfoxEnabled: Boolean,
+        val showLongfoxAnimation: Boolean,
         val trackersBlockedCount: Int,
         val sportsWidgetState: SportsWidgetState,
         override val headerState: HeaderState,
@@ -245,7 +247,8 @@ internal sealed class HomepageState {
                     recommendationState.pocketStories.isNotEmpty() && !settings.privateModeAndStoriesEntryPointEnabled,
                 showCollections = settings.collections,
                 showPrivacyReport = settings.showPrivacyReportFeature,
-                showLongfoxEntryPoint = settings.longfoxEnabled && longfoxEntryPointReady,
+                longfoxEnabled = settings.longfoxEnabled,
+                showLongfoxAnimation = settings.longfoxEnabled && longfoxEntryPointReady,
                 trackersBlockedCount = blockedTrackersState.trackersBlockedCount,
                 sportsWidgetState = sportsWidgetState,
                 headerState = buildHeaderState(

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/store/HomepageState.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/store/HomepageState.kt
@@ -86,7 +86,7 @@ internal sealed class HomepageState {
      * @property showPocketStoriesCarousel Whether to show the pocket stories section.
      * @property showCollections Whether to show the collections section.
      * @property showPrivacyReport Whether to show the privacy report section.
-     * @property longfoxEnabled Whether the longfox game is enabled
+     * @property longfoxEnabled Whether the longfox game is enabled.
      * @property showLongfoxAnimation Whether to play the fox peek animation on the privacy report card.
      * @property trackersBlockedCount The number of trackers blocked for the privacy report.
      * @property sportsWidgetState State of the sports widget on the homepage.

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/ui/Homepage.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/ui/Homepage.kt
@@ -220,8 +220,8 @@ internal fun Homepage(
                         is HomepageState.Normal -> {
                             val settings = components.settings
                             val appStore = components.appStore
-                            LaunchedEffect(showLongfoxEntryPoint) {
-                                if (showLongfoxEntryPoint) {
+                            LaunchedEffect(showLongfoxAnimation) {
+                                if (showLongfoxAnimation) {
                                     settings.longfoxEntryPointShownCount++
                                     appStore.dispatch(
                                         AppAction.UpdateShowFoxPeekAnimation(false),
@@ -250,7 +250,8 @@ internal fun Homepage(
                                     onPrivacyReportTapped = interactor::onPrivacyReportTapped,
                                     onLongfoxEntryPointClicked = interactor::onLongfoxEntryPointClicked,
                                     modifier = Modifier.padding(top = 16.dp),
-                                    showLongfoxEntryPoint = showLongfoxEntryPoint,
+                                    longfoxEnabled = longfoxEnabled,
+                                    showLongfoxAnimation = showLongfoxAnimation,
                                 )
                             }
 
@@ -284,7 +285,7 @@ internal fun Homepage(
                                     interactor = interactor,
                                     cardBackgroundColor = cardBackgroundColor,
                                     recentTabs = recentTabs,
-                                    reducedTopSpacing = showPrivacyReport && showLongfoxEntryPoint,
+                                    reducedTopSpacing = showPrivacyReport && showLongfoxAnimation,
                                 )
 
                                 if (showRecentSyncedTab) {
@@ -672,7 +673,8 @@ private fun HomepagePreview() {
                     showPocketStoriesCarousel = true,
                     showCollections = true,
                     showPrivacyReport = true,
-                    showLongfoxEntryPoint = false,
+                    longfoxEnabled = false,
+                    showLongfoxAnimation = false,
                     trackersBlockedCount = 754,
                     sportsWidgetState = SportsWidgetState(),
                     headerState = HeaderState.Normal(
@@ -727,7 +729,8 @@ private fun HomepageBannerPreview() {
                     showPocketStoriesCarousel = true,
                     showCollections = true,
                     showPrivacyReport = true,
-                    showLongfoxEntryPoint = false,
+                    longfoxEnabled = false,
+                    showLongfoxAnimation = false,
                     trackersBlockedCount = 754,
                     sportsWidgetState = SportsWidgetState(),
                     headerState = HeaderState.Normal(
@@ -782,7 +785,8 @@ private fun HomepagePreviewCollections() {
                     showPocketStoriesCarousel = true,
                     showCollections = true,
                     showPrivacyReport = true,
-                    showLongfoxEntryPoint = false,
+                    longfoxEnabled = false,
+                    showLongfoxAnimation = false,
                     trackersBlockedCount = 754,
                     sportsWidgetState = SportsWidgetState(),
                     headerState = HeaderState.Normal(
@@ -837,7 +841,8 @@ private fun MinimalHomepagePreview() {
                     showPocketStoriesCarousel = true,
                     showCollections = false,
                     showPrivacyReport = true,
-                    showLongfoxEntryPoint = false,
+                    longfoxEnabled = false,
+                    showLongfoxAnimation = false,
                     trackersBlockedCount = 754,
                     sportsWidgetState = SportsWidgetState(),
                     headerState = HeaderState.Normal(

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/ui/Homepage.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/ui/Homepage.kt
@@ -229,6 +229,13 @@ internal fun Homepage(
                                 }
                             }
 
+                            val longfoxEntryPointShown = longfoxEnabled && showPrivacyReport
+                            LaunchedEffect(longfoxEntryPointShown) {
+                                if (longfoxEntryPointShown) {
+                                    interactor.onLongfoxEntryPointShown()
+                                }
+                            }
+
                             if (showTopSites) {
                                 TopSitesSection(
                                     topSites = topSites,

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/ui/Homepage.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/ui/Homepage.kt
@@ -222,7 +222,7 @@ internal fun Homepage(
                             val appStore = components.appStore
                             LaunchedEffect(showLongfoxAnimation) {
                                 if (showLongfoxAnimation) {
-                                    settings.longfoxEntryPointShownCount++
+                                    settings.longfoxPeekAnimationShownCount++
                                     appStore.dispatch(
                                         AppAction.UpdateShowFoxPeekAnimation(false),
                                     )

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/ui/MiddleSearchHomepage.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/ui/MiddleSearchHomepage.kt
@@ -203,7 +203,8 @@ private fun MiddleSearchHomepagePreview() {
                 showPocketStoriesCarousel = true,
                 showCollections = true,
                 showPrivacyReport = true,
-                showLongfoxEntryPoint = true,
+                longfoxEnabled = true,
+                showLongfoxAnimation = true,
                 trackersBlockedCount = 754,
                 sportsWidgetState = SportsWidgetState(),
                 headerState = HeaderState.Normal(

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackersBlockedCard.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackersBlockedCard.kt
@@ -62,15 +62,23 @@ private const val DISPLAY_DURATION_MS = 3000L
 private const val TYPEWRITER_REVERSE_DELAY_MS = 1200L
 
 internal const val LONGFOX_FOX_IMAGE_TEST_TAG = "trackersBlockedCard.longfoxFox"
+internal const val PROTECTION_STATUS_PILL_TEST_TAG = "trackersBlockedCard.protectionStatusPill"
 
 /**
  * A card that displays the number of trackers blocked with an animated fox.
  *
+ * When [longfoxEnabled] is true the pill launches the longfox game via [onLongfoxEntryPointClicked];
+ * otherwise it opens the privacy report via [onPrivacyReportTapped]. This routing is independent of
+ * [showLongfoxAnimation], which only controls the occasional fox peek animation.
+ *
  * @param trackersBlockedCount The number of trackers blocked to display.
  * @param modifier Modifier to be applied to the card.
- * @param onPrivacyReportTapped Invoked when the pill is tapped. If null, the pill is not clickable.
- * @param onLongfoxEntryPointClicked Invoked when the longfox typewriter text is tapped.
- * @param showLongfoxEntryPoint Whether to show the fox animation and typewriter text.
+ * @param onPrivacyReportTapped Invoked when the pill is tapped while longfox is disabled. If null,
+ * the pill is not clickable.
+ * @param onLongfoxEntryPointClicked Invoked when the pill is tapped while longfox is enabled.
+ * @param longfoxEnabled Whether the longfox game is enabled, routing pill taps to
+ * [onLongfoxEntryPointClicked] instead of [onPrivacyReportTapped].
+ * @param showLongfoxAnimation Whether to play the fox peek animation and typewriter text.
  */
 @Composable
 fun TrackersBlockedCard(
@@ -78,17 +86,18 @@ fun TrackersBlockedCard(
     modifier: Modifier = Modifier,
     onPrivacyReportTapped: (() -> Unit)? = null,
     onLongfoxEntryPointClicked: () -> Unit = {},
-    showLongfoxEntryPoint: Boolean = false,
+    longfoxEnabled: Boolean = false,
+    showLongfoxAnimation: Boolean = false,
 ) {
     var isPlayingAnimation by remember { mutableStateOf(false) }
     val foxOffsetY = remember { Animatable(1f) }
     var isReversing by remember { mutableStateOf(false) }
 
-    // Latch the entry point becoming visible into isPlayingAnimation. showLongfoxEntryPoint is
+    // Latch the animation becoming visible into isPlayingAnimation. showLongfoxAnimation is
     // cleared as soon as the homepage consumes it, so the animation is driven off the latch below
     // to ensure it runs to completion rather than being cancelled mid-flight.
-    LaunchedEffect(showLongfoxEntryPoint) {
-        if (showLongfoxEntryPoint) {
+    LaunchedEffect(showLongfoxAnimation) {
+        if (showLongfoxAnimation) {
             isPlayingAnimation = true
         }
     }
@@ -138,7 +147,7 @@ fun TrackersBlockedCard(
 
             ProtectionStatusPill(
                 trackersBlockedCount = trackersBlockedCount,
-                onPrivacyReportTapped = onPrivacyReportTapped,
+                onClick = if (longfoxEnabled) onLongfoxEntryPointClicked else onPrivacyReportTapped,
             )
         }
 
@@ -146,9 +155,7 @@ fun TrackersBlockedCard(
             Spacer(modifier = Modifier.height(6.dp))
 
             TypewriterText(
-                modifier = Modifier
-                    .clickable { onLongfoxEntryPointClicked() }
-                    .padding(bottom = FirefoxTheme.layout.space.static300),
+                modifier = Modifier.padding(bottom = FirefoxTheme.layout.space.static300),
                 text = stringResource(R.string.help_catch_trackers),
                 isReversing = isReversing,
             )
@@ -159,19 +166,20 @@ fun TrackersBlockedCard(
 @Composable
 private fun ProtectionStatusPill(
     trackersBlockedCount: Int,
-    onPrivacyReportTapped: (() -> Unit)? = null,
+    onClick: (() -> Unit)? = null,
 ) {
     val shape = MaterialTheme.shapes.extraLarge
     Row(
         modifier = Modifier
+            .testTag(PROTECTION_STATUS_PILL_TEST_TAG)
             .background(
                 color = MaterialTheme.colorScheme.surfaceBright,
                 shape = shape,
             )
             .clip(shape)
             .thenConditional(
-                Modifier.clickable { onPrivacyReportTapped?.invoke() },
-                { onPrivacyReportTapped != null },
+                Modifier.clickable { onClick?.invoke() },
+                { onClick != null },
             )
             .padding(horizontal = 16.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -274,7 +282,8 @@ private fun TrackersBlockedCardPreview() {
             TrackersBlockedCard(
                 trackersBlockedCount = 754,
                 onPrivacyReportTapped = {},
-                showLongfoxEntryPoint = true,
+                longfoxEnabled = true,
+                showLongfoxAnimation = true,
             )
         }
     }
@@ -288,7 +297,7 @@ private fun TrackersBlockedCardEmptyPreview() {
             TrackersBlockedCard(
                 trackersBlockedCount = 0,
                 onPrivacyReportTapped = {},
-                showLongfoxEntryPoint = false,
+                showLongfoxAnimation = false,
             )
         }
     }
@@ -321,7 +330,8 @@ private fun TrackersBlockedCardInteractivePreview() {
                     TrackersBlockedCard(
                         trackersBlockedCount = 754,
                         onPrivacyReportTapped = {},
-                        showLongfoxEntryPoint = true,
+                        longfoxEnabled = true,
+                        showLongfoxAnimation = true,
                     )
                 }
 

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -71,7 +71,7 @@ import org.mozilla.fenix.settings.sitepermissions.AUTOPLAY_BLOCK_ALL
 import org.mozilla.fenix.settings.sitepermissions.AUTOPLAY_BLOCK_AUDIBLE
 import org.mozilla.fenix.tabstray.DefaultTabManagementFeatureHelper
 import org.mozilla.fenix.termsofuse.TOU_VERSION
-import org.mozilla.fenix.utils.Settings.Companion.LONGFOX_ENTRY_POINT_MAX_SHOWS
+import org.mozilla.fenix.utils.Settings.Companion.LONGFOX_PEEK_ANIMATION_MAX_SHOWS
 import org.mozilla.fenix.wallpapers.Wallpaper
 import java.security.InvalidParameterException
 import java.util.concurrent.TimeUnit.MILLISECONDS
@@ -103,8 +103,8 @@ class Settings(
         private const val ALLOWED_INT = 2
         private const val INACTIVE_TAB_MINIMUM_TO_SHOW_AUTO_CLOSE_DIALOG = 20
 
-        const val LONGFOX_ENTRY_POINT_MAX_SHOWS = 5
-        const val LONGFOX_ENTRY_POINT_LAUNCH_INTERVAL = 3
+        const val LONGFOX_PEEK_ANIMATION_MAX_SHOWS = 5
+        const val LONGFOX_PEEK_ANIMATION_LAUNCH_INTERVAL = 3
 
         const val THIRTY_SECONDS_MS = 30 * 1000L
         const val FOUR_HOURS_MS = 60 * 60 * 4 * 1000L
@@ -3225,7 +3225,7 @@ class Settings(
 
     /**
      * Number of times the app has been foregrounded (cold start or returned from background).
-     * Used to gate the longfox entry point animation.
+     * Used to gate the longfox peek animation.
      */
     var appLaunchCount by intPreference(
         key = appContext.getPreferenceKey(R.string.pref_key_app_launch_count),
@@ -3233,23 +3233,23 @@ class Settings(
     )
 
     /**
-     * Number of times the longfox entry point animation has been shown on the homepage.
-     * Capped at [LONGFOX_ENTRY_POINT_MAX_SHOWS]; once reached the animation is no longer shown.
+     * Number of times the longfox peek animation has been shown on the homepage.
+     * Capped at [LONGFOX_PEEK_ANIMATION_MAX_SHOWS]; once reached the animation is no longer shown.
      */
-    var longfoxEntryPointShownCount by intPreference(
-        key = appContext.getPreferenceKey(R.string.pref_key_longfox_entry_point_shown_count),
+    var longfoxPeekAnimationShownCount by intPreference(
+        key = appContext.getPreferenceKey(R.string.pref_key_longfox_peek_animation_shown_count),
         default = 0,
     )
 
     /**
-     * Returns true when the longfox entry point animation should be armed for the current
+     * Returns true when the longfox peek animation should be armed for the current
      * app foreground: feature enabled, not yet reached the show cap, and on every Nth launch.
      */
     fun shouldShowLongfoxPeekAnimationThisTime(): Boolean =
         longfoxEnabled &&
-            longfoxEntryPointShownCount < LONGFOX_ENTRY_POINT_MAX_SHOWS &&
+            longfoxPeekAnimationShownCount < LONGFOX_PEEK_ANIMATION_MAX_SHOWS &&
             appLaunchCount > 0 &&
-            appLaunchCount % LONGFOX_ENTRY_POINT_LAUNCH_INTERVAL == 0
+            appLaunchCount % LONGFOX_PEEK_ANIMATION_LAUNCH_INTERVAL == 0
 
     /**
      * Indicates whether the app should automatically clean up downloaded files.

--- a/mobile/android/fenix/app/src/main/res/values/preference_keys.xml
+++ b/mobile/android/fenix/app/src/main/res/values/preference_keys.xml
@@ -610,7 +610,7 @@
     <!-- Longfox -->
     <string name="pref_key_enable_longfox" translatable="false">pref_key_enable_longfox</string>
     <string name="pref_key_app_launch_count" translatable="false">pref_key_app_launch_count</string>
-    <string name="pref_key_longfox_entry_point_shown_count" translatable="false">pref_key_longfox_entry_point_shown_count</string>
+    <string name="pref_key_longfox_peek_animation_shown_count" translatable="false">pref_key_longfox_peek_animation_shown_count</string>
 
     <!-- Sports Widget -->
     <string name="pref_key_sports_selected_countries" translatable="false">pref_key_sports_selected_countries</string>

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/logo/LogoControllerTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/logo/LogoControllerTest.kt
@@ -8,6 +8,7 @@ package org.mozilla.fenix.home.logo
 
 import android.view.ViewGroup
 import mozilla.components.support.test.fakes.android.FakeContext
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -17,10 +18,13 @@ class LogoControllerTest {
 
     class FakeLongFoxFeature : LongFoxFeatureApi {
         var started = false
+        var entryPointShownCount = 0
         override fun start(container: ViewGroup) {
             started = true
         }
-        override fun onEntryPointShown() { }
+        override fun onEntryPointShown() {
+            entryPointShownCount++
+        }
     }
 
     class FakeViewGroup : ViewGroup(FakeContext()) {
@@ -60,5 +64,16 @@ class LogoControllerTest {
         )
         logoController.handleLongfoxEntryPointClicked()
         assertTrue(fakeLongFoxFeature.started)
+    }
+
+    @Test
+    fun `record telemetry when entry point shown`() {
+        val logoController = LogoController(
+            longFoxFeature = fakeLongFoxFeature,
+            container = FakeViewGroup(),
+            longFoxEnabled = true,
+        )
+        logoController.handleLongfoxEntryPointShown()
+        assertEquals(1, fakeLongFoxFeature.entryPointShownCount)
     }
 }

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackersBlockedCardTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackersBlockedCardTest.kt
@@ -9,7 +9,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -22,12 +24,12 @@ class TrackersBlockedCardTest {
     val composeTestRule = createComposeRule()
 
     @Test
-    fun `when the longfox entry point is not shown, the fox is not displayed`() {
+    fun `when the longfox animation is not shown, the fox is not displayed`() {
         composeTestRule.setContent {
             FirefoxTheme(theme = Theme.Light) {
                 TrackersBlockedCard(
                     trackersBlockedCount = 3,
-                    showLongfoxEntryPoint = false,
+                    showLongfoxAnimation = false,
                 )
             }
         }
@@ -36,16 +38,16 @@ class TrackersBlockedCardTest {
     }
 
     @Test
-    fun `if the entry point is cleared mid-animation the peek animation still runs to completion`() {
+    fun `if the animation flag is cleared mid-animation the peek animation still runs to completion`() {
         // The animation is driven by the compose clock, so pause it to step through deterministically.
         composeTestRule.mainClock.autoAdvance = false
 
-        var showLongfoxEntryPoint by mutableStateOf(true)
+        var showLongfoxAnimation by mutableStateOf(true)
         composeTestRule.setContent {
             FirefoxTheme(theme = Theme.Light) {
                 TrackersBlockedCard(
                     trackersBlockedCount = 3,
-                    showLongfoxEntryPoint = showLongfoxEntryPoint,
+                    showLongfoxAnimation = showLongfoxAnimation,
                 )
             }
         }
@@ -55,12 +57,77 @@ class TrackersBlockedCardTest {
         composeTestRule.onNodeWithTag(LONGFOX_FOX_IMAGE_TEST_TAG).assertExists()
 
         // The homepage consumes the entry point and clears the flag while the fox is still peeking.
-        showLongfoxEntryPoint = false
+        showLongfoxAnimation = false
 
         // The animation is latched, so it must keep running rather than being cancelled here.
         composeTestRule.mainClock.advanceTimeBy(20_000L)
 
         // Once the full peek/dwell/retract sequence ends, the fox is removed.
         composeTestRule.onNodeWithTag(LONGFOX_FOX_IMAGE_TEST_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun `when longfox is enabled, tapping the pill launches the game rather than the privacy report`() {
+        var privacyReportTaps = 0
+        var longfoxTaps = 0
+        composeTestRule.setContent {
+            FirefoxTheme(theme = Theme.Light) {
+                TrackersBlockedCard(
+                    trackersBlockedCount = 3,
+                    onPrivacyReportTapped = { privacyReportTaps++ },
+                    onLongfoxEntryPointClicked = { longfoxTaps++ },
+                    longfoxEnabled = true,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag(PROTECTION_STATUS_PILL_TEST_TAG).performClick()
+
+        assertEquals(1, longfoxTaps)
+        assertEquals(0, privacyReportTaps)
+    }
+
+    @Test
+    fun `when longfox is disabled, tapping the pill opens the privacy report rather than the game`() {
+        var privacyReportTaps = 0
+        var longfoxTaps = 0
+        composeTestRule.setContent {
+            FirefoxTheme(theme = Theme.Light) {
+                TrackersBlockedCard(
+                    trackersBlockedCount = 3,
+                    onPrivacyReportTapped = { privacyReportTaps++ },
+                    onLongfoxEntryPointClicked = { longfoxTaps++ },
+                    longfoxEnabled = false,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag(PROTECTION_STATUS_PILL_TEST_TAG).performClick()
+
+        assertEquals(1, privacyReportTaps)
+        assertEquals(0, longfoxTaps)
+    }
+
+    @Test
+    fun `pill routing is independent of the peek animation`() {
+        // longfox enabled but no animation this view - the pill must still launch the game.
+        var privacyReportTaps = 0
+        var longfoxTaps = 0
+        composeTestRule.setContent {
+            FirefoxTheme(theme = Theme.Light) {
+                TrackersBlockedCard(
+                    trackersBlockedCount = 3,
+                    onPrivacyReportTapped = { privacyReportTaps++ },
+                    onLongfoxEntryPointClicked = { longfoxTaps++ },
+                    longfoxEnabled = true,
+                    showLongfoxAnimation = false,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag(PROTECTION_STATUS_PILL_TEST_TAG).performClick()
+
+        assertEquals(1, longfoxTaps)
+        assertEquals(0, privacyReportTaps)
     }
 }


### PR DESCRIPTION
Bug 2043181: Switch between longfox and privacy dashboard cta

- if longfox is enabled, the privacy button cta launches longfox, otherwise it launches the privacy dashboard
-- previously longfox was only accessible from the peeking fox animation. i have renamed the logic around the peeking fox animation to clarify that this is no longer the same thing as the longfox entry point.
- send a telemetry event every time the longfox cta is shown (i had left this out of https://bugzilla.mozilla.org/show_bug.cgi?id=2039559 until we had figured out what the cta was!)
