### PR TITLE
gl.rs: Fix Mali Bifrost GPU detection on Mesa's Panfrost driver

### DIFF
--- a/gfx/wr/webrender/src/device/gl.rs
+++ b/gfx/wr/webrender/src/device/gl.rs
@@ -1512,12 +1512,12 @@ fn is_mali_midgard(renderer_name: &str) -> bool {
 
 /// Returns whether this GPU belongs to the Mali Bifrost family
 fn is_mali_bifrost(renderer_name: &str) -> bool {
-    renderer_name == "Mali-G31"
-        || renderer_name == "Mali-G51"
-        || renderer_name == "Mali-G71"
-        || renderer_name == "Mali-G52"
-        || renderer_name == "Mali-G72"
-        || renderer_name == "Mali-G76"
+    renderer_name.starts_with("Mali-G31")
+        || renderer_name.starts_with("Mali-G51")
+        || renderer_name.starts_with("Mali-G71")
+        || renderer_name.starts_with("Mali-G52")
+        || renderer_name.starts_with("Mali-G72")
+        || renderer_name.starts_with("Mali-G76")
 }
 
 /// Returns whether this GPU belongs to the Mali Valhall family


### PR DESCRIPTION
The `GL_RENDERER` string contains more information when using the Panfrost driver from Mesa.  For example, an Arm Mali-G31 GPU currently returns this render string: `Mali-G31 MC1 (Panfrost)`

Exact-matching the string would result in not properly considering these GPUs to be Bifrost.  Using `starts_with` instead should make these GPUs detect properly when using Panfrost, while not changing detection with the proprietary driver.

Note: This will probably result in `supports_render_target_partial_update` being false when using Panfrost on a Bifrost GPU, were it would have returned true before, due to the GPU being mistakenly identified as Valhall.  If `supports_render_target_partial_update` works on Panfrost, the check should probably be updated to only return false if `Panfrost` isn't present in the render string.  Honestly, a lot of the generation-specific feature disabling probably needs to be tested and adjusted to account for Panfrost anyways.  (For that matter, this probably applies to other Mesa drivers, such as Freedreno.)  That said, it's better safe than sorry, so for now, properly detecting Bifrost GPUs as Bifrost and not Valhall is probably the best first step.

Note: I haven't tested this; I actually noticed this issue while doing some research unrelated to Firefox.  It should be correct from a technical standpoint, as best as I can tell, and the change is extremely simple, so I feel comfortable submitting this PR.