### PR TITLE
Bug 2068042 - Fix :host matching regression. r=#style

### DIFF
--- a/servo/components/style/selector_map.rs
+++ b/servo/components/style/selector_map.rs
@@ -830,6 +830,12 @@ fn specific_bucket_for<'a>(
             )
         },
         Component::Host(ref selector) => {
+            // Even tho we bucket shadow host rules in shadow trees, this rule could be in the
+            // document.
+            //
+            // TODO(emilio): We could return more state during bucketing and just discard the
+            // selector entirely, probably.
+            *bucket_matches = BucketMatches::Unknown;
             if let Some(selector) = selector {
                 find_bucket(
                     selector.iter(),
@@ -839,7 +845,6 @@ fn specific_bucket_for<'a>(
                     /* nested = */ true,
                 )
             } else {
-                // :host rules are bucketed, so we can leave bucket_matches as-is.
                 Bucket::Universal
             }
         },

--- a/testing/web-platform/tests/css/css-shadow/host-in-document-descendant.html
+++ b/testing/web-platform/tests/css/css-shadow/host-in-document-descendant.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<title>:host in document stylesheet doesn't match all elements</title>
+<link rel="match" href="/css/reference/green.html">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=2068042">
+<link rel="help" href="https://drafts.csswg.org/css-shadow-1/#host-selector">
+<style>
+body {
+  background: green;
+}
+:root :host {
+  background: red !important;
+}
+</style>


### PR DESCRIPTION
If `:host` is in the document we currently don't bucket them.
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->

---

Lando: [link](https://lando.moz.tools/pulls/firefox-autoland/354/)
Bugzilla: [bug 2068042](https://bugzilla.mozilla.org/show_bug.cgi?id=2068042)

:no_entry_sign: This pull request has 2 blockers.