### PR TITLE
Bug 2069393 - Collect stylesheet invalidations more lazily. r=#style

### DIFF
--- a/servo/components/style/author_styles.rs
+++ b/servo/components/style/author_styles.rs
@@ -64,7 +64,11 @@ where
         stylist: &mut Stylist,
         guard: &SharedRwLockReadGuard,
     ) -> StylesheetInvalidationSet {
-        let (flusher, mut invalidations) = self.stylesheets.flush();
+        // TODO(emilio): We don't collect invalidations for shadow trees, see
+        // Servo_StyleSet_FlushStyleSheets.
+        let (flusher, mut invalidations) =
+            self.stylesheets
+                .flush(None, self.data.custom_media_map(), guard);
         let result = stylist.rebuild_author_data(
             &self.data,
             flusher.sheets,

--- a/servo/components/style/stylesheet_set.rs
+++ b/servo/components/style/stylesheet_set.rs
@@ -7,7 +7,7 @@
 use crate::derives::*;
 use crate::device::Device;
 use crate::invalidation::stylesheets::{RuleChangeKind, StylesheetInvalidationSet};
-use crate::shared_lock::SharedRwLockReadGuard;
+use crate::shared_lock::{SharedRwLockReadGuard, StylesheetGuards};
 use crate::stylesheets::{
     CssRule, CssRuleRef, CustomMediaMap, Origin, OriginSet, PerOrigin, StylesheetInDocument,
 };
@@ -224,11 +224,13 @@ where
         rev_pos.map(|i| self.entries.len() - i - 1)
     }
 
-    fn remove(&mut self, sheet: &S) {
+    /// Removes a sheet from the collection, returning whether the sheet had
+    /// been committed (that is, whether it has been part of a flush).
+    fn remove(&mut self, sheet: &S) -> bool {
         let index = self.find_sheet_index(sheet);
         if cfg!(feature = "gecko") && index.is_none() {
             // FIXME(emilio): Make Gecko's PresShell::AddUserSheet not suck.
-            return;
+            return false;
         }
         let sheet = self.entries.remove(index.unwrap());
         // Removing sheets makes us tear down the whole cascade and invalidation
@@ -243,6 +245,7 @@ where
         } else {
             self.dirty = true;
         }
+        sheet.committed
     }
 
     fn contains(&self, sheet: &S) -> bool {
@@ -293,6 +296,26 @@ where
         self.entries.iter_mut().map(|e| &mut e.sheet)
     }
 
+    /// Collects invalidations for the sheets that have been added (i.e. sheets not yet committed)
+    /// since the last flush.
+    fn collect_pending_invalidations(
+        &self,
+        invalidations: &mut StylesheetInvalidationSet,
+        device: &Device,
+        custom_media: &CustomMediaMap,
+        guard: &SharedRwLockReadGuard,
+    ) {
+        if !self.dirty {
+            return;
+        }
+        for entry in &self.entries {
+            if entry.committed {
+                continue;
+            }
+            invalidations.collect_invalidations_for(device, custom_media, &entry.sheet, guard);
+        }
+    }
+
     fn flush(&mut self) -> SheetCollectionFlusher<'_, S> {
         let dirty = mem::replace(&mut self.dirty, false);
         let validity = mem::replace(&mut self.data_validity, DataValidity::Valid);
@@ -341,37 +364,30 @@ macro_rules! sheet_set_methods {
 
         /// Appends a new stylesheet to the current set.
         ///
-        /// No device implies not computing invalidations.
-        pub fn append_stylesheet(
-            &mut self,
-            device: Option<&Device>,
-            custom_media: &CustomMediaMap,
-            sheet: S,
-            guard: &SharedRwLockReadGuard,
-        ) {
+        /// Invalidations for the new sheet are collected when flushing.
+        pub fn append_stylesheet(&mut self, sheet: S, guard: &SharedRwLockReadGuard) {
             debug!(concat!($set_name, "::append_stylesheet"));
-            self.collect_invalidations_for(device, custom_media, &sheet, guard);
             let collection = self.collection_for(&sheet, guard);
             collection.append(sheet);
         }
 
         /// Insert a given stylesheet before another stylesheet in the document.
+        ///
+        /// Invalidations for the new sheet are collected when flushing.
         pub fn insert_stylesheet_before(
             &mut self,
-            device: Option<&Device>,
-            custom_media: &CustomMediaMap,
             sheet: S,
             before_sheet: S,
             guard: &SharedRwLockReadGuard,
         ) {
             debug!(concat!($set_name, "::insert_stylesheet_before"));
-            self.collect_invalidations_for(device, custom_media, &sheet, guard);
-
             let collection = self.collection_for(&sheet, guard);
             collection.insert_before(sheet, &before_sheet);
         }
 
         /// Remove a given stylesheet from the set.
+        ///
+        /// No device implies not computing invalidations.
         pub fn remove_stylesheet(
             &mut self,
             device: Option<&Device>,
@@ -380,10 +396,12 @@ macro_rules! sheet_set_methods {
             guard: &SharedRwLockReadGuard,
         ) {
             debug!(concat!($set_name, "::remove_stylesheet"));
-            self.collect_invalidations_for(device, custom_media, &sheet, guard);
-
             let collection = self.collection_for(&sheet, guard);
-            collection.remove(&sheet)
+            // If the sheet never made it to a flush, it never affected the document styles, so
+            // nothing to invalidate.
+            if collection.remove(&sheet) {
+                self.collect_invalidations_for(device, custom_media, &sheet, guard);
+            }
         }
 
         /// Notify the set that a rule from a given stylesheet has changed
@@ -506,8 +524,24 @@ where
 
     /// Flush the current set, unmarking it as dirty, and returns a `DocumentStylesheetFlusher` in
     /// order to rebuild the stylist and the invalidation set.
-    pub fn flush(&mut self) -> (DocumentStylesheetFlusher<'_, S>, StylesheetInvalidationSet) {
+    ///
+    /// `custom_media_for_origin` is used to compute the invalidations for the sheets added since
+    /// the last flush.
+    pub fn flush<'a>(
+        &mut self,
+        device: &Device,
+        guards: &StylesheetGuards,
+        custom_media_for_origin: impl Fn(Origin) -> &'a CustomMediaMap,
+    ) -> (DocumentStylesheetFlusher<'_, S>, StylesheetInvalidationSet) {
         debug!("DocumentStylesheetSet::flush");
+        for (collection, origin) in self.collections.iter_origins() {
+            collection.collect_pending_invalidations(
+                &mut self.invalidations,
+                device,
+                custom_media_for_origin(origin),
+                guards.for_origin(origin),
+            );
+        }
         (
             DocumentStylesheetFlusher {
                 collections: &mut self.collections,
@@ -647,7 +681,22 @@ where
     }
 
     /// Flush the stylesheets for this author set.
-    pub fn flush(&mut self) -> (AuthorStylesheetFlusher<'_, S>, StylesheetInvalidationSet) {
+    ///
+    /// No device implies not computing invalidations.
+    pub fn flush(
+        &mut self,
+        device: Option<&Device>,
+        custom_media: &CustomMediaMap,
+        guard: &SharedRwLockReadGuard,
+    ) -> (AuthorStylesheetFlusher<'_, S>, StylesheetInvalidationSet) {
+        if let Some(device) = device {
+            self.collection.collect_pending_invalidations(
+                &mut self.invalidations,
+                device,
+                custom_media,
+                guard,
+            );
+        }
         (
             AuthorStylesheetFlusher {
                 sheets: self.collection.flush(),

--- a/servo/components/style/stylist.rs
+++ b/servo/components/style/stylist.rs
@@ -1066,7 +1066,10 @@ impl Stylist {
 
         self.num_rebuilds += 1;
 
-        let (flusher, mut invalidations) = self.stylesheets.flush();
+        let cascade_data = &self.cascade_data;
+        let (flusher, mut invalidations) = self.stylesheets.flush(&self.device, guards, |origin| {
+            &cascade_data.borrow_for_origin(origin).custom_media
+        });
 
         self.cascade_data
             .rebuild(
@@ -1110,21 +1113,13 @@ impl Stylist {
         before_sheet: StylistSheet,
         guard: &SharedRwLockReadGuard,
     ) {
-        let custom_media = self.cascade_data.custom_media_for_sheet(&sheet, guard);
-        self.stylesheets.insert_stylesheet_before(
-            Some(&self.device),
-            custom_media,
-            sheet,
-            before_sheet,
-            guard,
-        )
+        self.stylesheets
+            .insert_stylesheet_before(sheet, before_sheet, guard)
     }
 
     /// Appends a new stylesheet to the current set.
     pub fn append_stylesheet(&mut self, sheet: StylistSheet, guard: &SharedRwLockReadGuard) {
-        let custom_media = self.cascade_data.custom_media_for_sheet(&sheet, guard);
-        self.stylesheets
-            .append_stylesheet(Some(&self.device), custom_media, sheet, guard)
+        self.stylesheets.append_stylesheet(sheet, guard)
     }
 
     /// Remove a given stylesheet to the current set.

--- a/servo/ports/geckolib/glue.rs
+++ b/servo/ports/geckolib/glue.rs
@@ -1809,9 +1809,7 @@ pub unsafe extern "C" fn Servo_AuthorStyles_AppendStyleSheet(
     let global_style_data = &*GLOBAL_STYLE_DATA;
     let guard = global_style_data.shared_lock.read();
     let sheet = unsafe { GeckoStyleSheet::new(sheet) };
-    styles
-        .stylesheets
-        .append_stylesheet(None, styles.data.custom_media_map(), sheet, &guard);
+    styles.stylesheets.append_stylesheet(sheet, &guard);
 }
 
 #[unsafe(no_mangle)]
@@ -1823,8 +1821,6 @@ pub unsafe extern "C" fn Servo_AuthorStyles_InsertStyleSheetBefore(
     let global_style_data = &*GLOBAL_STYLE_DATA;
     let guard = global_style_data.shared_lock.read();
     styles.stylesheets.insert_stylesheet_before(
-        None,
-        styles.data.custom_media_map(),
         unsafe { GeckoStyleSheet::new(sheet) },
         unsafe { GeckoStyleSheet::new(before_sheet) },
         &guard,


### PR DESCRIPTION
We already keep track of whether a stylesheet has been committed or not,
so this patch:

 * Avoids collecting invalidations for removals that haven't made it to
   the document.
 * Avoids collecting invalidations for insertions that get removed too
   early.

This helps with bug 2065622, because most of the time in invalidation
there is just useless.
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->

---

Lando: [link](https://lando.moz.tools/pulls/firefox-autoland/358/)
Bugzilla: [bug 2069393](https://bugzilla.mozilla.org/show_bug.cgi?id=2069393)

:warning: This pull request has 3 warnings.
:no_entry_sign: This pull request has 1 blocker.