### PR TITLE
Bug 2066814 - Restrict the properties that highlight pseudos get at cascade time. r=#style

### DIFF
--- a/servo/components/style/gecko/pseudo_element.rs
+++ b/servo/components/style/gecko/pseudo_element.rs
@@ -521,19 +521,7 @@ impl PseudoElement {
         self.is_anon_box()
     }
 
-    /// Property flag that properties must have to apply to this pseudo-element.
     #[inline]
-    pub fn property_restriction(&self) -> Option<PropertyFlags> {
-        Some(match *self {
-            PseudoElement::FirstLetter => PropertyFlags::APPLIES_TO_FIRST_LETTER,
-            PseudoElement::FirstLine => PropertyFlags::APPLIES_TO_FIRST_LINE,
-            PseudoElement::Placeholder => PropertyFlags::APPLIES_TO_PLACEHOLDER,
-            PseudoElement::Cue => PropertyFlags::APPLIES_TO_CUE,
-            PseudoElement::Marker => PropertyFlags::APPLIES_TO_MARKER,
-            _ => return None,
-        })
-    }
-
     /// Whether this pseudo-element should actually exist if it has
     /// the given styles.
     pub fn should_exist(&self, style: &ComputedValues) -> bool {

--- a/servo/components/style/gecko/pseudo_element_definition.mako.rs
+++ b/servo/components/style/gecko/pseudo_element_definition.mako.rs
@@ -70,6 +70,34 @@ impl PseudoElement {
         FLAGS[i]
     }
 
+    /// Property flag that properties must have to apply to this pseudo-element, or empty if there
+    /// are no restrictions.
+    #[inline]
+    pub fn property_restriction(&self) -> PropertyFlags {
+        static FLAGS: [PropertyFlags; PSEUDO_COUNT + 1] = [
+            % for pseudo in PSEUDOS:
+            % if pseudo.name == "first-letter":
+            PropertyFlags::APPLIES_TO_FIRST_LETTER,
+            % elif pseudo.name == "first-line":
+            PropertyFlags::APPLIES_TO_FIRST_LINE,
+            % elif pseudo.name == "marker":
+            PropertyFlags::APPLIES_TO_MARKER,
+            % elif pseudo.name == "cue":
+            PropertyFlags::APPLIES_TO_CUE,
+            % elif pseudo.name == "placeholder":
+            PropertyFlags::APPLIES_TO_PLACEHOLDER,
+            % elif pseudo.name in ["selection", "highlight", "target-text"]:
+            PropertyFlags::APPLIES_TO_HIGHLIGHT,
+            % else:
+            PropertyFlags::empty(),
+            % endif
+            % endfor
+            // Unknown ::-webkit pseudos have no restrictions.
+            PropertyFlags::empty()
+        ];
+        FLAGS[self.index()]
+    }
+
     /// Gets the flags associated to this pseudo-element or anon box.
     #[inline]
     pub fn flags(&self) -> PseudoStyleTypeFlags {

--- a/servo/components/style/properties/cascade.rs
+++ b/servo/components/style/properties/cascade.rs
@@ -118,7 +118,7 @@ where
 struct DeclarationIterator<'a> {
     // Global to the iteration.
     guards: &'a StylesheetGuards<'a>,
-    restriction: Option<PropertyFlags>,
+    restriction: PropertyFlags,
     // The rule we're iterating over.
     current_rule_node: Option<&'a StrongRuleNode>,
     // Per rule state.
@@ -133,7 +133,7 @@ impl<'a> DeclarationIterator<'a> {
         guards: &'a StylesheetGuards,
         pseudo: Option<&PseudoElement>,
     ) -> Self {
-        let restriction = pseudo.and_then(|p| p.property_restriction());
+        let restriction = pseudo.map_or(PropertyFlags::empty(), |p| p.property_restriction());
         let mut iter = Self {
             guards,
             current_rule_node: Some(rule_node),
@@ -170,13 +170,13 @@ impl<'a> Iterator for DeclarationIterator<'a> {
                     continue;
                 }
 
-                if let Some(restriction) = self.restriction {
+                if !self.restriction.is_empty() {
                     // decl.id() is either a longhand or a custom
                     // property.  Custom properties are always allowed, but
                     // longhands are only allowed if they have our
                     // restriction flag set.
                     if let PropertyDeclarationId::Longhand(id) = decl.id() {
-                        if !id.flags().contains(restriction)
+                        if !id.flags().contains(self.restriction)
                             && self.priority.cascade_level().origin() != CascadeOrigin::UA
                         {
                             continue;

--- a/servo/components/style/properties/data.py
+++ b/servo/components/style/properties/data.py
@@ -1202,7 +1202,7 @@ class PropertyRestrictions:
 
     @staticmethod
     def webkit_text_properties():
-        props = set(
+        return set(
             [
                 # Kinda like css-text?
                 "-webkit-text-stroke-width",
@@ -1210,7 +1210,6 @@ class PropertyRestrictions:
                 "-webkit-text-stroke-color",
             ]
         )
-        return props
 
     # https://drafts.csswg.org/css-pseudo/#first-letter-styling
     @staticmethod
@@ -1365,6 +1364,17 @@ class PropertyRestrictions:
             + PropertyRestrictions.shorthand(data, "outline")
             + PropertyRestrictions.shorthand(data, "font")
             + PropertyRestrictions.shorthand(data, "font-synthesis")
+        )
+
+    # https://drafts.csswg.org/css-pseudo/#highlight-pseudos
+    # https://drafts.csswg.org/css-pseudo/#highlight-styling
+    def highlight(data):
+        return set(
+            [
+                "color",
+                "background-color",
+            ]
+            + PropertyRestrictions.spec(data, "css-text-decor")
         )
 
 

--- a/servo/components/style/properties/mod.rs
+++ b/servo/components/style/properties/mod.rs
@@ -62,12 +62,15 @@ bitflags! {
         const APPLIES_TO_CUE = 1 << 4;
         /// This longhand property applies to ::marker.
         const APPLIES_TO_MARKER = 1 << 5;
+        /// Applies to ::highlight() and related (::selection / ::target-text) pseudo-elements.
+        /// https://drafts.csswg.org/css-pseudo/#highlight-styling
+        const APPLIES_TO_HIGHLIGHT = 1 << 6;
         /// This property is a legacy shorthand.
         ///
         /// https://drafts.csswg.org/css-cascade/#legacy-shorthand
-        const IS_LEGACY_SHORTHAND = 1 << 6;
-       /// This shorthand remains enabled even if some subproperties are pref-disabled.
-        const ALLOWS_DISABLED_SUBPROPERTIES = 1 << 7;
+        const IS_LEGACY_SHORTHAND = 1 << 7;
+        /// This shorthand remains enabled even if some subproperties are pref-disabled.
+        const ALLOWS_DISABLED_SUBPROPERTIES = 1 << 8;
 
         /* The following flags are currently not used in Rust code, they
          * only need to be listed in corresponding properties so that

--- a/servo/components/style/properties/properties.mako.rs
+++ b/servo/components/style/properties/properties.mako.rs
@@ -536,6 +536,7 @@ ${id_set("PrioritaryPropertyIdSet", [p for p in data.longhands if p.is_prioritar
     MARKER_RESTRICTIONS = PropertyRestrictions.marker(data)
     PLACEHOLDER_RESTRICTIONS = PropertyRestrictions.placeholder(data)
     CUE_RESTRICTIONS = PropertyRestrictions.cue(data)
+    HIGHLIGHT_RESTRICTIONS = PropertyRestrictions.highlight(data)
 
     def restriction_flags(property):
         name = property.name
@@ -550,6 +551,8 @@ ${id_set("PrioritaryPropertyIdSet", [p for p in data.longhands if p.is_prioritar
             flags.append("APPLIES_TO_MARKER")
         if name in CUE_RESTRICTIONS:
             flags.append("APPLIES_TO_CUE")
+        if name in HIGHLIGHT_RESTRICTIONS:
+            flags.append("APPLIES_TO_HIGHLIGHT")
         return flags
 
 %>

--- a/servo/components/style/rule_cache.rs
+++ b/servo/components/style/rule_cache.rs
@@ -185,8 +185,7 @@ impl RuleCache {
         if context
             .builder
             .pseudo
-            .and_then(|p| p.property_restriction())
-            .is_some()
+            .is_some_and(|p| !p.property_restriction().is_empty())
         {
             return None;
         }
@@ -230,7 +229,7 @@ impl RuleCache {
         // A pseudo-element with property restrictions can result in different computed values if
         // it's also used for a non-pseudo.
         // TODO: we could consider inserting them and just checking the builder like we do for zoom.
-        if pseudo.and_then(|p| p.property_restriction()).is_some() {
+        if pseudo.is_some_and(|p| !p.property_restriction().is_empty()) {
             return false;
         }
 

--- a/servo/ports/geckolib/glue.rs
+++ b/servo/ports/geckolib/glue.rs
@@ -93,7 +93,8 @@ use style::properties::{
     parse_one_declaration_into, parse_style_attribute, CSSWideKeyword, ComputedValues,
     CountedUnknownProperty, Importance, LonghandId, NonCustomPropertyId,
     OwnedPropertyDeclarationId, PropertyDeclarationBlock, PropertyDeclarationId,
-    PropertyDeclarationIdSet, PropertyId, ShorthandId, SourcePropertyDeclaration, StyleBuilder,
+    PropertyDeclarationIdSet, PropertyFlags, PropertyId, ShorthandId, SourcePropertyDeclaration,
+    StyleBuilder,
 };
 use style::properties_and_values::registry::PropertyRegistration;
 use style::rule_cache::RuleCacheConditions;
@@ -7538,7 +7539,7 @@ pub extern "C" fn Servo_GetComputedKeyframeValues(
         &mut tree_counting_caches,
     );
 
-    let restriction = pseudo.and_then(|p| p.property_restriction());
+    let restriction = pseudo.map_or(PropertyFlags::empty(), |p| p.property_restriction());
 
     let global_style_data = &*GLOBAL_STYLE_DATA;
     let guard = global_style_data.shared_lock.read();
@@ -7601,7 +7602,7 @@ pub extern "C" fn Servo_GetComputedKeyframeValues(
                     }
 
                     // Skip restricted properties
-                    if restriction.map_or(false, |r| !property.flags().contains(r)) {
+                    if !restriction.is_empty() && !property.flags().contains(restriction) {
                         return;
                     }
 

--- a/testing/web-platform/meta/css/css-pseudo/highlight-cascade/highlight-cascade-007.html.ini
+++ b/testing/web-platform/meta/css/css-pseudo/highlight-cascade/highlight-cascade-007.html.ini
@@ -1,37 +1,7 @@
 [highlight-cascade-007.html]
   max-asserts: 2
-  [M::selection’s font-size is the same as in M]
-    expected: FAIL
-
-  [M span::selection’s font-size is the same as in M span]
-    expected: FAIL
-
-  [M::selection’s own text-shadow respects M’s font-size]
-    expected: FAIL
-
   [M span::selection’s inherited text-shadow respects M’s font-size]
     expected: FAIL
 
-  [W::selection’s line-height is the same as in W]
-    expected: FAIL
-
-  [W span::selection’s line-height is the same as in W span]
-    expected: FAIL
-
-  [W::selection’s own text-shadow respects W’s line-height]
-    expected: FAIL
-
   [W span::selection’s inherited text-shadow respects W’s line-height]
-    expected: FAIL
-
-  [U::selection’s font-size is the same as in U]
-    expected: FAIL
-
-  [U span::selection’s font-size is the same as in U span]
-    expected: FAIL
-
-  [U::selection’s own text-decoration-thickness respects U’s font-size]
-    expected: FAIL
-
-  [U span::selection’s own text-decoration-thickness respects U span’s font-size]
     expected: FAIL

--- a/testing/web-platform/meta/forced-colors-mode/forced-colors-mode-14.html.ini
+++ b/testing/web-platform/meta/forced-colors-mode/forced-colors-mode-14.html.ini
@@ -1,2 +1,0 @@
-[forced-colors-mode-14.html]
-  expected: FAIL

--- a/testing/web-platform/tests/css/css-pseudo/selection-background-color-non-applicable-properties-ref.html
+++ b/testing/web-platform/tests/css/css-pseudo/selection-background-color-non-applicable-properties-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<script src="support/selections.js"></script>
+<style>
+  div {
+    font-size: 300%;
+  }
+</style>
+<p>Test passes if "Selected Text" appears selected using the OS selection colors.
+<div id="test">Selected Text</div>
+<script>selectNodeContents(document.getElementById("test"));</script>

--- a/testing/web-platform/tests/css/css-pseudo/selection-background-color-non-applicable-properties.html
+++ b/testing/web-platform/tests/css/css-pseudo/selection-background-color-non-applicable-properties.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Pseudo-Elements Test: ::selection rule with only non-applicable properties doesn't clear the default background</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#highlight-styling">
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#highlight-cascade">
+<link rel="match" href="selection-background-color-non-applicable-properties-ref.html">
+<meta name="assert" content="An author ::selection rule that only specifies properties that don't apply to highlight pseudo-elements (like border-radius or padding) contributes no declarations, so the selection is still painted using the default highlight colors.">
+<script src="support/selections.js"></script>
+<style>
+  div {
+    font-size: 300%;
+  }
+  div::selection {
+    border-radius: 2px;
+    padding: 4px 0;
+  }
+</style>
+<p>Test passes if "Selected Text" appears selected using the OS selection colors.
+<div id="test">Selected Text</div>
+<script>selectNodeContents(document.getElementById("test"));</script>


### PR DESCRIPTION
Matches Chrome and the spec in terms of em / lh units etc, and prevents
border-radius to set the border-background flag without extra tracking.
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->

---

Lando: [link](https://lando.moz.tools/pulls/firefox-autoland/357/)
Bugzilla: [bug 2066814](https://bugzilla.mozilla.org/show_bug.cgi?id=2066814)

:warning: This pull request has 6 warnings.
:no_entry_sign: This pull request has 1 blocker.