### PR TITLE
Bug 2059390: fix crash in SitePermissionsFragment.onDismiss

### DIFF
--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -1261,8 +1261,14 @@ abstract class BaseBrowserFragment :
                 shouldShowDoNotAskAgainCheckBox = context.components.appStore.state.mode != BrowsingMode.Private,
                 store = store,
                 shouldHide = {
-                    val state = requireComponents.appStore.state
-                    state.isPrivateScreenLocked && state.mode.isPrivate
+                    // if the fragment is detached,
+                    // returning true will hide the site permission prompt rather than crash
+                    if (this.context == null) {
+                        true
+                    } else {
+                        val state = requireComponents.appStore.state
+                        state.isPrivateScreenLocked && state.mode.isPrivate
+                    }
                 },
             ),
             owner = this,


### PR DESCRIPTION
If a fragment is detached, it is no longer safe to call `requireComponents`, because this method throws if the `context` is null. In this case, `BaseBrowserFragment` is not attached and returning true from `shouldHide` will stop us from showing the permission prompt, rather than crashing. Also checked `hidePermissionsPrompt` which will be called if `shouldHide` is true. This allows for the case of the fragment not being attached by using an optional and a let, so should be safe to call in this detached fragment case.

[try is running here](https://treeherder.mozilla.org/jobs?repo=try&revision=8dbfc878c87991d2da9167e8ad5daed2bb54579a)