### PR TITLE
Bug 2031056 - Eliminating duplication of NALU type bytes in generated AVCC

### DIFF
--- a/dom/media/platforms/agnostic/bytestreams/H264.cpp
+++ b/dom/media/platforms/agnostic/bytestreams/H264.cpp
@@ -1263,10 +1263,10 @@ bool H264::DecodeRecoverySEI(const mozilla::MediaByteBuffer* aSEI,
     uint8_t aProfile, uint8_t aConstraints, H264_LEVEL aLevel,
     const gfx::IntSize& aSize) {
   // SPS of a 144p video.
-  const uint8_t originSPS[] = {0x4d, 0x40, 0x0c, 0xe8, 0x80, 0x80, 0x9d,
-                               0x80, 0xb5, 0x01, 0x01, 0x01, 0x40, 0x00,
-                               0x00, 0x00, 0x40, 0x00, 0x00, 0x0f, 0x03,
-                               0xc5, 0x0a, 0x44, 0x80};
+  const uint8_t originSPS[] = {0x67, 0x4d, 0x40, 0x0c, 0xe8, 0x80, 0x80,
+                               0x9d, 0x80, 0xb5, 0x01, 0x01, 0x01, 0x40,
+                               0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x0f,
+                               0x03, 0xc5, 0x0a, 0x44, 0x80};
 
   RefPtr<MediaByteBuffer> extraData = new MediaByteBuffer();
   extraData->AppendElements(originSPS, sizeof(originSPS));
@@ -1275,7 +1275,8 @@ bool H264::DecodeRecoverySEI(const mozilla::MediaByteBuffer* aSEI,
   RefPtr<MediaByteBuffer> sps = new MediaByteBuffer();
   BitWriter bw(sps);
 
-  br.ReadBits(8);  // Skip original profile_idc
+  bw.WriteU8(br.ReadBits(8));  // NALU SPS byte
+  br.ReadBits(8);              // Skip original profile_idc
   bw.WriteU8(aProfile);
   br.ReadBits(8);  // Skip original constraint flags && reserved_zero_2bits
   aConstraints =
@@ -1332,7 +1333,7 @@ bool H264::DecodeRecoverySEI(const mozilla::MediaByteBuffer* aSEI,
       EncodeNALUnit(sps->Elements(), sps->Length());
   extraData->Clear();
 
-  const uint8_t PPS[] = {0xeb, 0xef, 0x20};
+  const uint8_t PPS[] = {0x67, 0xeb, 0xef, 0x20};
 
   WriteExtraData(
       extraData, aProfile, aConstraints, static_cast<uint8_t>(aLevel),
@@ -1350,18 +1351,17 @@ void H264::WriteExtraData(MediaByteBuffer* aDestExtraData,
   aDestExtraData->AppendElement(aProfile);
   aDestExtraData->AppendElement(aConstraints);
   aDestExtraData->AppendElement(aLevel);
-  aDestExtraData->AppendElement(3);  // nalLENSize-1
-  aDestExtraData->AppendElement(1);  // numPPS
+  aDestExtraData->AppendElement(
+      0xfc | 3);  // reserved (6 bits) | nalLengthSizeMinusOne (= 3)
+  aDestExtraData->AppendElement(0xe0 | 1);  // reserved (3 bits) | numSPS (= 1)
   uint8_t c[2];
-  mozilla::BigEndian::writeUint16(&c[0], aSPS.Length() + 1);
+  mozilla::BigEndian::writeUint16(&c[0], aSPS.Length());
   aDestExtraData->AppendElements(c, 2);
-  aDestExtraData->AppendElement((0x00 << 7) | (0x3 << 5) | H264_NAL_SPS);
   aDestExtraData->AppendElements(aSPS.Elements(), aSPS.Length());
 
   aDestExtraData->AppendElement(1);  // numPPS
-  mozilla::BigEndian::writeUint16(&c[0], aPPS.Length() + 1);
+  mozilla::BigEndian::writeUint16(&c[0], aPPS.Length());
   aDestExtraData->AppendElements(c, 2);
-  aDestExtraData->AppendElement((0x00 << 7) | (0x3 << 5) | H264_NAL_PPS);
   aDestExtraData->AppendElements(aPPS.Elements(), aPPS.Length());
 }
 
@@ -1395,9 +1395,18 @@ void H264::WriteExtraData(MediaByteBuffer* aDestExtraData,
   avcc.mAVCProfileIndication = reader.ReadBits(8);
   avcc.mProfileCompatibility = reader.ReadBits(8);
   avcc.mAVCLevelIndication = reader.ReadBits(8);
-  (void)reader.ReadBits(6);  // reserved
+  uint8_t padding6Bits = (uint8_t)reader.ReadBits(6);  // reserved
+  if (padding6Bits < 0b111111) {
+    LOG("Padding 6 bits ({}) for Length Size Minus One are not all set!",
+        padding6Bits);
+    return mozilla::Err(NS_ERROR_FAILURE);
+  }
   avcc.mLengthSizeMinusOne = reader.ReadBits(2);
-  (void)reader.ReadBits(3);  // reserved
+  uint8_t padding3Bits = (uint8_t)reader.ReadBits(3);  // reserved
+  if (padding3Bits < 0b111) {
+    LOG("Padding 3 bits ({}) for numSPS are not all set!", padding3Bits);
+    return mozilla::Err(NS_ERROR_FAILURE);
+  }
   const uint8_t numSPS = reader.ReadBits(5);
   for (uint8_t idx = 0; idx < numSPS; idx++) {
     if (reader.BitsLeft() < 16) {
@@ -1502,9 +1511,9 @@ already_AddRefed<mozilla::MediaByteBuffer> AVCCConfig::CreateNewExtraData()
   writer.WriteBits(mAVCProfileIndication, 8);
   writer.WriteBits(mProfileCompatibility, 8);
   writer.WriteBits(mAVCLevelIndication, 8);
-  writer.WriteBits(0x111111, 6);  // reserved
+  writer.WriteBits(0b111111, 6);  // reserved
   writer.WriteBits(mLengthSizeMinusOne, 2);
-  writer.WriteBits(0x111, 3);  // reserved
+  writer.WriteBits(0b111, 3);  // reserved
   writer.WriteBits(mSPSs.Length(), 5);
   for (const auto& nalu : mSPSs) {
     writer.WriteBits(nalu.mNALU.Length(), 16);

--- a/dom/media/platforms/agnostic/bytestreams/gtest/TestByteStreams.cpp
+++ b/dom/media/platforms/agnostic/bytestreams/gtest/TestByteStreams.cpp
@@ -911,6 +911,19 @@ TEST(H264, CreateNewExtraData)
   EXPECT_EQ(*avcc.mBitDepthLumaMinus8, 0);
   EXPECT_EQ(*avcc.mBitDepthChromaMinus8, 0);
 
+  // Create new extradata with non-zero chroma_format,
+  // bit_depth_luma_minus8 and bit_depth_chroma_minus8.
+  *avcc.mChromaFormat = 2;          // 2 bits
+  *avcc.mBitDepthLumaMinus8 = 5;    // 3 bits
+  *avcc.mBitDepthChromaMinus8 = 3;  // 3 bits
+  extradata = avcc.CreateNewExtraData();
+  res = AVCCConfig::Parse(extradata);
+  EXPECT_TRUE(res.isOk());
+  avcc = res.unwrap();
+  EXPECT_EQ(avcc.mChromaFormat.value(), 2);
+  EXPECT_EQ(avcc.mBitDepthLumaMinus8.value(), 5);
+  EXPECT_EQ(avcc.mBitDepthChromaMinus8.value(), 3);
+
   // Use a wrong attribute, which will generate an invalid config
   avcc.mConfigurationVersion = 5;
   extradata = avcc.CreateNewExtraData();


### PR DESCRIPTION
Simplifying Method `H264::WriteExtraData` so it no longer introduces NALU type bytes for SPS nor for PPS in the process of generating AVCC, eliminating the odds of duplicating them. The responsibility of introducing such bytes is being delegated upstream.

Expanding unit test `H264.CreateNewExtraData` by verifying chroma bits in AVCC containing both SPS and PPS.

*Extra:* adding checks for bits padding `mLengthSizeMinusOne` and `numSPS` values in method `AVCCConfig::Parse`, and correcting lines setting faulty values for those bits.