### PR TITLE
Bug 2044409 - Filter slider updates while Accessibility shouldUseAutoSize is false

### DIFF
--- a/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/AccessibilityFragment.kt
+++ b/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/AccessibilityFragment.kt
@@ -48,9 +48,16 @@ class AccessibilityFragment : PreferenceFragmentCompat(), SystemInsetsPaddedFrag
         )
 
         textSizePreference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { preference, newValue ->
+            // Bug 2044409: The `setIsSliderEnabled` call below doesn't disable this callback
+            // until the next recomposition so explicitly check the current value of `shouldUseAutoSize`
+            // and reject updates. Otherwise we will set illegal combinations of engine settings.
+            if (settings.shouldUseAutoSize) {
+                return@OnPreferenceChangeListener false
+            }
+
             val newTextScale = newValue as Float
 
-            // Save new text scale value. We assume auto sizing is off if this change listener was called.
+            // Save new text scale value.
             components.core.engine.settings.fontSizeFactor = newTextScale
 
             // Reload the current session to reflect the new text scale


### PR DESCRIPTION
The engine code doesn't allow setting a fontSizeFactor when auto-sizing is enabled. We previously tried to disable the Slider that updates the size factor in order to prevent update messages, but the disable doesn't take effect until next recomposition. As a result we see crashes in monkey testing which adds noise even if it is highly unlikely for a normal user to hit.