### PR TITLE
Bug 1735300 - Do not use MP4 edit-list preroll as the media start time

### DIFF
--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -3538,7 +3538,14 @@ void MediaFormatReader::OnFirstDemuxCompleted(
 
   auto& decoder = GetDecoderData(aType);
   MOZ_ASSERT(decoder.mFirstDemuxedSampleTime.isNothing());
-  decoder.mFirstDemuxedSampleTime.emplace(aSamples->GetSamples()[0]->mTime);
+  TimeUnit firstDemuxedSampleTime = aSamples->GetSamples()[0]->mTime;
+  const TrackInfo* info = decoder.GetCurrentInfo();
+  if (firstDemuxedSampleTime.IsNegative() && info &&
+      info->mMediaTime.IsPositive()) {
+    // Negative samples before positive media time are decode pre-roll.
+    firstDemuxedSampleTime = TimeUnit::Zero(firstDemuxedSampleTime);
+  }
+  decoder.mFirstDemuxedSampleTime.emplace(firstDemuxedSampleTime);
   MaybeResolveMetadataPromise();
 }
 

--- a/dom/media/gtest/TestMediaFormatReader.cpp
+++ b/dom/media/gtest/TestMediaFormatReader.cpp
@@ -32,6 +32,66 @@ using testing::MockFunction;
 using testing::Return;
 using testing::StrEq;
 
+TEST(TestMediaFormatReader, PositiveMediaTimeIgnoresNegativePreroll)
+{
+  RefPtr dataDemuxer = new MockMediaDataDemuxer();
+  RefPtr trackDemuxer =
+      new MockMediaTrackDemuxer("video/x-test; width=640; height=360");
+
+  ON_CALL(*dataDemuxer, GetNumberTracks(TrackType::kVideoTrack))
+      .WillByDefault(Return(1));
+
+  ON_CALL(*dataDemuxer, GetTrackDemuxer)
+      .WillByDefault([&](TrackType aType, uint32_t aTrackNumber) {
+        EXPECT_EQ(aTrackNumber, 0u);
+        EXPECT_EQ(aType, TrackType::kVideoTrack);
+        return do_AddRef(trackDemuxer);
+      });
+
+  ON_CALL(*trackDemuxer, GetInfo).WillByDefault([]() {
+    auto extended =
+        MakeMediaContainerType("video/x-test; width=640; height=360").value();
+    UniquePtr<TrackInfo> info =
+        CreateTrackInfoWithMIMETypeAndContainerTypeExtraParameters(
+            extended.Type().AsString(), extended);
+    info->mMediaTime = TimeUnit::FromMicroseconds(6375000);
+    return info;
+  });
+
+  EXPECT_CALL(*trackDemuxer, MockGetSamples).WillOnce([]() {
+    RefPtr sample = new MediaRawData;
+    sample->mTime = TimeUnit::FromMicroseconds(-6375000);
+    sample->mDuration = TimeUnit::FromMicroseconds(41667);
+    RefPtr<SamplesHolder> samples = new SamplesHolder;
+    samples->AppendSample(std::move(sample));
+    return SamplesPromise::CreateAndResolve(samples, __func__);
+  });
+
+  RefPtr pdm = new MockDecoderModule();
+  PDMFactory::AutoForcePDM autoForcePDM(pdm);
+  auto owner = std::make_unique<MockMediaDecoderOwner>();
+  RefPtr container = new VideoFrameContainer(
+      owner.get(),
+      MakeAndAddRef<ImageContainer>(ImageUsageType::VideoFrameContainer,
+#ifdef MOZ_WIDGET_ANDROID
+                                    // Work around bug 1922144
+                                    ImageContainer::SYNCHRONOUS
+#else
+                                    ImageContainer::ASYNCHRONOUS
+#endif
+                                    ));
+  MediaFormatReaderInit init;
+  init.mVideoFrameContainer = container;
+  RefPtr reader = new MediaFormatReader(init, dataDemuxer);
+  RefPtr proxy = new ReaderProxy(AbstractThread::MainThread(), reader);
+  EXPECT_NS_SUCCEEDED(reader->Init());
+
+  MetadataHolder metadata = WaitForResolve(proxy->ReadMetadata());
+  EXPECT_EQ(metadata.mInfo->mStartTime, TimeUnit::Zero());
+
+  WaitForResolve(proxy->Shutdown());
+}
+
 TEST(TestMediaFormatReader, WaitingForDemuxAfterInternalSeek)
 {
   RefPtr<MediaFormatReader> reader;


### PR DESCRIPTION
## Summary

- Treat negative first demuxed samples on tracks with positive media time as decode pre-roll when computing `MediaFormatReader` metadata start time.
- Preserve the original negative sample timestamp for decode; only the metadata origin is clamped to zero.
- Add a `MediaFormatReader` gtest covering an MP4 edit-list style pre-roll first sample.

## Why

This fixes [Bug 1735300](https://bugzilla.mozilla.org/show_bug.cgi?id=1735300).

MP4 edit lists describe the presentation timeline. A decoder may still need samples before the presentation start in order to decode the first visible frame, but those dependency samples should not become the media element's visible `currentTime == 0` frame.

That distinction matches the broader media stack's behavior:

- FFmpeg's `mov/mp4/3gp` demuxer documents edit lists as timeline data: by default it modifies the stream index to reflect the timeline described by the edit list, with `ignore_editlist` as the opt-out path. See the `ignore_editlist` and `advanced_editlist` options in the [FFmpeg formats documentation](https://ffmpeg.org/ffmpeg-formats.html#mov_002fmp4_002f3gp).
- QuickTime has first-class edit-list semantics for presenting only selected media ranges without duplicating media data. See Apple's [Playing with edit lists](https://developer.apple.com/documentation/quicktime-file-format/playing_with_edit_lists) documentation.
- OpenCV exposes an FFmpeg video I/O backend (`CAP_FFMPEG`), so video-processing workflows using that backend follow FFmpeg's presentation timeline behavior rather than exposing decode pre-roll as frame zero. See OpenCV's [`VideoCapture` API backend list](https://docs.opencv.org/4.x/dc/d3d/videoio_8hpp.html).

The current Firefox behavior lets MP4 decode pre-roll pull the media timeline earlier. That makes the first visible frame differ from Chrome and from file-processing tools that honor the edit-list presentation start.

## Visual evidence

These screenshots use the public sample from Bug 1735300. The file reports a 2.0s audio/video presentation, while its first video packets are negative decode pre-roll:

```text
format start=0.000000 duration=2.000000
video  start=0.000000 duration=2.000000
audio  start=0.000000 duration=2.000000
first video packet pts=-6.375000 dts=-6.458333 duration=0.041667 flags=KD_
```

Current Firefox 152.0.1 at `0.000000s` still shows pre-roll before the edit-list start:

![Current Firefox at 0s](https://gist.githubusercontent.com/dancrew32/bf545fef7b858e95990e9b254c29cf94/raw/firefox-before-start-video.svg)

Chrome 149.0.7827.156 at `0.000000s` starts on the edit-list presentation frame:

![Chrome at 0s](https://gist.githubusercontent.com/dancrew32/bf545fef7b858e95990e9b254c29cf94/raw/chrome-start-video.svg)

Current Firefox near the presentation end still remains behind the edit-list timeline:

![Current Firefox near end](https://gist.githubusercontent.com/dancrew32/bf545fef7b858e95990e9b254c29cf94/raw/firefox-before-end-video.svg)

Chrome near the presentation end remains aligned with the presentation timeline:

![Chrome near end](https://gist.githubusercontent.com/dancrew32/bf545fef7b858e95990e9b254c29cf94/raw/chrome-end-video.svg)

## Test plan

- `git diff --check`
- Added `TestMediaFormatReader.PositiveMediaTimeIgnoresNegativePreroll`
- Not run locally: `./mach gtest TestMediaFormatReader.PositiveMediaTimeIgnoresNegativePreroll`

This local checkout is sparse because the full Firefox checkout exceeded available disk on this machine. A full checkout/build or try run is still needed before this is ready for non-draft review.

## Notes

- GitHub draft only. Mozilla review/landing should still go through the normal Bugzilla/Phabricator path if that is preferred for this component.
- Patched-Firefox visual screenshots are still pending a full local build or try artifact.
