### PR TITLE
Bug 2050032 - reset peeking fox animation when restoring from background

### DIFF
--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackersBlockedCard.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackersBlockedCard.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,7 +47,10 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import mozilla.components.compose.base.modifier.thenConditional
 import org.mozilla.fenix.R
 import org.mozilla.fenix.theme.FirefoxTheme
@@ -92,6 +96,7 @@ fun TrackersBlockedCard(
     var isPlayingAnimation by remember { mutableStateOf(false) }
     val foxOffsetY = remember { Animatable(1f) }
     var isReversing by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
 
     // Latch the animation becoming visible into isPlayingAnimation. showLongfoxAnimation is
     // cleared as soon as the homepage consumes it, so the animation is driven off the latch below
@@ -102,9 +107,20 @@ fun TrackersBlockedCard(
         }
     }
 
+    // see bug 2050032.
+    // animateTo is frame-driven and freezes while backgrounded, but the delays below keep running,
+    // so a peek interrupted by backgrounding would otherwise play its retract transition on return.
+    // Reset to the hidden state when the card leaves the foreground so it restores cleanly.
+    LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
+        isPlayingAnimation = false
+        coroutineScope.launch { foxOffsetY.snapTo(1f) }
+    }
+
     LaunchedEffect(isPlayingAnimation) {
         if (isPlayingAnimation) {
             isReversing = false
+            // make sure we always start from the beginning position.
+            foxOffsetY.snapTo(1f)
             foxOffsetY.animateTo(
                 targetValue = 0f,
                 animationSpec = tween(durationMillis = FOX_ANIMATION_DURATION, easing = Ease),

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackersBlockedCardTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackersBlockedCardTest.kt
@@ -4,17 +4,21 @@
 
 package org.mozilla.fenix.trackingprotection
 
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.fenix.helpers.lifecycle.TestLifecycleOwner
 import org.mozilla.fenix.theme.FirefoxTheme
 import org.mozilla.fenix.theme.Theme
 
@@ -63,6 +67,37 @@ class TrackersBlockedCardTest {
         composeTestRule.mainClock.advanceTimeBy(20_000L)
 
         // Once the full peek/dwell/retract sequence ends, the fox is removed.
+        composeTestRule.onNodeWithTag(LONGFOX_FOX_IMAGE_TEST_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun `when the card is backgrounded mid-animation the fox is removed instead of replaying its retract`() {
+        // The animation is driven by the compose clock, so pause it to step through deterministically.
+        composeTestRule.mainClock.autoAdvance = false
+
+        val lifecycleOwner = TestLifecycleOwner(initialState = Lifecycle.State.RESUMED)
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+                FirefoxTheme(theme = Theme.Light) {
+                    TrackersBlockedCard(
+                        trackersBlockedCount = 3,
+                        showLongfoxAnimation = true,
+                    )
+                }
+            }
+        }
+
+        // The fox is peeking out once the animation starts.
+        composeTestRule.mainClock.advanceTimeBy(100L)
+        composeTestRule.onNodeWithTag(LONGFOX_FOX_IMAGE_TEST_TAG).assertExists()
+
+        // Sending the app to the background must reset the card to its hidden default state.
+        composeTestRule.runOnUiThread { lifecycleOwner.onStop() }
+        composeTestRule.mainClock.advanceTimeBy(100L)
+        composeTestRule.onNodeWithTag(LONGFOX_FOX_IMAGE_TEST_TAG).assertDoesNotExist()
+
+        // It must stay hidden rather than playing the retract transition when the app returns.
+        composeTestRule.mainClock.advanceTimeBy(20_000L)
         composeTestRule.onNodeWithTag(LONGFOX_FOX_IMAGE_TEST_TAG).assertDoesNotExist()
     }
 


### PR DESCRIPTION
[try is running here](https://treeherder.mozilla.org/jobs?repo=try&landoInstance=lando-prod-2025&landoCommitID=62488)