### PR TITLE
Bug 2070503 - Use an empty atom to store the universal name of PtNameAndClassSelectors. r=#style

### DIFF
--- a/servo/components/style/gecko/pseudo_element.rs
+++ b/servo/components/style/gecko/pseudo_element.rs
@@ -102,6 +102,10 @@ pub enum Target {
 pub struct PtNameAndClassSelector(thin_vec::ThinVec<Atom>);
 
 impl PtNameAndClassSelector {
+    /// The atom we use to represent the universal type. This can't be a valid name (and note that * can
+    /// be a valid name because of escapes).
+    const UNIVERSAL_NAME: Atom = atom!("");
+
     /// Constructs a new one from a name.
     pub fn from_name(name: Atom) -> Self {
         Self(thin_vec::thin_vec![name])
@@ -141,7 +145,7 @@ impl PtNameAndClassSelector {
             if matches!(target, Target::Selector)
                 && input.try_parse(|i| i.expect_delim('*')).is_ok()
             {
-                Ok(atom!("*"))
+                Ok(Self::UNIVERSAL_NAME)
             } else {
                 CustomIdent::parse(input, &[]).map(|c| c.0)
             }
@@ -183,9 +187,9 @@ impl PtNameAndClassSelector {
             return Err(ParseError::custom(StyleParseErrorKind::UnspecifiedError));
         }
 
-        // Use the universal symbol as the first element to present the part of
+        // Use the universal selector as the first element to present the part of
         // `<pt-name-selector>` because they are equivalent (and the serialization is the same).
-        let mut result = thin_vec::thin_vec![name.unwrap_or(atom!("*"))];
+        let mut result = thin_vec::thin_vec![name.unwrap_or(Self::UNIVERSAL_NAME)];
         result.append(&mut classes);
 
         Ok(Self(result))
@@ -198,8 +202,7 @@ impl ToCss for PtNameAndClassSelector {
         W: fmt::Write,
     {
         let name = self.name();
-        if name == &atom!("*") {
-            // serialize_atom_identifier() may serialize "*" as "\*", so we handle it separately.
+        if *name == Self::UNIVERSAL_NAME {
             dest.write_char('*')?;
         } else {
             serialize_atom_identifier(name, dest)?;
@@ -448,8 +451,8 @@ impl PseudoElement {
                 // The specificity of a named view transition pseudo-element selector with a `*`
                 // argument and with an empty <pt-class-selector> is zero.
                 // https://drafts.csswg.org/css-view-transitions-2/#pseudo-element-class-additions
-                (name_and_class.name() != &atom!("*") || !name_and_class.classes().is_empty())
-                    as u32
+                (name_and_class.name() != &PtNameAndClassSelector::UNIVERSAL_NAME
+                    || !name_and_class.classes().is_empty()) as u32
             },
             _ => 1,
         }
@@ -608,7 +611,7 @@ impl PseudoElement {
                 // check it first.
                 // https://drafts.csswg.org/css-view-transitions-1/#named-view-transition-pseudo
                 let s_name = s_name_class.name();
-                if s_name != name.name() && s_name != &atom!("*") {
+                if s_name != name.name() && s_name != &PtNameAndClassSelector::UNIVERSAL_NAME {
                     return false;
                 }
 


### PR DESCRIPTION
Since "*" is a real name if escaped.

This fixes the tests in https://github.com/web-platform-tests/wpt/pull/62480
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->

---

Lando: [link](https://lando.moz.tools/pulls/firefox-autoland/361/)
Bugzilla: [bug 2070503](https://bugzilla.mozilla.org/show_bug.cgi?id=2070503)

:warning: This pull request has 4 warnings.
:no_entry_sign: This pull request has 1 blocker.