### PR TITLE
Bug 2043333 - Update telemetry for stories to support a source parameter to distinguish between homepage and stories screen events. r=gl

### DIFF
--- a/mobile/android/fenix/app/metrics.yaml
+++ b/mobile/android/fenix/app/metrics.yaml
@@ -15390,6 +15390,11 @@ home.content.article:
       topic: &topic
         description: The topic of the recommendation. Like "entertainment".
         type: string
+      source: &source_pocket
+        description: >
+          The surface where the article was shown.
+          One of "homepage" or "stories_screen".
+        type: string
     send_in_pings:
       - home
 
@@ -15415,6 +15420,7 @@ home.content.article:
       received_rank: *received_rank
       recommended_at: *recommended_at
       topic: *topic
+      source: *source_pocket
     send_in_pings:
       - home
 

--- a/mobile/android/fenix/app/metrics.yaml
+++ b/mobile/android/fenix/app/metrics.yaml
@@ -9790,6 +9790,11 @@ pocket:
         description: |
           Position of the clicked story in the list shown.
           Uses the [row x column] matrix notation.
+      source:
+        type: string
+        description: |
+          Where the clicked story was shown.
+          One of "homepage" or "stories_screen".
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/21593
     data_reviews:

--- a/mobile/android/fenix/app/metrics.yaml
+++ b/mobile/android/fenix/app/metrics.yaml
@@ -9756,6 +9756,12 @@ pocket:
     type: event
     description: |
       The Pocket recommended stories are shown on the home screen.
+    extra_keys:
+      source:
+        type: string
+        description: |
+          Where the stories impression was recorded.
+          One of "homepage" or "stories_screen".
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/21593
     data_reviews:

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
@@ -31,6 +31,7 @@ import org.mozilla.fenix.home.bookmarks.Bookmark
 import org.mozilla.fenix.home.pocket.PocketImpression
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesCategory
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesSelectedCategory
+import org.mozilla.fenix.home.pocket.controller.StoriesImpressionSource
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTab
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTabState
 import org.mozilla.fenix.home.recenttabs.RecentTab
@@ -598,10 +599,12 @@ sealed class AppAction : Action {
          *
          * @property recommendation The [ContentRecommendation] that was clicked.
          * @property position The position (0-index) of the [ContentRecommendation].
+         * @property source The surface where the clicked recommendation was shown.
          */
         data class ContentRecommendationClicked(
             val recommendation: ContentRecommendation,
             val position: Int,
+            val source: StoriesImpressionSource,
         ) : ContentRecommendationsAction()
 
         /**
@@ -621,9 +624,12 @@ sealed class AppAction : Action {
          *
          * @property impressions A list of [PocketImpression]s detailing the story shown and
          * their respective position.
+         * @property source The surface where the stories were shown.
          */
-        data class PocketStoriesShown(val impressions: List<PocketImpression>) :
-            ContentRecommendationsAction()
+        data class PocketStoriesShown(
+            val impressions: List<PocketImpression>,
+            val source: StoriesImpressionSource,
+        ) : ContentRecommendationsAction()
 
         /**
          * Cleans all in-memory data about Pocket stories and categories.

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/fake/FakeHomepagePreview.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/fake/FakeHomepagePreview.kt
@@ -35,6 +35,7 @@ import org.mozilla.fenix.home.collections.CollectionsState
 import org.mozilla.fenix.home.interactor.HomepageInteractor
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesCategory
 import org.mozilla.fenix.home.pocket.PocketState
+import org.mozilla.fenix.home.pocket.controller.StoriesImpressionSource
 import org.mozilla.fenix.home.pocket.interactor.PocketStoriesInteractor
 import org.mozilla.fenix.home.privatebrowsing.interactor.PrivateBrowsingInteractor
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTab
@@ -140,7 +141,10 @@ internal object FakeHomepagePreview {
                 storyPosition: Triple<Int, Int, Int>,
             ) { /* no op */ }
 
-            override fun onStoriesShown(storiesShown: List<PocketStory>) { /* no op */ }
+            override fun onStoriesShown(
+                storiesShown: List<PocketStory>,
+                source: StoriesImpressionSource,
+            ) { /* no op */ }
 
             override fun onCategoryClicked(categoryClicked: PocketRecommendedStoriesCategory) { /* no op */ }
 

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/fake/FakeHomepagePreview.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/fake/FakeHomepagePreview.kt
@@ -151,6 +151,7 @@ internal object FakeHomepagePreview {
             override fun onStoryClicked(
                 storyClicked: PocketStory,
                 storyPosition: Triple<Int, Int, Int>,
+                source: StoriesImpressionSource,
             ) { /* no op */ }
 
             override fun onDiscoverMoreClicked() { /* no op */ }

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/middleware/HomeTelemetryMiddleware.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/middleware/HomeTelemetryMiddleware.kt
@@ -40,6 +40,7 @@ class HomeTelemetryMiddleware : Middleware<AppState, AppAction> {
                         scheduledCorpusItemId = recommendation.scheduledCorpusItemId,
                         tileId = recommendation.tileId.toInt(),
                         topic = recommendation.topic,
+                        source = action.source.sourceName,
                     ),
                 )
 
@@ -60,6 +61,7 @@ class HomeTelemetryMiddleware : Middleware<AppState, AppAction> {
                                     scheduledCorpusItemId = story.scheduledCorpusItemId,
                                     tileId = story.tileId.toInt(),
                                     topic = story.topic,
+                                    source = action.source.sourceName,
                                 ),
                             )
                         }

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/controller/PocketStoriesController.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/controller/PocketStoriesController.kt
@@ -129,6 +129,7 @@ internal class DefaultPocketStoriesController(
                         position = storyPosition.third,
                     ),
                 ),
+                source = StoriesImpressionSource.HOMEPAGE,
             ),
         )
 
@@ -164,6 +165,7 @@ internal class DefaultPocketStoriesController(
                 impressions = storiesShown
                     .filter { it is ContentRecommendation || it is PocketRecommendedStory }
                     .map { PocketImpression(story = it, position = storiesShown.indexOf(it)) },
+                source = source,
             ),
         )
 
@@ -247,6 +249,7 @@ internal class DefaultPocketStoriesController(
                     ContentRecommendationsAction.ContentRecommendationClicked(
                         recommendation = storyClicked,
                         position = storyPosition.third,
+                        source = source,
                     ),
                 )
             }

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/controller/PocketStoriesController.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/controller/PocketStoriesController.kt
@@ -33,6 +33,15 @@ import java.lang.ref.WeakReference
 private const val POCKET_CATEGORIES_SELECTED_AT_A_TIME_COUNT = 8
 
 /**
+ * The surface where a Pocket stories impression was recorded. Used as the `source` extra on the
+ * `pocket.home_recs_shown` Glean event.
+ */
+enum class StoriesImpressionSource(val sourceName: String) {
+    HOMEPAGE("homepage"),
+    STORIES_SCREEN("stories_screen"),
+}
+
+/**
  * Contract for how all user interactions with the Pocket stories feature are to be handled.
  */
 interface PocketStoriesController {
@@ -49,8 +58,9 @@ interface PocketStoriesController {
      * Callback to decide what should happen as an effect of a new list of stories being shown.
      *
      * @param storiesShown the new list of [PocketStory]es shown to the user.
+     * @param source the surface where the stories were shown.
      */
-    fun handleStoriesShown(storiesShown: List<PocketStory>)
+    fun handleStoriesShown(storiesShown: List<PocketStory>, source: StoriesImpressionSource)
 
     /**
      * Callback allowing to handle a specific [PocketRecommendedStoriesCategory] being clicked by the user.
@@ -138,7 +148,10 @@ internal class DefaultPocketStoriesController(
         }
     }
 
-    override fun handleStoriesShown(storiesShown: List<PocketStory>) {
+    override fun handleStoriesShown(
+        storiesShown: List<PocketStory>,
+        source: StoriesImpressionSource,
+    ) {
         // Only report here the impressions for recommended stories.
         // Sponsored stories use a different API for more accurate tracking.
         appStore.dispatch(
@@ -149,7 +162,9 @@ internal class DefaultPocketStoriesController(
             ),
         )
 
-        Pocket.homeRecsShown.record(NoExtras())
+        Pocket.homeRecsShown.record(
+            Pocket.HomeRecsShownExtra(source = source.sourceName),
+        )
     }
 
     override fun handleCategoryClick(categoryClicked: PocketRecommendedStoriesCategory) {

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/controller/PocketStoriesController.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/controller/PocketStoriesController.kt
@@ -75,8 +75,13 @@ interface PocketStoriesController {
      * @param storyClicked The just clicked [PocketStory].
      * @param storyPosition `row x column x index` matrix representing the grid and index position
      * of the clicked story.
+     * @param source the surface where the clicked story was shown.
      */
-    fun handleStoryClicked(storyClicked: PocketStory, storyPosition: Triple<Int, Int, Int>)
+    fun handleStoryClicked(
+        storyClicked: PocketStory,
+        storyPosition: Triple<Int, Int, Int>,
+        source: StoriesImpressionSource,
+    )
 
     /**
      * Callback for when the user clicks on the "Discover more" button.
@@ -211,6 +216,7 @@ internal class DefaultPocketStoriesController(
     override fun handleStoryClicked(
         storyClicked: PocketStory,
         storyPosition: Triple<Int, Int, Int>,
+        source: StoriesImpressionSource,
     ) {
         val storyUrl = when (navController.currentDestination?.id) {
             R.id.storiesFragment -> storyClicked.url.markAsOpenedFromStoriesScreen()
@@ -231,6 +237,7 @@ internal class DefaultPocketStoriesController(
                     Pocket.HomeRecsStoryClickedExtra(
                         position = "${storyPosition.first}x${storyPosition.second}",
                         timesShown = storyClicked.timesShown.inc().toString(),
+                        source = source.sourceName,
                     ),
                 )
             }

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/controller/PocketStoriesController.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/controller/PocketStoriesController.kt
@@ -58,7 +58,7 @@ interface PocketStoriesController {
      * Callback to decide what should happen as an effect of a new list of stories being shown.
      *
      * @param storiesShown the new list of [PocketStory]es shown to the user.
-     * @param source the surface where the stories were shown.
+     * @param source The surface where the stories were shown.
      */
     fun handleStoriesShown(storiesShown: List<PocketStory>, source: StoriesImpressionSource)
 
@@ -75,7 +75,7 @@ interface PocketStoriesController {
      * @param storyClicked The just clicked [PocketStory].
      * @param storyPosition `row x column x index` matrix representing the grid and index position
      * of the clicked story.
-     * @param source the surface where the clicked story was shown.
+     * @param source The surface where the clicked story was shown.
      */
     fun handleStoryClicked(
         storyClicked: PocketStory,

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/interactor/PocketStoriesInteractor.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/interactor/PocketStoriesInteractor.kt
@@ -8,6 +8,7 @@ import mozilla.components.service.pocket.PocketStory
 import mozilla.components.service.pocket.PocketStory.PocketRecommendedStory
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesCategory
 import org.mozilla.fenix.home.pocket.controller.PocketStoriesController
+import org.mozilla.fenix.home.pocket.controller.StoriesImpressionSource
 
 /**
  * Contract for all possible user interactions with the Pocket recommended stories feature.
@@ -26,8 +27,9 @@ interface PocketStoriesInteractor {
      * Callback for then new stories are shown to the user.
      *
      * @param storiesShown The new list of [PocketRecommendedStory]es shown to the user.
+     * @param source the surface where the stories were shown.
      */
-    fun onStoriesShown(storiesShown: List<PocketStory>)
+    fun onStoriesShown(storiesShown: List<PocketStory>, source: StoriesImpressionSource)
 
     /**
      * Callback for when the user clicks a specific category.
@@ -66,8 +68,8 @@ class DefaultPocketStoriesInteractor(
         controller.handleStoryShown(storyShown, storyPosition)
     }
 
-    override fun onStoriesShown(storiesShown: List<PocketStory>) {
-        controller.handleStoriesShown(storiesShown)
+    override fun onStoriesShown(storiesShown: List<PocketStory>, source: StoriesImpressionSource) {
+        controller.handleStoriesShown(storiesShown, source)
     }
 
     override fun onCategoryClicked(categoryClicked: PocketRecommendedStoriesCategory) {

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/interactor/PocketStoriesInteractor.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/interactor/PocketStoriesInteractor.kt
@@ -27,7 +27,7 @@ interface PocketStoriesInteractor {
      * Callback for then new stories are shown to the user.
      *
      * @param storiesShown The new list of [PocketRecommendedStory]es shown to the user.
-     * @param source the surface where the stories were shown.
+     * @param source The surface where the stories were shown.
      */
     fun onStoriesShown(storiesShown: List<PocketStory>, source: StoriesImpressionSource)
 
@@ -44,7 +44,7 @@ interface PocketStoriesInteractor {
      * @param storyClicked The just clicked [PocketStory].
      * @param storyPosition `row x column x index` matrix representing the grid and index position
      * of the clicked story.
-     * @param source the surface where the clicked story was shown.
+     * @param source The surface where the clicked story was shown.
      */
     fun onStoryClicked(
         storyClicked: PocketStory,

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/interactor/PocketStoriesInteractor.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/interactor/PocketStoriesInteractor.kt
@@ -44,8 +44,13 @@ interface PocketStoriesInteractor {
      * @param storyClicked The just clicked [PocketStory].
      * @param storyPosition `row x column x index` matrix representing the grid and index position
      * of the clicked story.
+     * @param source the surface where the clicked story was shown.
      */
-    fun onStoryClicked(storyClicked: PocketStory, storyPosition: Triple<Int, Int, Int>)
+    fun onStoryClicked(
+        storyClicked: PocketStory,
+        storyPosition: Triple<Int, Int, Int>,
+        source: StoriesImpressionSource,
+    )
 
     /**
      * Callback when an user clicks on the "Discover more" nutton for stories on the homepage.
@@ -76,8 +81,12 @@ class DefaultPocketStoriesInteractor(
         controller.handleCategoryClick(categoryClicked)
     }
 
-    override fun onStoryClicked(storyClicked: PocketStory, storyPosition: Triple<Int, Int, Int>) {
-        controller.handleStoryClicked(storyClicked, storyPosition)
+    override fun onStoryClicked(
+        storyClicked: PocketStory,
+        storyPosition: Triple<Int, Int, Int>,
+        source: StoriesImpressionSource,
+    ) {
+        controller.handleStoryClicked(storyClicked, storyPosition, source)
     }
 
     override fun onDiscoverMoreClicked() {

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/ui/PocketSection.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/ui/PocketSection.kt
@@ -22,6 +22,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.home.HomeSectionHeader
 import org.mozilla.fenix.home.fake.FakeHomepagePreview
 import org.mozilla.fenix.home.pocket.PocketState
+import org.mozilla.fenix.home.pocket.controller.StoriesImpressionSource
 import org.mozilla.fenix.home.pocket.interactor.PocketStoriesInteractor
 import org.mozilla.fenix.theme.FirefoxTheme
 import org.mozilla.fenix.wallpapers.WallpaperState
@@ -45,7 +46,10 @@ fun PocketSection(
         // We should report back when a certain story is actually being displayed.
         // Cannot do it reliably so for now we'll just mass report everything as being displayed.
         state.stories.let {
-            interactor.onStoriesShown(storiesShown = it)
+            interactor.onStoriesShown(
+                storiesShown = it,
+                source = StoriesImpressionSource.HOMEPAGE,
+            )
         }
     }
 

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/ui/PocketSection.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/ui/PocketSection.kt
@@ -69,7 +69,9 @@ fun PocketSection(
             contentPadding = horizontalPadding,
             backgroundColor = cardBackgroundColor,
             onStoryShown = interactor::onStoryShown,
-            onStoryClicked = interactor::onStoryClicked,
+            onStoryClicked = { story, position ->
+                interactor.onStoryClicked(story, position, StoriesImpressionSource.HOMEPAGE)
+            },
         )
     }
 }

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/ui/StoriesScreen.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/ui/StoriesScreen.kt
@@ -165,7 +165,13 @@ private fun Stories(
         itemsIndexed(state.pocketStories) { index, story ->
             StoryCard(
                 story = story,
-                onClick = interactor::onStoryClicked,
+                onClick = { clickedStory, position ->
+                    interactor.onStoryClicked(
+                        clickedStory,
+                        position,
+                        StoriesImpressionSource.STORIES_SCREEN,
+                    )
+                },
             )
         }
     }

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/ui/StoriesScreen.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/ui/StoriesScreen.kt
@@ -34,6 +34,7 @@ import mozilla.components.compose.base.utils.BackInvokedHandler
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.appstate.recommendations.ContentRecommendationsState
 import org.mozilla.fenix.home.fake.FakeHomepagePreview
+import org.mozilla.fenix.home.pocket.controller.StoriesImpressionSource
 import org.mozilla.fenix.home.pocket.interactor.PocketStoriesInteractor
 import org.mozilla.fenix.home.ui.LeftChevronPillButton
 import org.mozilla.fenix.theme.FirefoxTheme
@@ -52,6 +53,15 @@ fun StoriesScreen(
 ) {
     LaunchedEffect(Unit) {
         interactor.onDiscoverMoreScreenViewed()
+    }
+
+    // We should report back when a certain story is actually being displayed.
+    // Cannot do it reliably so for now we'll just mass report everything as being displayed.
+    LaunchedEffect(state.pocketStories) {
+        interactor.onStoriesShown(
+            storiesShown = state.pocketStories,
+            source = StoriesImpressionSource.STORIES_SCREEN,
+        )
     }
 
     BackInvokedHandler {

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -19,6 +19,7 @@ import org.mozilla.fenix.home.logo.LogoController
 import org.mozilla.fenix.home.logo.TrackingProtectionController
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesCategory
 import org.mozilla.fenix.home.pocket.controller.PocketStoriesController
+import org.mozilla.fenix.home.pocket.controller.StoriesImpressionSource
 import org.mozilla.fenix.home.privatebrowsing.controller.PrivateBrowsingController
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTab
 import org.mozilla.fenix.home.recentsyncedtabs.controller.RecentSyncedTabController
@@ -381,8 +382,8 @@ class SessionControlInteractor(
         pocketStoriesController.handleStoryShown(storyShown, storyPosition)
     }
 
-    override fun onStoriesShown(storiesShown: List<PocketStory>) {
-        pocketStoriesController.handleStoriesShown(storiesShown)
+    override fun onStoriesShown(storiesShown: List<PocketStory>, source: StoriesImpressionSource) {
+        pocketStoriesController.handleStoriesShown(storiesShown, source)
     }
 
     override fun onCategoryClicked(categoryClicked: PocketRecommendedStoriesCategory) {

--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -390,8 +390,12 @@ class SessionControlInteractor(
         pocketStoriesController.handleCategoryClick(categoryClicked)
     }
 
-    override fun onStoryClicked(storyClicked: PocketStory, storyPosition: Triple<Int, Int, Int>) {
-        pocketStoriesController.handleStoryClicked(storyClicked, storyPosition)
+    override fun onStoryClicked(
+        storyClicked: PocketStory,
+        storyPosition: Triple<Int, Int, Int>,
+        source: StoriesImpressionSource,
+    ) {
+        pocketStoriesController.handleStoryClicked(storyClicked, storyPosition, source)
     }
 
     override fun onDiscoverMoreClicked() {

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/components/AppStoreTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/components/AppStoreTest.kt
@@ -44,6 +44,7 @@ import org.mozilla.fenix.home.pocket.POCKET_STORIES_DEFAULT_CATEGORY_NAME
 import org.mozilla.fenix.home.pocket.PocketImpression
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesCategory
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesSelectedCategory
+import org.mozilla.fenix.home.pocket.controller.StoriesImpressionSource
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTab
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTabState
 import org.mozilla.fenix.home.recenttabs.RecentTab
@@ -565,6 +566,7 @@ class AppStoreTest {
                     PocketImpression(story = sponsoredContent, position = 0),
                     PocketImpression(story = sponsoredContent3, position = 2),
                 ),
+                source = StoriesImpressionSource.HOMEPAGE,
             ),
         )
 
@@ -615,6 +617,7 @@ class AppStoreTest {
                     PocketImpression(story = recommendation1, position = 0),
                     PocketImpression(story = recommendation3, position = 2),
                 ),
+                source = StoriesImpressionSource.HOMEPAGE,
             ),
         )
 

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/PocketMiddlewareTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/PocketMiddlewareTest.kt
@@ -33,6 +33,7 @@ import org.mozilla.fenix.datastore.SelectedPocketStoriesCategories.SelectedPocke
 import org.mozilla.fenix.home.pocket.PocketImpression
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesCategory
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesSelectedCategory
+import org.mozilla.fenix.home.pocket.controller.StoriesImpressionSource
 
 class PocketMiddlewareTest {
 
@@ -74,6 +75,7 @@ class PocketMiddlewareTest {
                         position = 1,
                     ),
                 ),
+                source = StoriesImpressionSource.HOMEPAGE,
             ),
         )
         testScheduler.advanceUntilIdle()

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
@@ -267,9 +267,15 @@ class SessionControlInteractorTest {
         val clickedStory: PocketStory = mockk()
         val storyPosition = Triple(1, 2, 3)
 
-        interactor.onStoryClicked(clickedStory, storyPosition)
+        interactor.onStoryClicked(clickedStory, storyPosition, StoriesImpressionSource.HOMEPAGE)
 
-        verify { pocketStoriesController.handleStoryClicked(clickedStory, storyPosition) }
+        verify {
+            pocketStoriesController.handleStoryClicked(
+                clickedStory,
+                storyPosition,
+                StoriesImpressionSource.HOMEPAGE,
+            )
+        }
     }
 
     @Test

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
@@ -21,6 +21,7 @@ import org.mozilla.fenix.home.logo.LogoController
 import org.mozilla.fenix.home.logo.TrackingProtectionController
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesCategory
 import org.mozilla.fenix.home.pocket.controller.PocketStoriesController
+import org.mozilla.fenix.home.pocket.controller.StoriesImpressionSource
 import org.mozilla.fenix.home.privatebrowsing.controller.PrivateBrowsingController
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTab
 import org.mozilla.fenix.home.recentsyncedtabs.controller.RecentSyncedTabController
@@ -245,9 +246,11 @@ class SessionControlInteractorTest {
     fun `GIVEN a PocketStoriesInteractor WHEN stories are shown THEN handle it in a PocketStoriesController`() {
         val shownStories: List<PocketStory> = emptyList()
 
-        interactor.onStoriesShown(shownStories)
+        interactor.onStoriesShown(shownStories, StoriesImpressionSource.HOMEPAGE)
 
-        verify { pocketStoriesController.handleStoriesShown(shownStories) }
+        verify {
+            pocketStoriesController.handleStoriesShown(shownStories, StoriesImpressionSource.HOMEPAGE)
+        }
     }
 
     @Test

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/middleware/HomeTelemetryMiddlewareTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/middleware/HomeTelemetryMiddlewareTest.kt
@@ -56,7 +56,7 @@ class HomeTelemetryMiddlewareTest {
             assertEquals(recommendation.topic, extraValues["topic"])
             assertEquals(position.toString(), extraValues["position"])
             assertEquals("false", extraValues["is_sponsored"])
-            assertEquals("homepage", extraValues["source"])
+            assertEquals(StoriesImpressionSource.HOMEPAGE.sourceName, extraValues["source"])
 
             pingReceived = true
         }

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/middleware/HomeTelemetryMiddlewareTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/middleware/HomeTelemetryMiddlewareTest.kt
@@ -20,6 +20,7 @@ import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction.ContentRecommendationsAction
 import org.mozilla.fenix.helpers.FenixGleanTestRule
 import org.mozilla.fenix.home.pocket.PocketImpression
+import org.mozilla.fenix.home.pocket.controller.StoriesImpressionSource
 import kotlin.test.assertNotNull
 
 @RunWith(AndroidJUnit4::class)
@@ -55,6 +56,7 @@ class HomeTelemetryMiddlewareTest {
             assertEquals(recommendation.topic, extraValues["topic"])
             assertEquals(position.toString(), extraValues["position"])
             assertEquals("false", extraValues["is_sponsored"])
+            assertEquals("homepage", extraValues["source"])
 
             pingReceived = true
         }
@@ -63,6 +65,38 @@ class HomeTelemetryMiddlewareTest {
             ContentRecommendationsAction.ContentRecommendationClicked(
                 recommendation = recommendation,
                 position = position,
+                source = StoriesImpressionSource.HOMEPAGE,
+            ),
+        )
+
+        job.join()
+        assertTrue(pingReceived)
+    }
+
+    @Test
+    fun `WHEN a recommendation is clicked on the stories screen THEN record the click telemetry with the stories screen source`() {
+        val store = createStore()
+        val recommendation = TestUtils.getFakeContentRecommendations(limit = 1).first()
+        val position = 100
+
+        assertNull(HomeContentArticle.click.testGetValue())
+
+        var pingReceived = false
+        val job = Pings.home.testBeforeNextSubmit {
+            assertNotNull(HomeContentArticle.click.testGetValue())
+
+            val snapshot = HomeContentArticle.click.testGetValue()!!
+            assertEquals(1, snapshot.size)
+            assertEquals("stories_screen", snapshot.first().extra!!["source"])
+
+            pingReceived = true
+        }
+
+        store.dispatch(
+            ContentRecommendationsAction.ContentRecommendationClicked(
+                recommendation = recommendation,
+                position = position,
+                source = StoriesImpressionSource.STORIES_SCREEN,
             ),
         )
 
@@ -104,6 +138,7 @@ class HomeTelemetryMiddlewareTest {
                 assertEquals(recommendation.topic, extraValues["topic"])
                 assertEquals(position.toString(), extraValues["position"])
                 assertEquals("false", extraValues["is_sponsored"])
+                assertEquals("homepage", extraValues["source"])
             }
 
             pingReceived = true
@@ -112,6 +147,44 @@ class HomeTelemetryMiddlewareTest {
         store.dispatch(
             ContentRecommendationsAction.PocketStoriesShown(
                 impressions = impressions,
+                source = StoriesImpressionSource.HOMEPAGE,
+            ),
+        )
+
+        job.join()
+        assertTrue(pingReceived)
+    }
+
+    @Test
+    fun `WHEN a list of recommendations are shown on the stories screen THEN record the impression telemetry with the stories screen source`() {
+        val store = createStore()
+        val impressions = TestUtils.getFakeContentRecommendations(limit = 3)
+            .mapIndexed { index, contentRecommendation ->
+                PocketImpression(
+                    story = contentRecommendation,
+                    position = index,
+                )
+            }
+
+        assertNull(HomeContentArticle.impression.testGetValue())
+
+        var pingReceived = false
+        val job = Pings.home.testBeforeNextSubmit {
+            assertNotNull(HomeContentArticle.impression.testGetValue())
+
+            val snapshot = HomeContentArticle.impression.testGetValue()!!
+            assertEquals(3, snapshot.size)
+            snapshot.forEach {
+                assertEquals("stories_screen", it.extra!!["source"])
+            }
+
+            pingReceived = true
+        }
+
+        store.dispatch(
+            ContentRecommendationsAction.PocketStoriesShown(
+                impressions = impressions,
+                source = StoriesImpressionSource.STORIES_SCREEN,
             ),
         )
 

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/pocket/DefaultPocketStoriesControllerTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/pocket/DefaultPocketStoriesControllerTest.kt
@@ -305,6 +305,38 @@ class DefaultPocketStoriesControllerTest {
     }
 
     @Test
+    fun `WHEN new stories are shown on the stories screen THEN update the State and record telemetry`() = runTest {
+        val store = spyk(AppStore())
+        val controller = createController(scope = this, appStore = store)
+        val recommendation = mockk<ContentRecommendation>()
+        val story = mockk<PocketStory>()
+        val sponsoredStory = mockk<PocketSponsoredStory>()
+        val storiesShown = listOf(recommendation, story, sponsoredStory)
+
+        assertNull(Pocket.homeRecsShown.testGetValue())
+
+        controller.handleStoriesShown(storiesShown, StoriesImpressionSource.STORIES_SCREEN)
+
+        verify {
+            store.dispatch(
+                ContentRecommendationsAction.PocketStoriesShown(
+                    impressions = listOf(
+                        PocketImpression(story = recommendation, position = 0),
+                        PocketImpression(story = story, position = 1),
+                    ),
+                ),
+            )
+        }
+
+        assertNotNull(Pocket.homeRecsShown.testGetValue())
+        assertEquals(1, Pocket.homeRecsShown.testGetValue()!!.size)
+        assertEquals(
+            "stories_screen",
+            Pocket.homeRecsShown.testGetValue()!!.single().extra?.get("source"),
+        )
+    }
+
+    @Test
     fun `WHEN a recommended story is clicked THEN open that story's url using HomeActivity and record telemetry`() = runTest {
         val story = PocketRecommendedStory(
             title = "",
@@ -318,7 +350,11 @@ class DefaultPocketStoriesControllerTest {
         val controller = createController(scope = this)
         assertNull(Pocket.homeRecsStoryClicked.testGetValue())
 
-        controller.handleStoryClicked(story, storyPosition = Triple(1, 2, 3))
+        controller.handleStoryClicked(
+            story,
+            storyPosition = Triple(1, 2, 3),
+            source = StoriesImpressionSource.HOMEPAGE,
+        )
 
         verify {
             navController.navigate(R.id.browserFragment)
@@ -336,6 +372,48 @@ class DefaultPocketStoriesControllerTest {
         assertEquals("1x2", event.single().extra!!["position"])
         assertTrue(event.single().extra!!.containsKey("times_shown"))
         assertEquals(story.timesShown.inc().toString(), event.single().extra!!["times_shown"])
+        assertTrue(event.single().extra!!.containsKey("source"))
+        assertEquals("homepage", event.single().extra!!["source"])
+    }
+
+    @Test
+    fun `WHEN a recommended story is clicked on the stories screen THEN open that story's url using HomeActivity and record telemetry`() = runTest {
+        val story = PocketRecommendedStory(
+            title = "",
+            url = "testLink",
+            imageUrl = "",
+            publisher = "",
+            category = "",
+            timeToRead = 0,
+            timesShown = 123,
+        )
+        val controller = createController(scope = this)
+        assertNull(Pocket.homeRecsStoryClicked.testGetValue())
+
+        controller.handleStoryClicked(
+            story,
+            storyPosition = Triple(1, 2, 3),
+            source = StoriesImpressionSource.STORIES_SCREEN,
+        )
+
+        verify {
+            navController.navigate(R.id.browserFragment)
+            fenixBrowserUseCases.loadUrlOrSearch(
+                searchTermOrURL = story.url,
+                newTab = true,
+                private = false,
+            )
+        }
+
+        assertNotNull(Pocket.homeRecsStoryClicked.testGetValue())
+        val event = Pocket.homeRecsStoryClicked.testGetValue()!!
+        assertEquals(1, event.size)
+        assertTrue(event.single().extra!!.containsKey("position"))
+        assertEquals("1x2", event.single().extra!!["position"])
+        assertTrue(event.single().extra!!.containsKey("times_shown"))
+        assertEquals(story.timesShown.inc().toString(), event.single().extra!!["times_shown"])
+        assertTrue(event.single().extra!!.containsKey("source"))
+        assertEquals("stories_screen", event.single().extra!!["source"])
     }
 
     @Test
@@ -354,7 +432,11 @@ class DefaultPocketStoriesControllerTest {
         val controller = createController(scope = this)
         assertNull(Pocket.homeRecsStoryClicked.testGetValue())
 
-        controller.handleStoryClicked(story, storyPosition = Triple(1, 2, 3))
+        controller.handleStoryClicked(
+            story,
+            storyPosition = Triple(1, 2, 3),
+            source = StoriesImpressionSource.HOMEPAGE,
+        )
 
         verify {
             navController.navigate(R.id.browserFragment)
@@ -372,6 +454,8 @@ class DefaultPocketStoriesControllerTest {
         assertEquals("1x2", event.single().extra!!["position"])
         assertTrue(event.single().extra!!.containsKey("times_shown"))
         assertEquals(story.timesShown.inc().toString(), event.single().extra!!["times_shown"])
+        assertTrue(event.single().extra!!.containsKey("source"))
+        assertEquals("homepage", event.single().extra!!["source"])
     }
 
     @Test
@@ -395,7 +479,11 @@ class DefaultPocketStoriesControllerTest {
 
         assertNull(Pocket.homeRecsSpocClicked.testGetValue())
 
-        controller.handleStoryClicked(sponsoredContent, storyPosition = Triple(2, 3, 4))
+        controller.handleStoryClicked(
+            sponsoredContent,
+            storyPosition = Triple(2, 3, 4),
+            source = StoriesImpressionSource.HOMEPAGE,
+        )
         testScheduler.advanceUntilIdle()
 
         assertEquals(1, Pocket.homeRecsSpocClicked.testGetValue()!!.size)
@@ -420,7 +508,11 @@ class DefaultPocketStoriesControllerTest {
         val story = PocketRecommendedStory("", "url", "", "", "", 0, 0)
         val controller = createController(scope = this)
 
-        controller.handleStoryClicked(story, storyPosition = Triple(1, 2, 3))
+        controller.handleStoryClicked(
+            story,
+            storyPosition = Triple(1, 2, 3),
+            source = StoriesImpressionSource.HOMEPAGE,
+        )
 
         verifyOrder {
             navController.navigate(R.id.browserFragment)
@@ -439,7 +531,11 @@ class DefaultPocketStoriesControllerTest {
         val story = PocketRecommendedStory("", "url", "", "", "", 0, 0)
         val controller = createController(scope = this)
 
-        controller.handleStoryClicked(story, storyPosition = Triple(1, 2, 3))
+        controller.handleStoryClicked(
+            story,
+            storyPosition = Triple(1, 2, 3),
+            source = StoriesImpressionSource.HOMEPAGE,
+        )
 
         verifyOrder {
             navController.navigate(R.id.browserFragment)
@@ -458,7 +554,11 @@ class DefaultPocketStoriesControllerTest {
         val story = PocketRecommendedStory("", originalURL, "", "", "", 0, 0)
         val controller = createController(scope = this)
 
-        controller.handleStoryClicked(story, storyPosition = Triple(1, 2, 3))
+        controller.handleStoryClicked(
+            story,
+            storyPosition = Triple(1, 2, 3),
+            source = StoriesImpressionSource.HOMEPAGE,
+        )
 
         verifyOrder {
             navController.navigate(R.id.browserFragment)
@@ -477,7 +577,11 @@ class DefaultPocketStoriesControllerTest {
         val story = PocketRecommendedStory("", originalURL, "", "", "", 0, 0)
         val controller = createController(scope = this)
 
-        controller.handleStoryClicked(story, storyPosition = Triple(1, 2, 3))
+        controller.handleStoryClicked(
+            story,
+            storyPosition = Triple(1, 2, 3),
+            source = StoriesImpressionSource.HOMEPAGE,
+        )
 
         verifyOrder {
             navController.navigate(R.id.browserFragment)

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/pocket/DefaultPocketStoriesControllerTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/pocket/DefaultPocketStoriesControllerTest.kt
@@ -227,6 +227,7 @@ class DefaultPocketStoriesControllerTest {
                     impressions = listOf(
                         PocketImpression(story = storyShown, position = 3),
                     ),
+                    source = StoriesImpressionSource.HOMEPAGE,
                 ),
             )
         }
@@ -267,6 +268,7 @@ class DefaultPocketStoriesControllerTest {
                     impressions = listOf(
                         PocketImpression(story = sponsoredContent, position = 3),
                     ),
+                    source = StoriesImpressionSource.HOMEPAGE,
                 ),
             )
         }
@@ -292,6 +294,7 @@ class DefaultPocketStoriesControllerTest {
                         PocketImpression(story = recommendation, position = 0),
                         PocketImpression(story = story, position = 1),
                     ),
+                    source = StoriesImpressionSource.HOMEPAGE,
                 ),
             )
         }
@@ -324,6 +327,7 @@ class DefaultPocketStoriesControllerTest {
                         PocketImpression(story = recommendation, position = 0),
                         PocketImpression(story = story, position = 1),
                     ),
+                    source = StoriesImpressionSource.STORIES_SCREEN,
                 ),
             )
         }

--- a/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/pocket/DefaultPocketStoriesControllerTest.kt
+++ b/mobile/android/fenix/app/src/test/java/org/mozilla/fenix/home/pocket/DefaultPocketStoriesControllerTest.kt
@@ -41,6 +41,7 @@ import org.mozilla.fenix.helpers.FenixGleanTestRule
 import org.mozilla.fenix.home.HomeFragmentDirections
 import org.mozilla.fenix.home.mars.MARSUseCases
 import org.mozilla.fenix.home.pocket.controller.DefaultPocketStoriesController
+import org.mozilla.fenix.home.pocket.controller.StoriesImpressionSource
 import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.utils.Stories.markAsOpenedFromHomeScreen
 import org.mozilla.fenix.utils.Stories.markAsOpenedFromStoriesScreen
@@ -282,7 +283,7 @@ class DefaultPocketStoriesControllerTest {
 
         assertNull(Pocket.homeRecsShown.testGetValue())
 
-        controller.handleStoriesShown(storiesShown)
+        controller.handleStoriesShown(storiesShown, StoriesImpressionSource.HOMEPAGE)
 
         verify {
             store.dispatch(
@@ -297,7 +298,10 @@ class DefaultPocketStoriesControllerTest {
 
         assertNotNull(Pocket.homeRecsShown.testGetValue())
         assertEquals(1, Pocket.homeRecsShown.testGetValue()!!.size)
-        assertNull(Pocket.homeRecsShown.testGetValue()!!.single().extra)
+        assertEquals(
+            "homepage",
+            Pocket.homeRecsShown.testGetValue()!!.single().extra?.get("source"),
+        )
     }
 
     @Test


### PR DESCRIPTION
Fire missing impression events from stories screen. 
Add source extra to home_recs_story_clicked and record it on the stories screen. 
Add source extra to home.content.article impression and click events.

[try](https://treeherder.mozilla.org/jobs?repo=try&landoInstance=lando-prod-2025&landoCommitID=64157)