### PR TITLE
task(fxa): Add new pairing channel commands to supporty v2 pairing flows

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -2406,6 +2406,10 @@ pref("identity.fxaccounts.remote.oauth.uri", "https://oauth.accounts.firefox.com
 // Whether FxA pairing using QR codes is enabled.
 pref("identity.fxaccounts.pairing.enabled", true);
 
+// The version of the pairing flow to request from FxA. Sent as the "v" query
+// parameter of the connect_another_device URL.
+pref("identity.fxaccounts.pairing.version", 1);
+
 // The remote URI of the FxA pairing server
 pref("identity.fxaccounts.remote.pairing.uri", "wss://channelserver.services.mozilla.com");
 

--- a/services/fxaccounts/FxAccounts.sys.mjs
+++ b/services/fxaccounts/FxAccounts.sys.mjs
@@ -942,6 +942,20 @@ FxAccountsInternal.prototype = {
     return this.oauth.completeOAuthFlow(sessionToken, code, state);
   },
 
+  // Grants an OAuth authorization code to another client, as the pairing
+  // authority. Requires a verified account, since granting a code hands the
+  // other client access to this account.
+  authorizeOAuthCode(options) {
+    return this.withVerifiedAccountState(async state => {
+      const { sessionToken } = await state.getUserAccountData(["sessionToken"]);
+      try {
+        return await this.oauth.authorizeOAuthCode(sessionToken, options);
+      } catch (err) {
+        throw this._errorToErrorClass(err);
+      }
+    });
+  },
+
   setScopedKeys(scopedKeys) {
     return this.keys.setScopedKeys(scopedKeys);
   },

--- a/services/fxaccounts/FxAccountsCommon.sys.mjs
+++ b/services/fxaccounts/FxAccountsCommon.sys.mjs
@@ -138,6 +138,12 @@ export let COMMAND_PAIR_SUPP_METADATA = "fxaccounts:pair_supplicant_metadata";
 export let COMMAND_PAIR_AUTHORIZE = "fxaccounts:pair_authorize";
 export let COMMAND_PAIR_DECLINE = "fxaccounts:pair_decline";
 export let COMMAND_PAIR_COMPLETE = "fxaccounts:pair_complete";
+// Asks the browser to start an OAuth flow on behalf of a pairing supplicant
+// and to hand the resulting OAuth parameters back to FxA.
+export let COMMAND_PAIR_OAUTH_START = "fxaccounts:pair_oauth_start";
+// Asks the browser, acting as the pairing authority, to grant an OAuth
+// authorization code for the supplicant's OAuth parameters.
+export let COMMAND_PAIR_OAUTH_FINISH = "fxaccounts:pair_oauth_finish";
 
 export let COMMAND_PROFILE_CHANGE = "profile:change";
 export let COMMAND_CAN_LINK_ACCOUNT = "fxaccounts:can_link_account";

--- a/services/fxaccounts/FxAccountsOAuth.sys.mjs
+++ b/services/fxaccounts/FxAccountsOAuth.sys.mjs
@@ -235,6 +235,88 @@ export class FxAccountsOAuth {
   }
 
   /**
+   * Grants an OAuth authorization code for another client.
+   *
+   * This is the counterpart to `beginOAuthFlow`: where that starts a flow for
+   * this browser to complete, this authorizes the parameters some *other*
+   * client produced by running its own `beginOAuthFlow`. It is used by the
+   * pairing authority, which is already signed in and so holds both the session
+   * token and the scoped keys the connecting client is asking for.
+   *
+   * If the caller supplied a `keys_jwk`, the requested scoped keys are wrapped
+   * into a `keys_jwe` so they can be delivered to that client through the auth
+   * server without the server itself being able to read them.
+   *
+   * @param { string } sessionToken: The session token encoded in hexadecimal
+   * @param {object} options: The OAuth parameters to authorize
+   *   - `client_id`: The OAuth client ID of the client being granted the code
+   *   - `state`: The state created by the other client's `beginOAuthFlow`
+   *   - `scope`: Space separated scopes being requested
+   *   - `access_type`: Typically `offline`
+   *   - `code_challenge`: The PKCE challenge
+   *   - `code_challenge_method`: The PKCE challenge method, ie `S256`
+   *   - `keys_jwk`: Optional public JWK to encrypt scoped keys to
+   *
+   * @returns {Promise<object>}: Object containing "code" and "state" properties.
+   */
+  async authorizeOAuthCode(sessionToken, options) {
+    const params = { ...options };
+    if (params.keys_jwk) {
+      const jwk = JSON.parse(
+        new TextDecoder().decode(
+          ChromeUtils.base64URLDecode(params.keys_jwk, { padding: "reject" })
+        )
+      );
+      params.keys_jwe = await this.#createKeysJWE(
+        sessionToken,
+        params.client_id,
+        params.scope,
+        jwk
+      );
+      delete params.keys_jwk;
+    }
+    return this.#fxaClient.oauthAuthorize(sessionToken, params);
+  }
+
+  /**
+   * Create a JWE to deliver keys to another client via the OAuth scoped-keys flow.
+   *
+   * This is used to transfer key material to another client, by providing an
+   * appropriately-encrypted value for the `keys_jwe` OAuth response parameter.
+   * Since we're transferring keys from one client to another, two things must be
+   * true:
+   *
+   *   * This client must actually have the key.
+   *   * The other client must be allowed to request that key.
+   *
+   * @param {string} sessionToken the sessionToken to use when fetching key metadata
+   * @param {string} clientId the client requesting access to our keys
+   * @param {string} scopes Space separated requested scopes being requested
+   * @param {object} jwk Ephemeral JWK provided by the client for secure key transfer
+   */
+  async #createKeysJWE(sessionToken, clientId, scopes, jwk) {
+    // This checks with the FxA server about what scopes the client is allowed.
+    // Note that we pass the requesting client_id here, not our own client_id.
+    const clientKeyData = await this.#fxaClient.getScopedKeyData(
+      sessionToken,
+      clientId,
+      scopes
+    );
+    const scopedKeys = {};
+    for (const scope of Object.keys(clientKeyData)) {
+      const key = await this.#fxaKeys.getKeyForScope(scope);
+      if (!key) {
+        throw new Error(`Key not available for scope "${scope}"`);
+      }
+      scopedKeys[scope] = key;
+    }
+    return lazy.jwcrypto.generateJWE(
+      jwk,
+      new TextEncoder().encode(JSON.stringify(scopedKeys))
+    );
+  }
+
+  /**
    * Obtain an OAuth access token for the given scopes, minted from the stored
    * session token.
    *

--- a/services/fxaccounts/FxAccountsPairing.sys.mjs
+++ b/services/fxaccounts/FxAccountsPairing.sys.mjs
@@ -27,7 +27,6 @@ ChromeUtils.defineESModuleGetters(lazy, {
     "resource://gre/modules/FxAccountsPairingChannel.sys.mjs",
 
   Weave: "resource://services-sync/main.sys.mjs",
-  jwcrypto: "moz-src:///services/crypto/modules/jwcrypto.sys.mjs",
 });
 
 const PAIRING_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob:pair-auth-webchannel";
@@ -436,80 +435,10 @@ export class FxAccountsPairingFlow {
   /**
    * Grant an OAuth authorization code for the connecting client.
    *
-   * @param {object} options
-   * @param options.client_id
-   * @param options.state
-   * @param options.scope
-   * @param options.access_type
-   * @param options.code_challenge_method
-   * @param options.code_challenge
-   * @param [options.keys_jwe]
+   * @param {object} options see `FxAccountsOAuth.authorizeOAuthCode`.
    * @returns {Promise<object>} Object containing "code" and "state" properties.
    */
   _authorizeOAuthCode(options) {
-    return this._fxa._withVerifiedAccountState(async state => {
-      const { sessionToken } = await state.getUserAccountData(["sessionToken"]);
-      const params = { ...options };
-      if (params.keys_jwk) {
-        const jwk = JSON.parse(
-          new TextDecoder().decode(
-            ChromeUtils.base64URLDecode(params.keys_jwk, { padding: "reject" })
-          )
-        );
-        params.keys_jwe = await this._createKeysJWE(
-          sessionToken,
-          params.client_id,
-          params.scope,
-          jwk
-        );
-        delete params.keys_jwk;
-      }
-      try {
-        return await this._fxai.fxAccountsClient.oauthAuthorize(
-          sessionToken,
-          params
-        );
-      } catch (err) {
-        throw this._fxai._errorToErrorClass(err);
-      }
-    });
-  }
-
-  /**
-   * Create a JWE to deliver keys to another client via the OAuth scoped-keys flow.
-   *
-   * This method is used to transfer key material to another client, by providing
-   * an appropriately-encrypted value for the `keys_jwe` OAuth response parameter.
-   * Since we're transferring keys from one client to another, two things must be
-   * true:
-   *
-   *   * This client must actually have the key.
-   *   * The other client must be allowed to request that key.
-   *
-   * @param {string} sessionToken the sessionToken to use when fetching key metadata
-   * @param {string} clientId the client requesting access to our keys
-   * @param {string} scopes Space separated requested scopes being requested
-   * @param {object} jwk Ephemeral JWK provided by the client for secure key transfer
-   */
-  async _createKeysJWE(sessionToken, clientId, scopes, jwk) {
-    // This checks with the FxA server about what scopes the client is allowed.
-    // Note that we pass the requesting client_id here, not our own client_id.
-    const clientKeyData = await this._fxai.fxAccountsClient.getScopedKeyData(
-      sessionToken,
-      clientId,
-      scopes
-    );
-    const scopedKeys = {};
-    for (const scope of Object.keys(clientKeyData)) {
-      const key = await this._fxai.keys.getKeyForScope(scope);
-      if (!key) {
-        throw new Error(`Key not available for scope "${scope}"`);
-      }
-      scopedKeys[scope] = key;
-    }
-    return lazy.jwcrypto.generateJWE(
-      jwk,
-      new TextEncoder().encode(JSON.stringify(scopedKeys))
-    );
+    return this._fxai.authorizeOAuthCode(options);
   }
 }

--- a/services/fxaccounts/FxAccountsWebChannel.sys.mjs
+++ b/services/fxaccounts/FxAccountsWebChannel.sys.mjs
@@ -26,6 +26,8 @@ import {
   COMMAND_PAIR_AUTHORIZE,
   COMMAND_PAIR_DECLINE,
   COMMAND_PAIR_COMPLETE,
+  COMMAND_PAIR_OAUTH_START,
+  COMMAND_PAIR_OAUTH_FINISH,
   COMMAND_PAIR_PREFERENCES,
   COMMAND_FIREFOX_VIEW,
   COMMAND_OAUTH_FLOW_IS_ACTIVE,
@@ -40,6 +42,7 @@ import {
   logPII,
 } from "resource://gre/modules/FxAccountsCommon.sys.mjs";
 import { SyncDisconnect } from "resource://services-sync/SyncDisconnect.sys.mjs";
+import { SCOPE_OLD_SYNC, SCOPE_PROFILE } from "./FxAccountsCommon.sys.mjs";
 
 const lazy = {};
 
@@ -71,6 +74,12 @@ XPCOMUtils.defineLazyPreferenceGetter(
   lazy,
   "pairingEnabled",
   "identity.fxaccounts.pairing.enabled"
+);
+XPCOMUtils.defineLazyPreferenceGetter(
+  lazy,
+  "pairingVersion",
+  "identity.fxaccounts.pairing.version",
+  1
 );
 XPCOMUtils.defineLazyPreferenceGetter(
   lazy,
@@ -416,6 +425,24 @@ FxAccountsWebChannel.prototype = {
           });
         break;
       }
+      case COMMAND_PAIR_OAUTH_START: {
+        this._ensurePairingEnabled(command, 2);
+        const params = await this._helpers.pairOAuthStart(data);
+        await this._channel.send(
+          { command, messageId: message.messageId, data: params },
+          sendingContext
+        );
+        break;
+      }
+      case COMMAND_PAIR_OAUTH_FINISH: {
+        this._ensurePairingEnabled(command, 2);
+        const codeAndState = await this._helpers.pairOAuthFinish(data);
+        await this._channel.send(
+          { command, messageId: message.messageId, data: codeAndState },
+          sendingContext
+        );
+        break;
+      }
       case COMMAND_PAIR_HEARTBEAT:
       case COMMAND_PAIR_SUPP_METADATA:
       case COMMAND_PAIR_AUTHORIZE:
@@ -453,6 +480,12 @@ FxAccountsWebChannel.prototype = {
         lazy.FxAccountsPairingFlow.finalizeAll();
         break;
       }
+    }
+  },
+
+  _ensurePairingEnabled(command, requiredVersion) {
+    if (!lazy.pairingEnabled || lazy.pairingVersion < requiredVersion) {
+      throw new Error(`Pairing is disabled for command: ${command}`);
     }
   },
 
@@ -787,6 +820,62 @@ FxAccountsWebChannelHelpers.prototype = {
   },
 
   /**
+   * Starts an OAuth flow on behalf of a pairing supplicant.
+   *
+   * The browser is the supplicant here - it owns the PKCE verifier and the
+   * private key needed to later complete the flow, but it is FxA which relays
+   * the resulting public parameters to the authority over the pairing channel.
+   *
+   * @param {string[]} [scopes] The scopes to request, defaults to the Sync scopes.
+   * @returns {Promise<object>} The OAuth parameters the authority needs, ie,
+   *   `state`, `scope`, `code_challenge` and `keys_jwk`.
+   */
+  async pairOAuthStart({ scopes = [SCOPE_OLD_SYNC, SCOPE_PROFILE] } = {}) {
+    log.debug(`Webchannel is starting a pairing oauth flow for ${scopes}`);
+    const { state, scope, code_challenge, keys_jwk } =
+      await this._fxAccounts._internal.oauth.beginOAuthFlow(scopes);
+    return { state, scope, code_challenge, keys_jwk };
+  },
+
+  /**
+   * Grants an OAuth authorization code for a pairing supplicant.
+   *
+   * The browser is the pairing authority here - it is already signed in, so it
+   * holds the scoped keys and the session token needed to authorize the
+   * supplicant's OAuth parameters. FxA relays the returned code and state to
+   * the supplicant over the pairing channel.
+   *
+   * @param {object} oauthParams The supplicant's OAuth parameters, as produced
+   *   by `pairOAuthStart` on the supplicant.
+   * @returns {Promise<object>} Object containing "code" and "state" properties.
+   */
+  async pairOAuthFinish({
+    client_id,
+    state,
+    scope,
+    code_challenge,
+    // `pairOAuthStart` always uses S256, so that's what we assume when the
+    // supplicant didn't tell us which method it used.
+    code_challenge_method = "S256",
+    keys_jwk,
+  }) {
+    log.debug("Webchannel is authorizing an oauth code for a pairing flow");
+    const codeAndState = await this._fxAccounts._internal.authorizeOAuthCode({
+      client_id,
+      access_type: "offline",
+      state,
+      scope,
+      code_challenge,
+      code_challenge_method,
+      keys_jwk,
+    });
+    if (codeAndState.state != state) {
+      throw new Error("OAuth state mismatch");
+    }
+    return codeAndState;
+  },
+
+  /**
    * Returns a boolean to indicate whether an oauth flow is in progress.
    */
   oauthFlowIsActive() {
@@ -918,6 +1007,7 @@ FxAccountsWebChannelHelpers.prototype = {
     return {
       multiService: true,
       pairing: lazy.pairingEnabled,
+      pairingVersion: lazy.pairingVersion,
       choose_what_to_sync: true,
       // This capability is for telling FxA that the current build can accept
       // accounts without passwords/sync keys (third-party auth)

--- a/services/fxaccounts/tests/xpcshell/test_oauth_flow.js
+++ b/services/fxaccounts/tests/xpcshell/test_oauth_flow.js
@@ -342,3 +342,141 @@ add_task(function test_complete_oauth_flow() {
     }
   });
 });
+
+// `authorizeOAuthCode` is the authority half of pairing: it grants a code for
+// parameters that some *other* client produced with `beginOAuthFlow`.
+add_task(function test_authorize_oauth_code() {
+  const SESSION_TOKEN = "01abcef12";
+  const SYNC_KEY = {
+    kty: "oct",
+    kid: "1510726318123-IqQv4onc7VcVE1kTQkyyOw",
+    k: "DW_ll5GwX6SJ5GPqJVAuMUP2t6kDqhUulc2cbt26xbTcaKGQl-9l29FHAQ7kUiJETma4s9fIpEHrt909zgFang",
+    scope: SCOPE_APP_SYNC,
+  };
+
+  function mockClient(overrides = {}) {
+    return {
+      async getScopedKeyData() {
+        return {
+          [SCOPE_APP_SYNC]: {
+            identifier: SCOPE_APP_SYNC,
+            keyRotationTimestamp: 12345678,
+          },
+        };
+      },
+      async oauthAuthorize(sessionToken, params) {
+        return { code: "fake code", state: params.state, params };
+      },
+      ...overrides,
+    };
+  }
+
+  async function generateEphemeralKeypair() {
+    const keypair = await crypto.subtle.generateKey(
+      { name: "ECDH", namedCurve: "P-256" },
+      true,
+      ["deriveKey"]
+    );
+    const publicJWK = await crypto.subtle.exportKey("jwk", keypair.publicKey);
+    delete publicJWK.key_ops;
+    return { publicJWK, privateKey: keypair.privateKey };
+  }
+
+  add_task(async function test_authorize_wraps_scoped_keys_into_jwe() {
+    const fxaClient = mockClient();
+    const oauth = new FxAccountsOAuth(fxaClient, {
+      getKeyForScope: () => SYNC_KEY,
+    });
+
+    // Stand in for the supplicant, which generated this keypair when it ran its
+    // own `beginOAuthFlow` and sent us only the public half.
+    const { publicJWK, privateKey } = await generateEphemeralKeypair();
+    const result = await oauth.authorizeOAuthCode(SESSION_TOKEN, {
+      client_id: "supplicant_client_id",
+      access_type: "offline",
+      state: "the-state",
+      scope: SCOPE_APP_SYNC,
+      code_challenge: "the-challenge",
+      code_challenge_method: "S256",
+      keys_jwk: ChromeUtils.base64URLEncode(
+        new TextEncoder().encode(JSON.stringify(publicJWK)),
+        { pad: false }
+      ),
+    });
+
+    Assert.equal(result.code, "fake code");
+    Assert.equal(result.state, "the-state");
+
+    // The public JWK must be swapped for an encrypted JWE before the params
+    // reach the server - the server must never see the raw key material.
+    const params = result.params;
+    Assert.ok(!params.keys_jwk, "keys_jwk should not be sent to the server");
+    Assert.ok(params.keys_jwe, "keys_jwe should be sent to the server");
+
+    // Only the holder of the supplicant's private key can read the keys back.
+    const decrypted = JSON.parse(
+      new TextDecoder().decode(
+        await jwcrypto.decryptJWE(params.keys_jwe, privateKey)
+      )
+    );
+    Assert.deepEqual(decrypted, { [SCOPE_APP_SYNC]: SYNC_KEY });
+
+    // The remaining OAuth params should be forwarded untouched.
+    Assert.equal(params.client_id, "supplicant_client_id");
+    Assert.equal(params.access_type, "offline");
+    Assert.equal(params.scope, SCOPE_APP_SYNC);
+    Assert.equal(params.code_challenge, "the-challenge");
+    Assert.equal(params.code_challenge_method, "S256");
+  });
+
+  add_task(async function test_authorize_without_keys_jwk() {
+    let getScopedKeyDataCalled = false;
+    const fxaClient = mockClient({
+      async getScopedKeyData() {
+        getScopedKeyDataCalled = true;
+        return {};
+      },
+    });
+    const oauth = new FxAccountsOAuth(fxaClient, {
+      getKeyForScope: () => SYNC_KEY,
+    });
+
+    const result = await oauth.authorizeOAuthCode(SESSION_TOKEN, {
+      client_id: "supplicant_client_id",
+      access_type: "offline",
+      state: "the-state",
+      scope: SCOPE_PROFILE,
+      code_challenge: "the-challenge",
+      code_challenge_method: "S256",
+    });
+
+    Assert.equal(result.code, "fake code");
+    Assert.ok(!result.params.keys_jwe, "No keys wrapped without a keys_jwk");
+    Assert.ok(
+      !getScopedKeyDataCalled,
+      "Should not ask the server for key data when no keys were requested"
+    );
+  });
+
+  add_task(async function test_authorize_missing_key_for_scope() {
+    const fxaClient = mockClient();
+    // The server says the client may have this scope's key, but we don't hold it.
+    const oauth = new FxAccountsOAuth(fxaClient, {
+      getKeyForScope: () => null,
+    });
+
+    const { publicJWK } = await generateEphemeralKeypair();
+    await Assert.rejects(
+      oauth.authorizeOAuthCode(SESSION_TOKEN, {
+        client_id: "supplicant_client_id",
+        state: "the-state",
+        scope: SCOPE_APP_SYNC,
+        keys_jwk: ChromeUtils.base64URLEncode(
+          new TextEncoder().encode(JSON.stringify(publicJWK)),
+          { pad: false }
+        ),
+      }),
+      /Key not available for scope/
+    );
+  });
+});

--- a/services/fxaccounts/tests/xpcshell/test_pairing.js
+++ b/services/fxaccounts/tests/xpcshell/test_pairing.js
@@ -9,6 +9,9 @@ const { FxAccountsPairingFlow } = ChromeUtils.importESModule(
 const { EventEmitter } = ChromeUtils.importESModule(
   "resource://gre/modules/EventEmitter.sys.mjs"
 );
+const { FxAccountsOAuth } = ChromeUtils.importESModule(
+  "resource://gre/modules/FxAccountsOAuth.sys.mjs"
+);
 ChromeUtils.defineESModuleGetters(this, {
   jwcrypto: "moz-src:///services/crypto/modules/jwcrypto.sys.mjs",
 });
@@ -41,6 +44,32 @@ const fxaConfig = {
     return OAUTH_URI;
   },
 };
+const fxaClient = {
+  async getScopedKeyData() {
+    return {
+      [SCOPE_APP_SYNC]: {
+        identifier: SCOPE_APP_SYNC,
+        keyRotationTimestamp: 12345678,
+      },
+    };
+  },
+  async oauthAuthorize() {
+    return { code: "mycode", state: "mystate" };
+  },
+};
+const fxaKeys = {
+  getKeyForScope() {
+    return {
+      kid: "123456",
+      k: KSYNC,
+      kty: "oct",
+    };
+  },
+};
+// The flow reaches authorization through FxAccountsInternal, which delegates to
+// FxAccountsOAuth. Use a real FxAccountsOAuth over the mock client and keys so
+// the keys_jwe generation is genuinely exercised rather than stubbed out.
+const fxaOAuth = new FxAccountsOAuth(fxaClient, fxaKeys);
 const fxAccounts = {
   getSignedInUser() {
     return {
@@ -50,37 +79,12 @@ const fxAccounts = {
       displayName: DISPLAY_NAME,
     };
   },
-  async _withVerifiedAccountState(cb) {
-    return cb({
-      async getUserAccountData() {
-        return {
-          sessionToken: SESSION,
-        };
-      },
-    });
-  },
   _internal: {
-    keys: {
-      getKeyForScope() {
-        return {
-          kid: "123456",
-          k: KSYNC,
-          kty: "oct",
-        };
-      },
-    },
-    fxAccountsClient: {
-      async getScopedKeyData() {
-        return {
-          [SCOPE_APP_SYNC]: {
-            identifier: SCOPE_APP_SYNC,
-            keyRotationTimestamp: 12345678,
-          },
-        };
-      },
-      async oauthAuthorize() {
-        return { code: "mycode", state: "mystate" };
-      },
+    keys: fxaKeys,
+    fxAccountsClient: fxaClient,
+    oauth: fxaOAuth,
+    authorizeOAuthCode(options) {
+      return fxaOAuth.authorizeOAuthCode(SESSION, options);
     },
   },
 };

--- a/services/fxaccounts/tests/xpcshell/test_web_channel.js
+++ b/services/fxaccounts/tests/xpcshell/test_web_channel.js
@@ -18,6 +18,9 @@ const { PREF_LAST_FXA_USER_EMAIL, PREF_LAST_FXA_USER_UID } =
 
 const URL_STRING = "https://example.com";
 
+const PREF_PAIRING_ENABLED = "identity.fxaccounts.pairing.enabled";
+const PREF_PAIRING_VERSION = "identity.fxaccounts.pairing.version";
+
 const mockSendingContext = {
   browsingContext: { top: { embedderElement: {} } },
   principal: {},
@@ -931,6 +934,45 @@ add_task(async function test_helpers_getFxAStatus_engines_oauth() {
   ]);
 });
 
+add_task(async function test_helpers_getFxAStatus_pairing_capabilities() {
+  let helpers = new FxAccountsWebChannelHelpers({
+    fxAccounts: {
+      _internal: {
+        getUserAccountData() {
+          return Promise.resolve(null);
+        },
+      },
+    },
+    privateBrowsingUtils: {
+      isBrowserPrivate: () => false,
+    },
+  });
+
+  Services.prefs.setBoolPref(PREF_PAIRING_ENABLED, true);
+  Services.prefs.setIntPref(PREF_PAIRING_VERSION, 2);
+
+  let { capabilities } = await helpers.getFxaStatus("sync", mockSendingContext);
+  Assert.strictEqual(capabilities.pairing, true, "pairing is enabled");
+  Assert.strictEqual(capabilities.pairingVersion, 2, "reports version 2");
+
+  Services.prefs.setIntPref(PREF_PAIRING_VERSION, 1);
+  ({ capabilities } = await helpers.getFxaStatus("sync", mockSendingContext));
+  Assert.strictEqual(capabilities.pairing, true, "pairing is still enabled");
+  Assert.strictEqual(capabilities.pairingVersion, 1, "reports version 1");
+
+  Services.prefs.setBoolPref(PREF_PAIRING_ENABLED, false);
+  ({ capabilities } = await helpers.getFxaStatus("sync", mockSendingContext));
+  Assert.strictEqual(capabilities.pairing, false, "pairing is disabled");
+  Assert.strictEqual(
+    capabilities.pairingVersion,
+    1,
+    "reports the version even when pairing is disabled"
+  );
+
+  Services.prefs.clearUserPref(PREF_PAIRING_ENABLED);
+  Services.prefs.clearUserPref(PREF_PAIRING_VERSION);
+});
+
 add_task(async function test_helpers_getFxaStatus_allowed_signedInUser() {
   let wasCalled = {
     getUserAccountData: false,
@@ -1444,6 +1486,140 @@ add_test(function test_oauth_flow_begin() {
 
   channel._channelCallback(WEBCHANNEL_ID, mockMessage, mockSendingContext);
 });
+
+add_task(async function test_pair_oauth_start() {
+  Services.prefs.setBoolPref(PREF_PAIRING_ENABLED, true);
+  Services.prefs.setIntPref(PREF_PAIRING_VERSION, 2);
+
+  let response = await sendWebChannelCommand(
+    "fxaccounts:pair_oauth_start",
+    "12349"
+  );
+
+  Assert.equal(response.command, "fxaccounts:pair_oauth_start");
+  Assert.equal(response.messageId, "12349");
+  Assert.equal(
+    response.data.scope,
+    "https://identity.mozilla.com/apps/oldsync profile",
+    "Defaults to the Sync scopes"
+  );
+  Assert.ok(response.data.state);
+  Assert.ok(response.data.code_challenge);
+  Assert.ok(response.data.keys_jwk);
+  Assert.deepEqual(
+    Object.keys(response.data).sort(),
+    ["code_challenge", "keys_jwk", "scope", "state"],
+    "Only the params FxA needs are exposed"
+  );
+
+  Services.prefs.clearUserPref(PREF_PAIRING_ENABLED);
+  Services.prefs.clearUserPref(PREF_PAIRING_VERSION);
+});
+
+add_task(async function test_pair_oauth_start_disabled() {
+  await assertPairingCommandDisabled("fxaccounts:pair_oauth_start", "12350");
+});
+
+add_task(async function test_pair_oauth_finish_disabled() {
+  await assertPairingCommandDisabled("fxaccounts:pair_oauth_finish", "12351");
+});
+
+add_task(async function test_helpers_pair_oauth_finish() {
+  let authorizeParams;
+  let helpers = new FxAccountsWebChannelHelpers({
+    fxAccounts: {
+      _internal: {
+        async authorizeOAuthCode(options) {
+          authorizeParams = options;
+          return { code: "thecode", state: options.state };
+        },
+      },
+    },
+  });
+
+  let result = await helpers.pairOAuthFinish({
+    client_id: "client_id",
+    state: "thestate",
+    scope: "profile",
+    code_challenge: "challenge",
+  });
+
+  Assert.deepEqual(result, { code: "thecode", state: "thestate" });
+  Assert.equal(authorizeParams.client_id, "client_id");
+  Assert.equal(authorizeParams.scope, "profile");
+  Assert.equal(authorizeParams.access_type, "offline");
+  Assert.equal(
+    authorizeParams.code_challenge_method,
+    "S256",
+    "Defaults to the method used by pairOAuthStart"
+  );
+});
+
+add_task(async function test_helpers_pair_oauth_finish_state_mismatch() {
+  let helpers = new FxAccountsWebChannelHelpers({
+    fxAccounts: {
+      _internal: {
+        async authorizeOAuthCode() {
+          return { code: "thecode", state: "someotherstate" };
+        },
+      },
+    },
+  });
+
+  await Assert.rejects(
+    helpers.pairOAuthFinish({
+      client_id: "client_id",
+      state: "thestate",
+      scope: "profile",
+      code_challenge: "challenge",
+      code_challenge_method: "S256",
+    }),
+    /OAuth state mismatch/
+  );
+});
+
+async function sendWebChannelCommand(command, messageId, data = {}) {
+  let channel = new FxAccountsWebChannel({
+    channel_id: WEBCHANNEL_ID,
+    content_uri: URL_STRING,
+  });
+
+  let promiseSend = new Promise(resolve => {
+    channel._channel = { send: response => resolve(response) };
+  });
+
+  channel._channelCallback(
+    WEBCHANNEL_ID,
+    { command, messageId, data },
+    mockSendingContext
+  );
+  return promiseSend;
+}
+
+// The OAuth pairing commands require both that pairing is enabled and that the
+// pairing version is at least 2, so check that each is enforced separately.
+async function assertPairingCommandDisabled(command, messageId) {
+  Services.prefs.setBoolPref(PREF_PAIRING_ENABLED, false);
+  Services.prefs.setIntPref(PREF_PAIRING_VERSION, 2);
+
+  let response = await sendWebChannelCommand(command, messageId);
+  Assert.ok(
+    response.data.error.message.includes("Pairing is disabled"),
+    "Should report an error rather than silently hanging when pairing is disabled"
+  );
+
+  Services.prefs.setBoolPref(PREF_PAIRING_ENABLED, true);
+  Services.prefs.setIntPref(PREF_PAIRING_VERSION, 1);
+
+  response = await sendWebChannelCommand(command, messageId);
+  Assert.ok(
+    response.data.error.message.includes("Pairing is disabled"),
+    "Should report an error when the pairing version is older than 2"
+  );
+
+  Services.prefs.clearUserPref(PREF_PAIRING_ENABLED);
+  Services.prefs.clearUserPref(PREF_PAIRING_VERSION);
+}
 
 function makeObserver(aObserveTopic, aObserveFunc) {
   let callback = function (aSubject, aTopic, aData) {


### PR DESCRIPTION
## Because:
- We are updating the pairing flows in FxA to be more streamlined.
- We are shifting the authority's channel server communication to FxA code, which improves symmetry with the supplicant's implementation.
- We need to expose a subset of oauth parameters in order to fulfill the contract for certain pairing-channel server messages.

## This Commit:
- Adds a new pref to gate new pairing channel commands
- Exposes pref in the fxa_status message in the `capabilities.pairingVersion` response.
- Adds a new pairing channel commands:
 - fxaccounts:pair_oauth_start: This kicks off the oauth pairing process on the supplicant's side. This results in the initial oauth params that are required by the 'pair:supp:request' message contract.
 - fxaccounts:pair_oauth_finish: This finalizes the pairing process on the authority's side, and results in a `code` and `state` that are required by the 'pair:auth:authorize' message contract.