### PR TITLE
Bug 2070311 - Fix interaction of rule cache reset reuse and visited optimization. r=#style

### DIFF
--- a/layout/reftests/css-visited/visited-rule-cache-1-ref.html
+++ b/layout/reftests/css-visited/visited-rule-cache-1-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE HTML>
+<title>Test for privacy restrictions on :visited (Bug 2070311)</title>
+<style>
+.item { border: 10px solid black; display: inline-block; }
+a { color: tomato; display: inline-block; }
+</style>
+<a href="unvisited-page.html"><div class="item">item</div><section class="item">item</section></a>

--- a/layout/reftests/css-visited/visited-rule-cache-1.html
+++ b/layout/reftests/css-visited/visited-rule-cache-1.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML>
+<title>Test for privacy restrictions on :visited (Bug 2070311)</title>
+<style>
+.item { border: 10px solid black; display: inline-block; }
+a { color: tomato; display: inline-block; }
+</style>
+<!--
+  The two children match the same rules (so the second one can use the reset
+  properties cached from the first one), but have different local names, so
+  they can't share style.
+-->
+<a href="visited-page.html"><div class="item">item</div><section class="item">item</section></a>

--- a/layout/style/test/moz.build
+++ b/layout/style/test/moz.build
@@ -109,6 +109,8 @@ TEST_HARNESS_FILES.testing.mochitest.tests.layout.style.test["css-visited"] += [
     "/layout/reftests/css-visited/visited-inherit-1-ref.html",
     "/layout/reftests/css-visited/visited-inherit-1.html",
     "/layout/reftests/css-visited/visited-page.html",
+    "/layout/reftests/css-visited/visited-rule-cache-1-ref.html",
+    "/layout/reftests/css-visited/visited-rule-cache-1.html",
     "/layout/reftests/css-visited/white-to-transparent-1-ref.html",
     "/layout/reftests/css-visited/white-to-transparent-1.html",
     "/layout/reftests/css-visited/width-1-ref.html",

--- a/layout/style/test/test_visited_reftests.html
+++ b/layout/style/test/test_visited_reftests.html
@@ -96,6 +96,7 @@ var gTests = [
   "== logical-box-border-color-visited-link-003.html logical-box-border-color-visited-link-ref.html",
   "== svg-paint-currentcolor-visited.svg svg-paint-currentcolor-visited-ref.svg",
   "== variables-visited.html variables-visited-ref.html",
+  "== visited-rule-cache-1.html visited-rule-cache-1-ref.html",
 ];
 
 // We record the maximum number of times we had to look at a test before

--- a/servo/components/style/properties/cascade.rs
+++ b/servo/components/style/properties/cascade.rs
@@ -245,9 +245,6 @@ pub enum CascadeMode<'a, 'b> {
     Visited {
         /// The cascade for our unvisited style.
         unvisited_context: &'a computed::Context<'b>,
-        /// The properties set on the unvisited style. These are useful if we can prove that the
-        /// visited rules are the same as the unvisited declarations.
-        unvisited_properties: &'a LonghandIdSet,
     },
 }
 
@@ -351,10 +348,7 @@ where
     let mut attribute_tracker = AttributeTracker::new(element_context);
 
     let properties_to_apply = match cascade_mode {
-        CascadeMode::Visited {
-            unvisited_context,
-            unvisited_properties,
-        } => {
+        CascadeMode::Visited { unvisited_context } => {
             context.builder.substitution_functions =
                 unvisited_context.builder.substitution_functions.clone();
             context.builder.writing_mode = unvisited_context.builder.writing_mode;
@@ -363,16 +357,18 @@ where
             // It also wouldn't be super-profitable, only a handful :visited properties are
             // non-inherited.
             using_cached_reset_properties = false;
-            let visited_dependent_props = LonghandIdSet::visited_dependent();
             // If we match the same rules when visited and unvisited, and we know there isn't any
             // visited-dependent properties, we can avoid gathering the declarations, we know none
             // would be relevant.
             if unvisited_context.builder.rules.as_ref() != Some(rules)
-                || unvisited_properties.contains_any(visited_dependent_props)
+                || unvisited_context
+                    .builder
+                    .flags()
+                    .intersects(ComputedValueFlags::USES_VISITED_DEPENDENT_PROPERTIES)
             {
                 iter_declarations(iter, &mut declarations, None, &mut attribute_tracker);
             }
-            visited_dependent_props
+            LonghandIdSet::visited_dependent()
         },
         CascadeMode::Unvisited { .. } => {
             cascade.init_custom_properties(&mut context);
@@ -419,6 +415,7 @@ where
     context.builder.clear_modified_reset();
 
     if let CascadeMode::Unvisited { visited_rules } = cascade_mode {
+        // NOTE: This relies on finished_applying_properties() having already happened.
         if let Some(visited_rules) = visited_rules {
             cascade.compute_visited_style_if_needed(
                 &mut context,
@@ -1226,7 +1223,6 @@ impl<'a> Cascade<'a> {
             try_tactic,
             CascadeMode::Visited {
                 unvisited_context: &*context,
-                unvisited_properties: &self.seen.longhands,
             },
             // Cascade input flags don't matter for the visited style, they are
             // in the main (unvisited) style.
@@ -1256,6 +1252,16 @@ impl<'a> Cascade<'a> {
             }
         }
 
+        // NOTE: This uses self.seen.longhands, not author_specified, because some UA styles do
+        // specify visited-dependent properties.
+        if self
+            .seen
+            .longhands
+            .contains_any(LonghandIdSet::visited_dependent())
+        {
+            builder.add_flags(ComputedValueFlags::USES_VISITED_DEPENDENT_PROPERTIES);
+        }
+
         if self
             .author_specified
             .contains_any(LonghandIdSet::border_background_properties())
@@ -1274,6 +1280,7 @@ impl<'a> Cascade<'a> {
         if self.author_specified.contains(LonghandId::GridAutoFlow) {
             builder.add_flags(ComputedValueFlags::HAS_AUTHOR_SPECIFIED_GRID_AUTO_FLOW);
         }
+
         #[cfg(feature = "servo")]
         {
             if let Some(font) = builder.get_font_if_mutated() {
@@ -1322,7 +1329,8 @@ impl<'a> Cascade<'a> {
             | ComputedValueFlags::USES_FONT_OR_WM_RELATIVE_UNITS
             | ComputedValueFlags::DEPENDS_ON_CONTAINER_STYLE_QUERY
             | ComputedValueFlags::USES_SIBLING_COUNT
-            | ComputedValueFlags::USES_SIBLING_INDEX;
+            | ComputedValueFlags::USES_SIBLING_INDEX
+            | ComputedValueFlags::USES_VISITED_DEPENDENT_PROPERTIES;
         context.builder.add_flags(style.flags & bits_to_copy);
 
         true

--- a/servo/components/style/properties/computed_value_flags.rs
+++ b/servo/components/style/properties/computed_value_flags.rs
@@ -137,6 +137,9 @@ bitflags! {
 
         /// Whether this style uses `sibling-index()`.
         const USES_SIBLING_INDEX = 1 << 27;
+
+        /// Whether this style uses any visited-dependent properties.
+        const USES_VISITED_DEPENDENT_PROPERTIES = 1 << 28;
     }
 }
 


### PR DESCRIPTION
We're hitting the "used cached reset properties" path, and thus we don't
notice that .item indeed sets border-color, which is a visited dependent
property. So we end up incorrectly with `border-color: currentcolor` in
the computed style, and thus wrong rendering.

Track the "used visited dependent properties" with a style bit and carry
that around instead.
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->

---

Lando: [link](https://lando.moz.tools/pulls/firefox-autoland/360/)
Bugzilla: [bug 2070311](https://bugzilla.mozilla.org/show_bug.cgi?id=2070311)

:warning: This pull request has 3 warnings.
:no_entry_sign: This pull request has 1 blocker.