### PR TITLE
Bug 2048099 - Return InvalidStateError when excludeCredentials matches a platform credential on macOS.

### DIFF
--- a/dom/webauthn/MacOSWebAuthnService.mm
+++ b/dom/webauthn/MacOSWebAuthnService.mm
@@ -555,6 +555,9 @@ NSDictionary<NSData*, ASAuthorizationPublicKeyCredentialPRFAssertionInputValues*
       case ASAuthorizationErrorCanceled:
         rv = NS_ERROR_DOM_NOT_ALLOWED_ERR;
         break;
+      case ASAuthorizationErrorMatchedExcludedCredential:
+        rv = NS_ERROR_DOM_INVALID_STATE_ERR;
+        break;
       case ASAuthorizationErrorFailed:
         // The message is right, but it's not about indexeddb.
         // See https://webidl.spec.whatwg.org/#constrainterror


### PR DESCRIPTION
On macOS 15+, ASAuthorizationErrorMatchedExcludedCredential (code 1006) is returned when a credential in the excludeCredentials list is found on the platform authenticator. This code was not handled in the ASAuthorizationErrorDomain switch in MacOSWebAuthnService.mm, so it fell through to the default NS_ERROR_DOM_NOT_ALLOWED_ERR — surfacing as a NotAllowedError DOMException indistinguishable from a user cancellation.

Per WebAuthn spec §5.1.3 step 20, an excludeCredentials match must return InvalidStateError. Chrome and Safari already conform. The WPT createcredential-excludecredentials.https.html (landed via Bug 1619996) asserts this but is currently SKIP'd in Firefox CI.

Confirmed via MOZ_LOG="macoswebauthnservice:5" on Firefox 151 / macOS 26.5.1: domain 'com.apple.AuthenticationServices.AuthorizationError' code 1006

```
[Parent 59271: Main Thread]: D/macoswebauthnservice MacOSAuthenticatorRequestDelegate::didCompleteWithAuthorization: got registration
[Parent 59271: Main Thread]: W/macoswebauthnservice MacOSAuthenticatorRequestDelegate::didCompleteWithError: domain 'com.apple.AuthenticationServices.AuthorizationError' code 1006 (The operation couldn’t be completed. (com.apple.AuthenticationServices.AuthorizationError error 1006.))
```