### PR TITLE
Fix searchfox paths rust-engines.md

### DIFF
--- a/services/sync/docs/rust-engines.md
+++ b/services/sync/docs/rust-engines.md
@@ -1,11 +1,11 @@
 # How Rust Engines are implemented
 
-There are 2 main components to engines implemented in Rust
+There are two main components to engines implemented in Rust
 
 ## The bridged-engine
 
 Because Rust engines still need to work with the existing Sync infrastructure,
-there's the concept of a {searchfox}`bridged-engine <services/sync/modules/bridged_engine.js>`.
+there's the concept of a {searchfox}`bridged-engine <services/sync/modules/bridged_engine.sys.mjs>`.
 In short, this is just a shim between the existing
-{searchfox}`Sync Service <services/sync/modules/service.js>`
+{searchfox}`Sync Service <services/sync/modules/service.sys.mjs>`
 and the Rust code.


### PR DESCRIPTION
Fixes typos in source docs: s/2/two/ and fixed searchfox paths to go to (now) .sys.mjs files.