### PR TITLE
Bug 2015253 - Only return a container frame top level docs during print preview. r=tnikkel,#layout

### DIFF
--- a/layout/printing/nsPrintJob.cpp
+++ b/layout/printing/nsPrintJob.cpp
@@ -1262,9 +1262,11 @@ nsresult nsPrintJob::ReflowPrintObject(const UniquePtr<nsPrintObject>& aPO) {
       !aPO->mParent || !aPO->mParent->PrintingIsEnabled();
   auto* embedderFrame = [&]() -> nsSubDocumentFrame* {
     if (documentIsTopLevel) {
-      if (nsCOMPtr<nsIDocumentViewer> viewer =
-              do_QueryInterface(mDocViewerPrint)) {
-        return viewer->FindContainerFrame();
+      if (mIsCreatingPrintPreview) {
+        if (nsCOMPtr<nsIDocumentViewer> viewer =
+                do_QueryInterface(mDocViewerPrint)) {
+          return viewer->FindContainerFrame();
+        }
       }
     } else if (aPO->mContent) {
       return do_QueryFrame(aPO->mContent->GetPrimaryFrame());


### PR DESCRIPTION
This matches the pre-regression logic, and fixes the coordinate system
of the slicing fragmentation fallback.

Unfortunately testing this is kind of a PITA, because the obvious way to
do it would be WPT print reftests, but that requires e10s. Regular
reftests don't have any print stuff that would reliably test the
fragmentation fallback I think?

I can try to come up with something tho...
