### PR TITLE
Bug 2053379 - Fix ShareFragment crash on rapid menu clicks. r=#android-reviewers

### DIFF
--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/components/menu/middleware/MenuNavigationMiddleware.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/components/menu/middleware/MenuNavigationMiddleware.kt
@@ -249,7 +249,7 @@ class MenuNavigationMiddleware(
                         },
                     )
 
-                    onDismiss()
+                    navController.popBackStack(R.id.menuDialogFragment, true)
                 }
 
                 is MenuAction.Navigate.ManageExtensions -> navController.nav(


### PR DESCRIPTION
The crash occurs when the user clicks the share icon rapidly.  The root cause is a race condition in `MenuNavigationMiddleware.kt`.

**Problem:**
In the `MenuAction.Navigate.Share` block, `onDismiss()` is called  asynchronously after `shareUseCases.shareUrl()`. This can interfere  with the back stack when the share button is clicked multiple times  in quick succession, leading to an `IllegalStateException`.

**Solution:**
Replace `onDismiss()` with a synchronous and safe navigation call: `navController.popBackStack(R.id.menuDialogFragment, true)`.

This ensures the menu dialog is removed from the back stack  immediately and *before* navigating to the ShareFragment,  eliminating the race condition.

**Tested:**
- Verified locally that rapid clicking no longer causes a crash.
- Confirmed that the share functionality works as expected in both  normal and private browsing modes.