### PR TITLE
Bug 2041870: Don't let mUseAccessibilityTheme override mUseDocumentColors. r=firefox-style-system-reviewers

### DIFF
--- a/layout/style/nsMediaFeatures.cpp
+++ b/layout/style/nsMediaFeatures.cpp
@@ -326,7 +326,7 @@ StylePrefersContrast Gecko_MediaFeatures_PrefersContrast(
     return StylePrefersContrast::NoPreference;
   }
   const auto& prefs = PreferenceSheet::PrefsFor(*aDocument);
-  if (!prefs.mUseAccessibilityTheme && prefs.mUseDocumentColors) {
+  if (prefs.mUseDocumentColors) {
     return StylePrefersContrast::NoPreference;
   }
   const auto& colors = prefs.ColorsFor(ColorScheme::Light);


### PR DESCRIPTION
See comment in bug - mUseDocumentColors already takes mUseAccessibilityTheme
into account if the pref is set to do so.
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->

---

Lando: [link](https://lando.moz.tools/pulls/firefox-autoland/343/)
Bugzilla: [bug 2041870](https://bugzilla.mozilla.org/show_bug.cgi?id=2041870)

:warning: This pull request has 6 warnings.
:no_entry_sign: This pull request has 3 blockers.