### PR TITLE
Bug 2068613: Add `all` to scoped name's `SpecifiedValueInfo`. r=#firefox-style-system-reviewers

### DIFF
--- a/servo/components/style/values/specified/position.rs
+++ b/servo/components/style/values/specified/position.rs
@@ -425,6 +425,7 @@ impl AnchorName {
 #[repr(transparent)]
 #[css(comma)]
 #[typed(todo_derive_fields)]
+#[value_info(other_values = "all")]
 pub struct ScopedNameList(
     /// `none | all | <dashed-ident>#`
     #[css(iterable, if_empty = "none")]


### PR DESCRIPTION
All of `timeline-scope`, `anchor-scope`, and `view-transition-scope` support it.
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->

---

Lando: [link](https://lando.moz.tools/pulls/firefox-autoland/355/)
Bugzilla: [bug 2068613](https://bugzilla.mozilla.org/show_bug.cgi?id=2068613)

:no_entry_sign: This pull request has 2 blockers.