### PR TITLE
Bug 2064472 - Factor out legacy shorthands code. r=#style

### DIFF
--- a/servo/components/style/properties/helpers.mako.rs
+++ b/servo/components/style/properties/helpers.mako.rs
@@ -650,7 +650,7 @@ pub mod ${property.ident} {
         ) -> Result<(), ParseError<'i>> {
             #[allow(unused_imports)]
             use crate::properties::{NonCustomPropertyId, LonghandId};
-            % if not shorthand.kind:
+            % if not shorthand.kind and "IS_LEGACY_SHORTHAND" not in shorthand.flags:
             use crate::properties::shorthands::${shorthand.ident}::parse_value;
             % endif
             input.parse_entirely(|input| parse_value(context, input)).map(|longhands| {
@@ -684,6 +684,9 @@ pub mod ${property.ident} {
         % endif
         % if shorthand.kind == "single_border":
         ${self.single_border_shorthand(shorthand)}
+        % endif
+        % if "IS_LEGACY_SHORTHAND" in shorthand.flags:
+        ${self.legacy_shorthand(shorthand)}
         % endif
     }
 </%def>
@@ -779,6 +782,25 @@ pub mod ${property.ident} {
                 self.${shorthand.sub_properties[i].ident},
                 % endfor
             )
+        }
+    }
+</%def>
+
+<%def name="legacy_shorthand(shorthand)">
+    type Value = crate::properties::longhands::${shorthand.sub_properties[0].ident}::SpecifiedValue;
+    fn parse_value<'i, 't>(
+        context: &ParserContext,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Longhands, ParseError<'i>> {
+        let v = Value::parse_legacy(context, input)?;
+        Ok(crate::properties::shorthands::expanded! {
+            ${shorthand.sub_properties[0].ident}: v,
+        })
+    }
+
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result where W: fmt::Write {
+            self.${shorthand.sub_properties[0].ident}.to_css_legacy(dest)
         }
     }
 </%def>

--- a/servo/components/style/properties/shorthands.rs
+++ b/servo/components/style/properties/shorthands.rs
@@ -647,83 +647,6 @@ pub mod vertical_align {
 }
 
 #[cfg(feature = "gecko")]
-pub mod page_break_before {
-    use super::*;
-    pub use crate::properties::generated::shorthands::page_break_before::*;
-
-    use crate::values::specified::BreakBetween;
-
-    pub fn parse_value<'i>(
-        context: &ParserContext,
-        input: &mut Parser<'i, '_>,
-    ) -> Result<Longhands, ParseError<'i>> {
-        Ok(expanded! {
-            break_before: BreakBetween::parse_legacy(context, input)?,
-        })
-    }
-
-    impl<'a> ToCss for LonghandsToSerialize<'a> {
-        fn to_css<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result
-        where
-            W: fmt::Write,
-        {
-            self.break_before.to_css_legacy(dest)
-        }
-    }
-}
-
-#[cfg(feature = "gecko")]
-pub mod page_break_after {
-    pub use crate::properties::generated::shorthands::page_break_after::*;
-
-    use super::*;
-    use crate::values::specified::BreakBetween;
-
-    pub fn parse_value<'i>(
-        context: &ParserContext,
-        input: &mut Parser<'i, '_>,
-    ) -> Result<Longhands, ParseError<'i>> {
-        Ok(expanded! {
-            break_after: BreakBetween::parse_legacy(context, input)?,
-        })
-    }
-
-    impl<'a> ToCss for LonghandsToSerialize<'a> {
-        fn to_css<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result
-        where
-            W: fmt::Write,
-        {
-            self.break_after.to_css_legacy(dest)
-        }
-    }
-}
-
-#[cfg(feature = "gecko")]
-pub mod page_break_inside {
-    use super::*;
-    pub use crate::properties::generated::shorthands::page_break_inside::*;
-    use crate::values::specified::BreakWithin;
-
-    pub fn parse_value<'i>(
-        context: &ParserContext,
-        input: &mut Parser<'i, '_>,
-    ) -> Result<Longhands, ParseError<'i>> {
-        Ok(expanded! {
-            break_inside: BreakWithin::parse_legacy(context, input)?,
-        })
-    }
-
-    impl<'a> ToCss for LonghandsToSerialize<'a> {
-        fn to_css<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result
-        where
-            W: fmt::Write,
-        {
-            self.break_inside.to_css_legacy(dest)
-        }
-    }
-}
-
-#[cfg(feature = "gecko")]
 pub mod offset {
     use super::*;
     pub use crate::properties::generated::shorthands::offset::*;
@@ -819,49 +742,6 @@ pub mod offset {
             }
             Ok(())
         }
-    }
-}
-
-pub mod _webkit_perspective {
-    pub use crate::properties::generated::shorthands::_webkit_perspective::*;
-
-    use super::*;
-
-    pub fn parse_value<'i, 't>(
-        context: &ParserContext,
-        input: &mut Parser<'i, 't>,
-    ) -> Result<Longhands, ParseError<'i>> {
-        use crate::properties::longhands::perspective;
-        use crate::values::generics::NonNegative;
-        use crate::values::specified::{AllowQuirks, Length, Perspective};
-
-        if let Ok(l) = input.try_parse(|input| {
-            Length::parse_non_negative_quirky(context, input, AllowQuirks::Always)
-        }) {
-            Ok(expanded! {
-                perspective: Perspective::Length(NonNegative(l)),
-            })
-        } else {
-            Ok(expanded! {
-                perspective: perspective::parse(context, input)?
-            })
-        }
-    }
-}
-
-pub mod _webkit_transform {
-    pub use crate::properties::generated::shorthands::_webkit_transform::*;
-
-    use super::*;
-
-    pub fn parse_value<'i, 't>(
-        context: &ParserContext,
-        input: &mut Parser<'i, 't>,
-    ) -> Result<Longhands, ParseError<'i>> {
-        use crate::values::specified::Transform;
-        Ok(expanded! {
-            transform: Transform::parse_legacy(context, input)?,
-        })
     }
 }
 
@@ -4372,32 +4252,6 @@ pub mod grid {
             dest.write_str(" / ")?;
             self.grid_template_columns.to_css(dest)?;
             Ok(())
-        }
-    }
-}
-
-#[cfg(feature = "gecko")]
-pub mod _webkit_line_clamp {
-    use super::*;
-    pub use crate::properties::generated::shorthands::_webkit_line_clamp::*;
-
-    use crate::values::specified::LineClamp;
-
-    pub fn parse_value<'i>(
-        context: &ParserContext,
-        input: &mut Parser<'i, '_>,
-    ) -> Result<Longhands, ParseError<'i>> {
-        Ok(expanded! {
-            line_clamp: LineClamp::parse_legacy(context, input)?,
-        })
-    }
-
-    impl<'a> ToCss for LonghandsToSerialize<'a> {
-        fn to_css<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result
-        where
-            W: fmt::Write,
-        {
-            self.line_clamp.to_css_legacy(dest)
         }
     }
 }

--- a/servo/components/style/properties/shorthands.toml
+++ b/servo/components/style/properties/shorthands.toml
@@ -242,13 +242,11 @@ spec = "https://drafts.fxtf.org/motion-1/#offset-shorthand"
 
 [-webkit-perspective]
 sub_properties = ["perspective"]
-derive_serialize = true
 flags = "IS_LEGACY_SHORTHAND"
 spec = "https://github.com/whatwg/compat/issues/100"
 
 [-webkit-transform]
 sub_properties = ["transform"]
-derive_serialize = true
 flags = "IS_LEGACY_SHORTHAND"
 spec = "https://github.com/whatwg/compat/issues/100"
 

--- a/servo/components/style/values/specified/box.rs
+++ b/servo/components/style/values/specified/box.rs
@@ -1728,6 +1728,31 @@ impl Parse for ContainerName {
 /// A specified value for the `perspective` property.
 pub type Perspective = GenericPerspective<NonNegativeLength>;
 
+impl Perspective {
+    /// Parses a `-webkit-perspective` value.
+    pub(crate) fn parse_legacy<'i>(
+        context: &ParserContext,
+        input: &mut Parser<'i, '_>,
+    ) -> Result<Self, ParseError<'i>> {
+        use crate::values::specified::{AllowQuirks, Length};
+        use crate::values::generics::NonNegative;
+        if let Ok(l) = input.try_parse(|input| {
+            Length::parse_non_negative_quirky(context, input, AllowQuirks::Always)
+        }) {
+            return Ok(Self::Length(NonNegative(l)));
+        }
+        Self::parse(context, input)
+    }
+
+    /// Serializes a `-webkit-perspective` value.
+    pub(crate) fn to_css_legacy<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result
+    where
+        W: Write,
+    {
+        self.to_css(dest)
+    }
+}
+
 /// https://drafts.csswg.org/css-box/#propdef-float
 #[allow(missing_docs)]
 #[derive(

--- a/servo/components/style/values/specified/transform.rs
+++ b/servo/components/style/values/specified/transform.rs
@@ -19,7 +19,8 @@ use crate::values::specified::{
 };
 use crate::Zero;
 use cssparser::{match_ignore_ascii_case, Parser};
-use style_traits::{ParseError, StyleParseErrorKind};
+use std::fmt;
+use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
 
 pub use crate::values::generics::transform::TransformStyle;
 
@@ -122,6 +123,14 @@ impl Transform {
     ) -> Result<Self, ParseError<'i>> {
         Self::parse_internal(context, input, AllowUnitlessPerspective::Yes)
     }
+
+    pub(crate) fn to_css_legacy<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result
+    where
+        W: fmt::Write,
+    {
+        self.to_css(dest)
+    }
+
     /// Internal parse function for deciding if we wish to accept prefixed values or not
     ///
     /// `transform` allows unitless zero angles as an exception, see:


### PR DESCRIPTION
A legacy shorthand is, fundamentally, a single-longhand shorthand with different parse and serialize methods.

We can trivially autogenerate all that code.