### PR TITLE
Bug 2047940: Refine longfox CTA.

### DIFF
--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackersBlockedCard.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackersBlockedCard.kt
@@ -148,15 +148,13 @@ fun TrackersBlockedCard(
             ProtectionStatusPill(
                 trackersBlockedCount = trackersBlockedCount,
                 onClick = if (longfoxEnabled) onLongfoxEntryPointClicked else onPrivacyReportTapped,
+                longfoxEnabled = longfoxEnabled,
             )
         }
 
         if (isPlayingAnimation && foxOffsetY.value < 1f) {
-            Spacer(modifier = Modifier.height(6.dp))
-
             TypewriterText(
-                modifier = Modifier.padding(bottom = FirefoxTheme.layout.space.static300),
-                text = stringResource(R.string.help_catch_trackers),
+                text = stringResource(org.mozilla.fenix.longfox.R.string.tap_to_play),
                 isReversing = isReversing,
             )
         }
@@ -167,6 +165,7 @@ fun TrackersBlockedCard(
 private fun ProtectionStatusPill(
     trackersBlockedCount: Int,
     onClick: (() -> Unit)? = null,
+    longfoxEnabled: Boolean,
 ) {
     val shape = MaterialTheme.shapes.extraLarge
     Row(
@@ -193,7 +192,10 @@ private fun ProtectionStatusPill(
         )
 
         Text(
-            text = if (trackersBlockedCount > 0) {
+            text =
+            if (longfoxEnabled) {
+                stringResource(R.string.help_catch_trackers)
+            } else if (trackersBlockedCount > 0) {
                 pluralStringResource(
                     R.plurals.trackers_blocked_count_2,
                     trackersBlockedCount,


### PR DESCRIPTION
When the button is going to launch longfox, changed the button text to "help catch trackers" and the animated TypewriterText to "tap to play!" These are the best strings we have available for 153. Hopefully they make it a bit clearer what is going to happen when you hit the button. Additionally, trimmed the padding underneath: this was a hangover from when the animated text was a CTA to launch longfox. We don't need that any more and it's pushing the other home page content down.

Before

<img width="108" height="234" alt="image" src="https://github.com/user-attachments/assets/6e844c0e-8747-4225-89de-e3aaf507c0ea" />
<img width="108" height="234" alt="image" src="https://github.com/user-attachments/assets/798742a8-6454-40d2-99ad-97adda2dcde9" />

After

<img width="108" height="234" alt="after-no-peek" src="https://github.com/user-attachments/assets/b1e36f8a-3b13-470a-ba19-69a4ff03eb62" />
<img width="108" height="234" alt="after-with-peek" src="https://github.com/user-attachments/assets/1983d8e3-ce7e-4b55-b9f0-2f6aedb18d29" />
