### PR TITLE
Bug 2063251: fix build failure with misleading message if you manually move your checked out dir.

### DIFF
--- a/mobile/android/gradle/mozconfig.gradle
+++ b/mobile/android/gradle/mozconfig.gradle
@@ -65,6 +65,7 @@ abstract class TopobjdirValueSource implements ValueSource<String, TopobjdirValu
 
         // Compute hash of all inputs for local caching
         def inputs = new StringBuilder()
+        inputs.append("topsrcdir=${topsrcdir}\n")
         inputs.append("MOZCONFIG=${parameters.mozconfigEnv.get()}\n")
         inputs.append("MOZ_OBJDIR=${parameters.mozObjdirEnv.get()}\n")
         inputs.append("mozconfigContents=${parameters.mozconfigContents.get().hashCode()}\n")


### PR DESCRIPTION
`topsrcdir` is used in a relative path for `MOZ_OBJDIR`, so cache should be invalidated if it changes.