### PR TITLE
Bug 2068111 - Fix ruff UP031 and PLW2901 warnings in python/mozbuild/…

### DIFF
--- a/python/mozbuild/mozbuild/action/fat_aar.py
+++ b/python/mozbuild/mozbuild/action/fat_aar.py
@@ -77,9 +77,8 @@ def fat_aar(
     # Collect multi-architecture inputs to the fat AAR.
     copier = FileCopier()
 
-    for arch, zip_path in zip_paths.items():
-        if not zip_path:
-            zip_path = _download_zip(distdir, arch)
+    for arch, zip_path_opt in zip_paths.items():
+        zip_path = zip_path_opt or _download_zip(distdir, arch)
         if verbose:
             print(f"Processing '{zip_path}' for architecture {arch}")
         # Map old non-architecture-specific path to new architecture-specific path.

--- a/python/mozbuild/mozbuild/action/file_generate_wrapper.py
+++ b/python/mozbuild/mozbuild/action/file_generate_wrapper.py
@@ -32,7 +32,6 @@ def action(fh, script, target_dir, *args):
     except Exception:
         relative = os.path.relpath(__file__, topsrcdir)
         print(
-            "%s:action caught exception. params=%s\n"
-            % (relative, json.dumps([script, target_dir] + args, indent=2))
+            f"{relative}:action caught exception. params={json.dumps([script, target_dir] + args, indent=2)}\n"
         )
         raise

--- a/python/mozbuild/mozbuild/action/generate_symbols_file.py
+++ b/python/mozbuild/mozbuild/action/generate_symbols_file.py
@@ -69,7 +69,7 @@ def generate_symbols_file(output, *args):
         # is, in fact, part of the symbol name as far as the symbols variable
         # is concerned.
         assert ext == ".def"
-        output.write("LIBRARY %s\nEXPORTS\n  %s\n" % (libname, "\n  ".join(symbols)))
+        output.write(f"LIBRARY {libname}\nEXPORTS\n  " + "\n  ".join(symbols) + "\n")
     elif (
         buildconfig.substs.get("GCC_USE_GNU_LD")
         or buildconfig.substs["OS_TARGET"] == "SunOS"
@@ -85,11 +85,13 @@ def generate_symbols_file(output, *args):
         #   *;
         # };
         output.write(
-            "%s {\nglobal:\n  %s;\nlocal:\n  *;\n};" % (libname, ";\n  ".join(symbols))
+            f"{libname} {{\nglobal:\n  "
+            + ";\n  ".join(symbols)
+            + ";\nlocal:\n  *;\n}};"
         )
     elif buildconfig.substs["OS_TARGET"] == "Darwin":
         # A list of symbols is generated for Apple ld that simply lists all
         # symbols, with an underscore prefix.
-        output.write("".join("_%s\n" % s for s in symbols))
+        output.write("".join(f"_{s}\n" for s in symbols))
 
     return set(pp.includes)

--- a/python/mozbuild/mozbuild/action/langpack_manifest.py
+++ b/python/mozbuild/mozbuild/action/langpack_manifest.py
@@ -391,7 +391,7 @@ def get_version_maybe_buildid(app_version):
 
     buildid = os.environ.get("MOZ_BUILD_DATE")
     if buildid and len(buildid) != 14:
-        print("Ignoring invalid MOZ_BUILD_DATE: %s" % buildid, file=sys.stderr)
+        print(f"Ignoring invalid MOZ_BUILD_DATE: {buildid}", file=sys.stderr)
         buildid = None
 
     if buildid:

--- a/python/mozbuild/mozbuild/action/node.py
+++ b/python/mozbuild/mozbuild/action/node.py
@@ -70,8 +70,8 @@ def execute_node_cmd(node_cmd_list):
         # XXX Starting with an empty list means that node scripts can
         # (intentionally or inadvertently) remove deps.  Do we want this?
         deps = []
-        for line in stdout.splitlines():
-            line = line.decode()
+        for raw_line in stdout.splitlines():
+            line = raw_line.decode()
             if "dep:" in line:
                 deps.append(line.replace("dep:", ""))
             else:
@@ -86,10 +86,9 @@ def execute_node_cmd(node_cmd_list):
         # disambiguate this from real "Permission denied" errors so that we
         # can log such problems more clearly?
         print(
-            """Failed with %s.  Be sure to check that your mozconfig doesn't
+            f"""Failed with {err}.  Be sure to check that your mozconfig doesn't
             have --disable-nodejs in it.  If it does, try removing that line and
-            building again."""
-            % str(err),
+            building again.""",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/python/mozbuild/mozbuild/action/package_generated_sources.py
+++ b/python/mozbuild/mozbuild/action/package_generated_sources.py
@@ -28,7 +28,7 @@ def main(argv):
             entry_abspath = mozpath.abspath(entry[1])
         if not entry_abspath.startswith(objdir_abspath):
             print(
-                "Warning: omitting generated source [%s] from archive" % entry_abspath,
+                f"Warning: omitting generated source [{entry_abspath}] from archive",
                 file=sys.stderr,
             )
             return False
@@ -40,7 +40,7 @@ def main(argv):
             and not os.path.exists(entry_abspath)
         ):
             print(
-                "Warning: omitting non-existing file [%s] from archive" % entry_abspath,
+                f"Warning: omitting non-existing file [{entry_abspath}] from archive",
                 file=sys.stderr,
             )
             return False

--- a/python/mozbuild/mozbuild/action/process_define_files.py
+++ b/python/mozbuild/mozbuild/action/process_define_files.py
@@ -41,9 +41,9 @@ def process_define_file(output, input):
         r = re.compile(
             r"^\s*#\s*(?P<cmd>[a-z]+)(?:\s+(?P<name>\S+)(?:\s+(?P<value>\S+))?)?", re.U
         )
-        for l in input_file:
-            m = r.match(l)
-            if m:
+        for raw_line in input_file:
+            line = raw_line
+            if m := r.match(line):
                 cmd = m.group("cmd")
                 name = m.group("name")
                 value = m.group("value")
@@ -71,28 +71,35 @@ def process_define_file(output, input):
                                 for name, val in config.defines["ALLDEFINES"].items()
                             )
                         )
-                        l = l[: m.start("cmd") - 1] + defines + l[m.end("name") :]
+                        line = (
+                            line[: m.start("cmd") - 1] + defines + line[m.end("name") :]
+                        )
                     elif cmd == "define":
                         if value and name in config.defines:
-                            l = (
-                                l[: m.start("value")]
+                            line = (
+                                line[: m.start("value")]
                                 + str(config.defines[name])
-                                + l[m.end("value") :]
+                                + line[m.end("value") :]
                             )
                     elif cmd == "undef":
                         if name in config.defines:
-                            l = (
-                                l[: m.start("cmd")]
+                            line = (
+                                line[: m.start("cmd")]
                                 + "define"
-                                + l[m.end("cmd") : m.end("name")]
+                                + line[m.end("cmd") : m.end("name")]
                                 + " "
                                 + str(config.defines[name])
-                                + l[m.end("name") :]
+                                + line[m.end("name") :]
                             )
                         else:
-                            l = "/* " + l[: m.end("name")] + " */" + l[m.end("name") :]
+                            line = (
+                                "/* "
+                                + line[: m.end("name")]
+                                + " */"
+                                + line[m.end("name") :]
+                            )
 
-            output.write(l)
+            output.write(line)
 
     deps = {path}
     deps.update(config.get_dependencies())

--- a/python/mozbuild/mozbuild/action/symbols_archive.py
+++ b/python/mozbuild/mozbuild/action/symbols_archive.py
@@ -20,7 +20,7 @@ def make_archive(archive_name, base, exclude, include):
     def fill_archive(add_file):
         for pat in include:
             for p, f in finder.find(pat):
-                print('  Adding to "%s":\n\t"%s"' % (archive_basename, p))
+                print(f'  Adding to "{archive_basename}":\n\t"{p}"')
                 add_file(p, f)
 
     with open(archive_name, "wb") as fh:

--- a/python/mozbuild/mozbuild/action/test_archive.py
+++ b/python/mozbuild/mozbuild/action/test_archive.py
@@ -192,16 +192,10 @@ ARCHIVE_FILES = {
             "source": buildconfig.topobjdir,
             "base": "dist/bin",
             "patterns": [
-                "%s%s" % (f, buildconfig.substs["BIN_SUFFIX"])
-                for f in TEST_HARNESS_BINS
+                f"{f}{buildconfig.substs['BIN_SUFFIX']}" for f in TEST_HARNESS_BINS
             ]
             + [
-                "%s%s%s"
-                % (
-                    buildconfig.substs["DLL_PREFIX"],
-                    f,
-                    buildconfig.substs["DLL_SUFFIX"],
-                )
+                f"{buildconfig.substs['DLL_PREFIX']}{f}{buildconfig.substs['DLL_SUFFIX']}"
                 for f in TEST_HARNESS_DLLS
             ],
             "dest": "bin",
@@ -636,7 +630,7 @@ ARCHIVE_FILES = {
         {
             "source": buildconfig.topobjdir,
             "base": "dist/bin",
-            "pattern": "http3server%s" % buildconfig.substs["BIN_SUFFIX"],
+            "pattern": f"http3server{buildconfig.substs['BIN_SUFFIX']}",
             "dest": "xpcshell/http3server",
         },
         {
@@ -708,16 +702,10 @@ ARCHIVE_FILES = {
             "source": buildconfig.topobjdir,
             "base": "dist/bin",
             "patterns": [
-                "%s%s" % (f, buildconfig.substs["BIN_SUFFIX"])
-                for f in TEST_HARNESS_BINS
+                f"{f}{buildconfig.substs['BIN_SUFFIX']}" for f in TEST_HARNESS_BINS
             ]
             + [
-                "%s%s%s"
-                % (
-                    buildconfig.substs["DLL_PREFIX"],
-                    f,
-                    buildconfig.substs["DLL_SUFFIX"],
-                )
+                f"{buildconfig.substs['DLL_PREFIX']}{f}{buildconfig.substs['DLL_SUFFIX']}"
                 for f in TRAIN_HOP_DLLS
             ],
             "dest": "bin",
@@ -782,8 +770,8 @@ for k, v in ARCHIVE_FILES.items():
         itertools.chain(*(e.get("ignore", []) for e in ARCHIVE_FILES["common"]))
     )
 
-    if not any(p.startswith("%s/" % k) for p in ignores):
-        raise Exception('"common" ignore list probably should contain %s' % k)
+    if not any(p.startswith(f"{k}/") for p in ignores):
+        raise Exception(f'"common" ignore list probably should contain {k}')
 
 
 def find_generated_harness_files():
@@ -860,9 +848,8 @@ def find_files(archive):
         finder = FileFinder(os.path.join(source, base), **common_kwargs)
 
         for pattern in patterns:
-            for p, f in finder.find(pattern):
-                if dest:
-                    p = mozpath.join(dest, p)
+            for raw_p, f in finder.find(pattern):
+                p = mozpath.join(dest, raw_p) if dest else raw_p
                 yield p, f
 
 
@@ -873,22 +860,22 @@ def find_manifest_dirs(topsrcdir, manifests):
     """
     dirs = set()
 
-    for p in manifests:
-        p = os.path.join(topsrcdir, p)
+    for manifest_path in manifests:
+        abs_manifest_path = os.path.join(topsrcdir, manifest_path)
 
-        if p.endswith(".ini") or p.endswith(".toml"):
+        if abs_manifest_path.endswith(".ini") or abs_manifest_path.endswith(".toml"):
             test_manifest = TestManifest()
-            test_manifest.read(p)
+            test_manifest.read(abs_manifest_path)
             dirs |= set([os.path.dirname(m) for m in test_manifest.manifests()])
 
-        elif p.endswith(".list"):
+        elif abs_manifest_path.endswith(".list"):
             m = ReftestManifest()
-            m.load(p)
+            m.load(abs_manifest_path)
             dirs |= m.dirs
 
         else:
             raise Exception(
-                f'"{os.path.splitext(p)[1]}" is not a supported manifest format.'
+                f'"{os.path.splitext(abs_manifest_path)[1]}" is not a supported manifest format.'
             )
 
     dirs = {mozpath.normpath(d[len(topsrcdir) :]).lstrip("/") for d in dirs}
@@ -946,14 +933,13 @@ def main(argv):
                     )
                     file_count += 1
         else:
-            raise Exception("unhandled file extension: %s" % out_file)
+            raise Exception(f"unhandled file extension: {out_file}")
 
     duration = time.monotonic() - t_start
     zip_size = os.path.getsize(args.outputfile)
     basename = os.path.basename(args.outputfile)
     print(
-        "Wrote %d files in %d bytes to %s in %.2fs"
-        % (file_count, zip_size, basename, duration)
+        f"Wrote {file_count} files in {zip_size} bytes to {basename} in {duration:.2f}s"
     )
 
 

--- a/python/mozbuild/mozbuild/action/wrap_rustc.py
+++ b/python/mozbuild/mozbuild/action/wrap_rustc.py
@@ -36,8 +36,7 @@ def parse_outputs(crate_output, dep_outputs, pass_l_flag):
                         args += ["-L", val]
                     else:
                         raise Exception(
-                            "Unknown flag passed through "
-                            '"cargo:rustc-flags": "%s"' % flag
+                            f'Unknown flag passed through "cargo:rustc-flags": "{flag}"'
                         )
             elif key == "rustc-link-lib" and f == crate_output:
                 args += ["-l", value]

--- a/python/mozbuild/mozbuild/action/xpccheck.py
+++ b/python/mozbuild/mozbuild/action/xpccheck.py
@@ -42,14 +42,7 @@ def verifyDirectory(initests, directory):
 
         if not found:
             print(
-                (
-                    "TEST-UNEXPECTED-FAIL | xpccheck | test "
-                    "%s is missing from test manifest %s!"
-                )
-                % (
-                    name,
-                    os.path.join(directory, "xpcshell.toml"),
-                ),
+                f"TEST-UNEXPECTED-FAIL | xpccheck | test {name} is missing from test manifest {os.path.join(directory, 'xpcshell.toml')}!",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -72,14 +65,7 @@ def verifyIniFile(initests, directory):
 
         if not found:
             print(
-                (
-                    "TEST-UNEXPECTED-FAIL | xpccheck | found "
-                    "%s in xpcshell.toml and not in directory '%s'"
-                )
-                % (
-                    name,
-                    directory,
-                ),
+                f"TEST-UNEXPECTED-FAIL | xpccheck | found {name} in xpcshell.toml and not in directory '{directory}'",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/python/mozbuild/mozbuild/action/xpidl-process.py
+++ b/python/mozbuild/mozbuild/action/xpidl-process.py
@@ -59,9 +59,9 @@ def process(
         idl = p.parse(idl_data, filename=path)
         idl.resolve(inc_paths, p, webidlconfig)
 
-        header_path = os.path.join(header_dir, "%s.h" % stem)
-        rs_rt_path = os.path.join(xpcrs_dir, "rt", "%s.rs" % stem)
-        rs_bt_path = os.path.join(xpcrs_dir, "bt", "%s.rs" % stem)
+        header_path = os.path.join(header_dir, f"{stem}.h")
+        rs_rt_path = os.path.join(xpcrs_dir, "rt", f"{stem}.rs")
+        rs_bt_path = os.path.join(xpcrs_dir, "bt", f"{stem}.rs")
 
         xpts.append(jsonxpt.build_typelib(idl))
         ts_data.append(typescript.ts_source(idl))
@@ -92,7 +92,7 @@ def process(
     # files to be changed in any way. This means that make will re-run us every
     # time a build is run whether or not anything changed. To fix this we
     # unconditionally write out the file.
-    xpt_path = os.path.join(xpt_dir, "%s.xpt" % module)
+    xpt_path = os.path.join(xpt_dir, f"{module}.xpt")
     with open(xpt_path, "w", encoding="utf-8", newline="\n") as fh:
         jsonxpt.write(jsonxpt.link(xpts), fh)
 
@@ -105,7 +105,7 @@ def process(
 
     rule.add_targets([xpt_path])
     if deps_dir:
-        deps_path = os.path.join(deps_dir, "%s.pp" % module)
+        deps_path = os.path.join(deps_dir, f"{module}.pp")
         with FileAvoidWrite(deps_path) as fh:
             mk.dump(fh)
 


### PR DESCRIPTION
…mozbuild/action r?#firefox-build-system-reviewers

Replace percent-style string formatting with f-strings for modern Python style and fix loop variable overwriting warnings in python/mozbuild/mozbuild/action/.

Differential Revision: https://phabricator.services.mozilla.com/D322635