### PR TITLE
Bug 2053117 - Upgrade WebRender CI Docker base image to debian:13.5.

### DIFF
--- a/gfx/wr/ci-scripts/docker-image/Dockerfile
+++ b/gfx/wr/ci-scripts/docker-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-20221205
+FROM debian:11.11
 
 COPY setup.sh /root
 RUN cd /root && ./setup.sh

--- a/gfx/wr/ci-scripts/docker-image/Dockerfile
+++ b/gfx/wr/ci-scripts/docker-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11.11
+FROM debian:13.5
 
 COPY setup.sh /root
 RUN cd /root && ./setup.sh


### PR DESCRIPTION
### Description
This PR upgrades the WebRender CI Docker base image to `debian:13.5` to resolve multiple security vulnerabilities found in the previous base image.

### Related Links
- **Bugzilla:** https://bugzilla.mozilla.org/show_bug.cgi?id=2053117
- **Phabricator Revision:** https://phabricator.services.mozilla.org/D310839
- **Reviewer:** @gw (Glenn Watson)