### PR TITLE
Bug 1688774 - Enable "Connection Settings" dialog to Accept file:// and npipe:// proxy

### DIFF
--- a/browser/components/preferences/dialogs/connection.js
+++ b/browser/components/preferences/dialogs/connection.js
@@ -128,7 +128,10 @@ var gConnectionsDialog = {
             .focus();
           event.preventDefault();
           return;
-        } else if (!Services.io.isValidHostname(proxyPref.value)) {
+        } else if (
+          !Services.io.isValidHostname(proxyPref.value) &&
+          !(prefName === "socks" && (proxyPref.value.startsWith("file://") || proxyPref.value.startsWith("npipe://")))
+        ) {
           document
             .getElementById("networkProxy" + prefName.toUpperCase())
             .focus();

--- a/browser/components/preferences/tests/networking/browser_connection_valid_hostname.js
+++ b/browser/components/preferences/tests/networking/browser_connection_valid_hostname.js
@@ -53,3 +53,77 @@ add_task(async function test_valid_hostname() {
 
   gBrowser.removeCurrentTab();
 });
+
+add_task(async function test_socks_file_uri() {
+  await openPreferencesViaOpenPreferencesAPI("general", { leaveOpen: true });
+  const connectionURL =
+    "chrome://browser/content/preferences/dialogs/connection.xhtml";
+  let dialog = await openAndLoadSubDialog(connectionURL);
+  let dialogElement = dialog.document.getElementById("ConnectionsDialog");
+
+  let oldNetworkProxyType = Services.prefs.getIntPref("network.proxy.type");
+  let oldSocksPort = Services.prefs.getIntPref("network.proxy.socks_port");
+  registerCleanupFunction(function () {
+    Services.prefs.setIntPref("network.proxy.type", oldNetworkProxyType);
+    Services.prefs.setIntPref("network.proxy.socks_port", oldSocksPort);
+    Services.prefs.clearUserPref("network.proxy.share_proxy_settings");
+    for (let proxyType of ["http", "ssl", "socks"]) {
+      Services.prefs.clearUserPref("network.proxy." + proxyType);
+      Services.prefs.clearUserPref("network.proxy." + proxyType + "_port");
+      if (proxyType == "http") {
+        continue;
+      }
+      Services.prefs.clearUserPref("network.proxy.backup." + proxyType);
+      Services.prefs.clearUserPref(
+        "network.proxy.backup." + proxyType + "_port"
+      );
+    }
+  });
+
+  let proxyType = dialog.Preferences.get("network.proxy.type");
+  let socksPref = dialog.Preferences.get("network.proxy.socks");
+  let socksPortPref = dialog.Preferences.get("network.proxy.socks_port");
+  proxyType.value = 1;
+  socksPortPref.value = 1234;
+
+  // file:// URIs should be accepted for SOCKS
+  socksPref.value = "file:///var/run/socks5.sock";
+  let beforeAcceptCalled = BrowserTestUtils.waitForEvent(
+    dialogElement,
+    "beforeaccept"
+  );
+  dialogElement.acceptDialog();
+  let event = await beforeAcceptCalled;
+  Assert.ok(
+    !event.defaultPrevented,
+    "The dialog was accepted with file:// SOCKS path"
+  );
+
+  // npipe:// URIs should also be accepted for SOCKS (Windows named pipes)
+  socksPref.value = "npipe:///./pipe/socks";
+  beforeAcceptCalled = BrowserTestUtils.waitForEvent(
+    dialogElement,
+    "beforeaccept"
+  );
+  dialogElement.acceptDialog();
+  event = await beforeAcceptCalled;
+  Assert.ok(
+    !event.defaultPrevented,
+    "The dialog was accepted with npipe:// SOCKS path"
+  );
+
+  // Regular hostnames should still work for SOCKS
+  socksPref.value = "localhost";
+  beforeAcceptCalled = BrowserTestUtils.waitForEvent(
+    dialogElement,
+    "beforeaccept"
+  );
+  dialogElement.acceptDialog();
+  event = await beforeAcceptCalled;
+  Assert.ok(
+    !event.defaultPrevented,
+    "The dialog was accepted with regular SOCKS hostname"
+  );
+
+  gBrowser.removeCurrentTab();
+});


### PR DESCRIPTION
Accept file:// and npipe:// URIs in SOCKS Host field of the Connection Settings dialog

When a user enters a `file:///path/to/socket` or `npipe:///./pipe/name` URI into the "SOCKS Host" field in Firefox's Connection Settings dialog and clicks OK, the dialog fails to accept the value. The OK button does nothing because the validation in the `beforeaccept` event handler rejects the URI because the `/` characters in the scheme are treated as invalid hostname characters.

The underlying SOCKS implementation already fully supports Unix domain sockets (`file://`) on Unix and named pipes (`npipe://`) on Windows — the problem was only in the **dialog validation**, not in the actual SOCKS connection code.

In `browser/components/preferences/dialogs/connection.js` line 131, the `beforeAccept` handler validates the SOCKS host using `Services.io.isValidHostname()`:

```javascript
} else if (!Services.io.isValidHostname(proxyPref.value)) {
```

`Services.io.isValidHostname()` returns `false` for `file:///path/to/socket` because the `/` characters in the URI scheme aren't valid hostname characters according to the DNS hostname validation rules. This triggers `event.preventDefault()` which blocks the OK button.

The SOCKS implementation already supports these URIs:

- **`nsSOCKSIOLayer.cpp`**: `SetLocalProxyPath()` (line 121) handles `file://` paths on both Unix and Windows, setting `aProxyAddr->raw.family = AF_UNIX` / `AF_LOCAL`
- **`nsSOCKSIOLayer.cpp`**: `IsLocalProxy()` (line 115) checks `IsHostLocalTarget()` which returns `true` when the host starts with `file:`
- **`nsSOCKSSocketProvider.cpp`**: `OpenTCPSocket()` (line 43) checks `StringBeginsWith(proxyHost, "file://")` and sets `family = AF_LOCAL` for Unix domain sockets

The dialog validation just wasn't aware of these URI schemes.

**Before (line 131):**
```javascript
} else if (!Services.io.isValidHostname(proxyPref.value)) {
```

**After (line 131):**
```javascript
} else if (
  !Services.io.isValidHostname(proxyPref.value) &&
  !(prefName === "socks" && (proxyPref.value.startsWith("file://") || proxyPref.value.startsWith("npipe://")))
) {
```

The change adds a SOCKS-specific check: if the field is the SOCKS field (`prefName === "socks"`) and the value starts with `file://` or `npipe://`, it is considered valid even if `isValidHostname()` returns `false`.

Added a new `test_socks_file_uri()` test that verifies:

1. `file:///var/run/socks5.sock` is accepted for SOCKS
2. `npipe:///./pipe/socks` is accepted for SOCKS (Windows named pipes)
3. Regular SOCKS hostnames like `localhost` still work

| Platform | URI Scheme | Description |
|----------|------------|-------------|
| Unix/Linux | `file:///path/to/socket` | Unix domain socket | | Windows | `npipe:///./pipe/name` | Named pipe |
| Both | `file:///path/to/socket` | Works on all platforms |

- The underlying SOCKS implementation for `file://` was added in previous patches (see `nsSOCKSIOLayer.cpp` line 156 for `AF_UNIX` and `nsSOCKSSocketProvider.cpp` line 50 for the `file://` check)
- `npipe://` support mirrors the Windows named pipe implementation
- This is not a new feature, but rather fixing the dialog to accept what the SOCKS code already understands

- Added `test_socks_file_uri()` in `browser_connection_valid_hostname.js` with three test cases:
  1. `file:///var/run/socks5.sock` -- accepted
  2. `npipe:///./pipe/socks` -- accepted
  3. `localhost` -- still works (regression check)

- Manual testing:
  1. Open `about:networking#socks` or `about:preferences#general`
  2. Scroll to "Connection Settings"
  3. Select "Manual proxy configuration"
  4. Enter `file:///var/run/socks5.sock` in the SOCKS Host field
  5. Click OK -- dialog accepts the value

- `./mach try fuzzy -q "browser_connection_valid_hostname"`
- `./mach test --headless browser/components/preferences/tests/networking/browser_connection_valid_hostname.js`