### PR TITLE
Bug 1973441, 2055879, 2063477 - Restore saved tab groups after crash or unexpected shutdown.

### DIFF
--- a/browser/components/sessionstore/SessionStartup.sys.mjs
+++ b/browser/components/sessionstore/SessionStartup.sys.mjs
@@ -198,8 +198,9 @@ export var SessionStartup = {
           }, 0)
         );
       }, 0);
+      let savedGroupsCount = initialState.savedGroups.length;
       lazy.sessionStoreLogger.debug(
-        `initialState contains ${pinnedTabCount} pinned tabs`
+        `initialState contains ${pinnedTabCount} pinned tabs and ${savedGroupsCount} saved groups`
       );
 
       lazy.BrowserUsageTelemetry.updateMaxTabPinnedCount(pinnedTabCount);

--- a/browser/components/sessionstore/SessionStore.sys.mjs
+++ b/browser/components/sessionstore/SessionStore.sys.mjs
@@ -1413,7 +1413,7 @@ var SessionStoreInternal = {
                 triggeringPrincipal_base64:
                   lazy.E10SUtils.SERIALIZED_SYSTEMPRINCIPAL,
               };
-              state = { windows: [{ tabs: [{ entries: [entry], formdata }] }] };
+              state = { windows: [{ tabs: [{ entries: [entry], formdata }] }], savedGroups: state.savedGroups };
               this._log.debug("initSession, will show about:sessionrestore");
             } else if (
               this._hasSingleTabWithURL(state.windows, "about:welcomeback")


### PR DESCRIPTION
add savedGroups to the restore state.

Related:
https://support.mozilla.org/en-US/questions/1572501
https://support.mozilla.org/en-US/questions/1579235
https://support.mozilla.org/en-US/questions/1597198