### PR TITLE
Bug 2048200: Expose longfox secret setting to all release types.

### DIFF
--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/HomeSettingsFragment.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/HomeSettingsFragment.kt
@@ -84,6 +84,7 @@ class HomeSettingsFragment : PreferenceFragmentCompat(), SystemInsetsPaddedFragm
         }
 
         requirePreference<SwitchPreferenceCompat>(R.string.pref_key_privacy_report).apply {
+            if (fenixSettings.longfoxEnabled) title = resources.getString(R.string.help_catch_trackers)
             isChecked = fenixSettings.showPrivacyReportFeature
             onPreferenceChangeListener = createMetricPreferenceChangeListener(
                 metricKey = getString(R.string.pref_key_privacy_report_metric),

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
@@ -452,7 +452,6 @@ class SecretSettingsFragment : PreferenceFragmentCompat(), SystemInsetsPaddedFra
         }
 
         requirePreference<SwitchPreferenceCompat>(R.string.pref_key_enable_longfox).apply {
-            isVisible = Config.channel.isNightlyOrDebug
             isChecked = settings.longfoxEnabled
             onPreferenceChangeListener = SharedPreferenceUpdater()
         }


### PR DESCRIPTION
This means that if people are in the longfox experiment and hate it, they can turn it off. 
conversely, if you are longfox curious you could switch it on!